### PR TITLE
Better usage of click for help flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-fal = "fal.cli:run"
+fal = "fal.cli:cli"

--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -10,40 +10,42 @@ from faldbt.parse import parse_project
 import faldbt.lib as lib
 
 
-@click.command()
-@click.argument("command")
+@click.group()
+@click.version_option()
+def cli():
+    pass
+
+
+@cli.command()
 @click.option(
     "--project-dir",
     default=os.getcwd(),
-    help="Directory to look for dbt_project.yml",
+    help="Directory to look for dbt_project.yml.",
     type=click.Path(exists=True),
 )
 @click.option(
     "--profiles-dir",
     default=DEFAULT_PROFILES_DIR,
-    help="Directory to look for profiles.yml",
+    help="Directory to look for profiles.yml.",
     type=click.Path(exists=True),
 )
 @click.option(
     "--keyword",
     default="fal",
-    help="Property in meta to look for fal configurations",
+    help="Property in meta to look for fal configurations.",
     type=click.STRING,
 )
 @click.option(
     "--all",
+    help="Only run models that ran in the last dbt run.",
     is_flag=True,
-    help="Only run models that ran in the last dbt run",
 )
 @click.option(
     "--debug",
+    help="Display debug logging during execution.",
     is_flag=True,
-    help="Display debug logging during dbt execution",
 )
-def run(command, project_dir, profiles_dir, keyword, all, debug):
-    if command != "run":
-        raise Exception("Please use run command")
-
+def run(project_dir, profiles_dir, keyword, all, debug):
     with log_manager.applicationbound():
         if debug:
             log_manager.set_debug()
@@ -56,4 +58,6 @@ def run(command, project_dir, profiles_dir, keyword, all, debug):
         ordered_scripts = ScriptGraph(models, keyword, project_dir).sort()
         ## TODO: Run ordered scripts instead
         for model in models:
-            run_scripts(model, keyword, project.manifest.nativeManifest, real_project_dir)
+            run_scripts(
+                model, keyword, project.manifest.nativeManifest, real_project_dir
+            )


### PR DESCRIPTION
```
❯ fal --version
fal, version 0.1.0

❯ fal --help
Usage: fal [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  run
  
❯ fal run --help
Usage: fal run [OPTIONS]

Options:
  --project-dir PATH   Directory to look for dbt_project.yml.
  --profiles-dir PATH  Directory to look for profiles.yml.
  --keyword TEXT       Property in meta to look for fal configurations.
  --all                Only run models that ran in the last dbt run.
  --debug              Display debug logging during execution.
  --help               Show this message and exit.
```