### PR TITLE
Select scripts option

### DIFF
--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -74,6 +74,13 @@ def cli():
     type=click.STRING,
 )
 @click.option(
+    "--script",
+    nargs=1,
+    default=None,
+    help="Specify script to run, overrides schema.yml",
+    type=click.STRING,
+)
+@click.option(
     "--experimental-ordering",
     help="Turns on ordering of the fal scripts.",
     is_flag=True,
@@ -92,6 +99,7 @@ def run(
     models,
     exclude,
     selector,
+    script,
     experimental_ordering,
     debug,
 ):
@@ -125,6 +133,12 @@ def run(
         project = FalProject(faldbt)
         models = project.get_filtered_models(all, selector_flags)
         print_run_info(models, keyword)
+
+        if script:
+            scripts = []
+            for model in models:
+                scripts.append(FalScript(model, script))
+            return run_scripts(scripts, project)
 
         if experimental_ordering:
             scripts = ScriptGraph(models, keyword, project_dir).sort()

--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -77,7 +77,8 @@ def cli():
     "--script",
     nargs=1,
     default=None,
-    help="Specify script to run, overrides schema.yml",
+    multiple=True,
+    help="Specify scripts to run, overrides schema.yml",
     type=click.STRING,
 )
 @click.option(
@@ -137,7 +138,8 @@ def run(
         if script:
             scripts = []
             for model in models:
-                scripts.append(FalScript(model, script))
+                for el in script:
+                    scripts.append(FalScript(model, el))
             return run_scripts(scripts, project)
 
         if experimental_ordering:


### PR DESCRIPTION
Adds `--script` option:

```
fal run --select my_model --script my_script1.py --script my_script2.py
```

here scripts specified in schema.yml are overridden. If more than one model is selected, all scripts run on all models.
