### PR TITLE
Move meta keyword from FalProject to FalDbt

### DIFF
--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -66,8 +66,8 @@ def run(project_dir, profiles_dir, keyword, all, experimental_ordering, debug):
         else:
             real_profiles_dir = DEFAULT_PROFILES_DIR
 
-        faldbt = FalDbt(real_project_dir, real_profiles_dir)
-        project = FalProject(faldbt, keyword)
+        faldbt = FalDbt(real_project_dir, real_profiles_dir, keyword)
+        project = FalProject(faldbt)
         models = project.get_filtered_models(all)
         print_run_info(models, keyword)
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -100,6 +100,7 @@ class DbtRunResult:
 class FalDbt:
     project_dir: str
     profiles_dir: str
+    keyword: str
 
     _config: RuntimeConfig
     _manifest: DbtManifest
@@ -111,10 +112,12 @@ class FalDbt:
 
     _firestore_client: Union[FirestoreClient, None]
 
-    def __init__(self, project_dir: str, profiles_dir: str):
+    def __init__(self, project_dir: str,
+                 profiles_dir: str,
+                 keyword: str = 'fal'):
         self.project_dir = project_dir
         self.profiles_dir = profiles_dir
-
+        self.keyword = keyword
         self._config = parse.get_dbt_config(project_dir, profiles_dir)
         lib.register_adapters(self._config)
 
@@ -338,10 +341,9 @@ class FalProject:
     def __init__(
         self,
         faldbt: FalDbt,
-        keyword: str,
     ):
         self._faldbt = faldbt
-        self.keyword = keyword
+        self.keyword = faldbt.keyword
         self.scripts = parse.get_scripts_list(faldbt.project_dir)
 
     def get_model_status(self, model: DbtModel):


### PR DESCRIPTION
FalDbt should be aware of fal meta keyword for future use cases.

When a user initializes FalDbt in a Python environment, they can now specify a keyword:

```
# meta_keyward is optional and is set to "fal" by default
fal = FalDbt(project_dir='my_proj', profiles_dir='my_profile', keyword='my_fal')
```