### PR TITLE
Make fal aware of dbt test results

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -80,3 +80,12 @@ jobs:
 
           echo "*** Checking fal output files ***"
           python check_outputs.py
+
+          echo "*** Starting dbt test run ***"
+          dbt test --profiles-dir . --model agent_wait_time
+
+          echo "*** Starting fal run ***"
+          fal run --profiles-dir .
+
+          echo "*** Checking fal output files ***"
+          python check_outputs.py test

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ context.current_model.status
 #= 'skipped'
 ```
 
+`context` object also has access to test information related to the current model. If the previous dbt command was either `test` or `build`, the `context.current_model.test` property is populated with a list of tests:
+```python
+context.current_model.tests
+#= [CurrentTest(name='not_null', modelname='historical_ozone_levels, column='ds', status='Pass')]
+```
+
 ### `ref` and `source` functions
 There are also available some familiar functions from `dbt`
 ```python

--- a/src/fal/run_scripts.py
+++ b/src/fal/run_scripts.py
@@ -24,7 +24,16 @@ class CurrentModel:
     name: str
     status: NodeStatus
     columns: Dict[str, ColumnInfo]
+    tests: List[Any]
     meta: Dict[Any, Any]
+
+
+@dataclass
+class CurrentTest:
+    name: str
+    modelname: str
+    column: str
+    status: str
 
 
 @dataclass
@@ -45,10 +54,13 @@ def run_scripts(list: List[FalScript], project: FalProject):
         meta = model.meta
         _del_key(meta, project.keyword)
 
+        tests = _process_tests(model.tests)
+
         current_model = CurrentModel(
             name=model.name,
             status=project.get_model_status(model),
             columns=model.columns,
+            tests=tests,
             meta=meta,
         )
 
@@ -80,3 +92,11 @@ def _del_key(dict: Dict[str, Any], key: str):
 
 def _get_target_path(config: RuntimeConfig) -> Path:
     return Path(os.path.realpath(os.path.join(config.project_root, config.target_path)))
+
+
+def _process_tests(tests: List[Any]):
+    return list(map(
+        lambda test: CurrentTest(name=test.name,
+                                 column=test.column,
+                                 status=test.status.name,
+                                 modelname=test.model), tests))

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dbt.node_types import NodeType
 from dbt.config import RuntimeConfig
-from dbt.contracts.graph.parsed import ParsedModelNode, ParsedSourceDefinition, ParsedGenericTestNode
+from dbt.contracts.graph.parsed import ParsedModelNode, ParsedSourceDefinition
 from dbt.contracts.graph.manifest import Manifest, MaybeNonSource, MaybeParsedSource
 from dbt.contracts.results import RunResultsArtifact, RunResultOutput
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -41,7 +41,7 @@ def normalize_directories(base: str, dirs: List[str]) -> List[Path]:
 
 @dataclass
 class DbtTest:
-    node: ParsedGenericTestNode
+    node: Any
     name: str = field(init=False)
     model: str = field(init=False)
     column: str = field(init=False)

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -510,7 +510,7 @@ class FalProject:
             )
 
         models = self._get_models_with_keyword(self.keyword)
-        if self._faldbt.method == 'test':
+        if self._faldbt.method in ['test', 'build']:
             tests = self._faldbt.list_tests()
             models = self._map_tests_to_models(models, tests)
 
@@ -520,7 +520,7 @@ class FalProject:
                     filtered_models.append(node)
             elif all:
                 filtered_models.append(node)
-            elif self._faldbt.method == 'test' and node.status == 'tested':
+            elif self._faldbt.method in ['test', 'build'] and node.status == 'tested':
                 filtered_models.append(node)
             elif self.get_model_status(node) != "skipped":
                 filtered_models.append(node)

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -119,6 +119,7 @@ class FalDbt:
     profiles_dir: str
     keyword: str
     features: List[Feature]
+    method: str
 
     _config: RuntimeConfig
     _manifest: DbtManifest
@@ -162,6 +163,9 @@ class FalDbt:
         self._run_results = DbtRunResult(
             parse.get_dbt_results(self.project_dir, self._config)
         )
+
+        self.method = self._run_results.nativeRunResult.args['rpc_method']
+
         self._model_status_map = dict(
             map(
                 lambda res: [res.unique_id, res.status],

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -49,9 +49,9 @@ class DbtTest:
 
     def __post_init__(self):
         node = self.node
-        self.name = node.name
         self.unique_id = node.unique_id
         if node.resource_type == NodeType.Test:
+            self.name = node.test_metadata.name
             self.model = re.findall(r"'([^']+)'", node.test_metadata.kwargs['model'])[0]
             self.column = node.test_metadata.kwargs['column_name']
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -489,10 +489,11 @@ class FalProject:
 
     def _map_tests_to_models(self, models: List[DbtModel], tests: List[DbtTest]) -> List[DbtModel]:
         for model in models:
+            model_status = self.get_model_status(model)
             for test in tests:
                 if test.model == model.name:
                     model.tests.append(test)
-                    if test.status != 'skipped':
+                    if test.status != 'skipped' and model_status == 'skipped':
                         model.set_status('tested')
         return models
 
@@ -519,8 +520,6 @@ class FalProject:
                 if node.unique_id in selected_ids:
                     filtered_models.append(node)
             elif all:
-                filtered_models.append(node)
-            elif self._faldbt.method in ['test', 'build'] and node.status == 'tested':
                 filtered_models.append(node)
             elif self.get_model_status(node) != "skipped":
                 filtered_models.append(node)

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -111,6 +111,16 @@ class DbtManifest:
             )
         )
 
+    def get_tests(self):
+        return list(
+            filter(
+                lambda test: test.node.resource_type == NodeType.Test,
+                map(
+                    lambda node: DbtTest(node=node), self.nativeManifest.nodes.values()
+                ),
+            )
+        )
+
     def get_sources(self) -> List[ParsedSourceDefinition]:
         return list(self.nativeManifest.sources.values())
 
@@ -242,6 +252,17 @@ class FalDbt:
             model.set_status(self.get_model_status(model.unique_id))
             models.append(model)
         return models
+
+    def list_tests(self) -> List[DbtTest]:
+        """
+        List tests
+        """
+        tests = []
+        for test in self._manifest.get_tests():
+            test.set_status(self.get_model_status(test.unique_id))
+            tests.append(test)
+
+        return tests
 
     def list_features(self) -> List[Feature]:
         return self.features

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -52,6 +52,10 @@ class DbtTest:
         self.unique_id = node.unique_id
         if node.resource_type == NodeType.Test:
             self.name = node.test_metadata.name
+
+            # node.test_metadata.kwargs looks like this:
+            # kwargs={'column_name': 'y', 'model': "{{ get_where_subquery(ref('boston')) }}"}
+            # and we want to get 'boston' is the model name that we want extract
             self.model = re.findall(r"'([^']+)'", node.test_metadata.kwargs['model'])[0]
             self.column = node.test_metadata.kwargs['column_name']
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -197,7 +197,10 @@ class FalDbt:
             parse.get_dbt_results(self.project_dir, self._config)
         )
 
-        self.method = self._run_results.nativeRunResult.args['rpc_method']
+        self.method = 'run'
+
+        if self._run_results.nativeRunResult:
+            self.method = self._run_results.nativeRunResult.args['rpc_method']
 
         self._model_status_map = dict(
             map(


### PR DESCRIPTION
Closes: #101 

context object has access to test information related to the current model. If the previous dbt command was either `test` or `build`, the context.current_model.test property is populated with a list of tests:
```
context.current_model.tests
#= [CurrentTest(name='not_null', modelname='historical_ozone_levels', column='ds', status='Pass')]
```