### PR TITLE
Add no-logging flag

### DIFF
--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -82,6 +82,11 @@ def cli():
     type=click.STRING,
 )
 @click.option(
+    "--no-logging",
+    help="Disable run info logging (will not affect logging from scripts)",
+    is_flag=True
+)
+@click.option(
     "--experimental-ordering",
     help="Turns on ordering of the fal scripts.",
     is_flag=True,
@@ -101,6 +106,7 @@ def run(
     exclude,
     selector,
     script,
+    no_logging,
     experimental_ordering,
     debug,
 ):
@@ -129,11 +135,12 @@ def run(
             )
 
         faldbt = FalDbt(
-            real_project_dir, real_profiles_dir, select, exclude, selector, keyword
+            real_project_dir, real_profiles_dir, select, exclude, selector, keyword, no_logging
         )
         project = FalProject(faldbt)
         models = project.get_filtered_models(all, selector_flags)
-        print_run_info(models, keyword)
+        if not no_logging:
+            print_run_info(models, keyword)
 
         if script:
             scripts = []
@@ -151,7 +158,7 @@ def run(
                     scripts.append(FalScript(model, path))
 
         # run model specific scripts first
-        run_scripts(scripts, project)
+        run_scripts(scripts, project, no_logging)
 
         # then run global scripts
         global_scripts = list(
@@ -161,4 +168,4 @@ def run(
             )
         )
 
-        run_global_scripts(global_scripts, project)
+        run_global_scripts(global_scripts, project, no_logging)

--- a/src/fal/run_scripts.py
+++ b/src/fal/run_scripts.py
@@ -38,7 +38,7 @@ class Context:
     config: ContextConfig
 
 
-def run_scripts(list: List[FalScript], project: FalProject):
+def run_scripts(list: List[FalScript], project: FalProject, no_logging: bool):
     faldbt = project._faldbt
     for script in list:
         model = script.model
@@ -55,18 +55,20 @@ def run_scripts(list: List[FalScript], project: FalProject):
         context_config = ContextConfig(_get_target_path(faldbt._config))
         context = Context(current_model=current_model, config=context_config)
 
-        logger.info("Running script {} for model {}", script.path, model.name)
+        if not no_logging:
+            logger.info("Running script {} for model {}", script.path, model.name)
 
         script.exec(context, faldbt)
 
 
-def run_global_scripts(list: List[FalScript], project: FalProject):
+def run_global_scripts(list: List[FalScript], project: FalProject, no_logging: bool):
     faldbt = project._faldbt
     for script in list:
         context_config = ContextConfig(_get_target_path(faldbt._config))
         context = Context(current_model=None, config=context_config)
 
-        logger.info("Running global script {}", script.path)
+        if not no_logging:
+            logger.info("Running global script {}", script.path)
 
         script.exec(context, faldbt)
 

--- a/src/fal/run_scripts.py
+++ b/src/fal/run_scripts.py
@@ -6,10 +6,10 @@ from dbt.config.runtime import RuntimeConfig
 from pathlib import Path
 
 from dbt.contracts.results import NodeStatus
-from dbt.logger import GLOBAL_LOGGER as logger
 
 from faldbt.project import FalProject
 from fal.dag import FalScript
+from fal.utils import FalLogger
 
 import faldbt.lib as lib
 
@@ -38,7 +38,7 @@ class Context:
     config: ContextConfig
 
 
-def run_scripts(list: List[FalScript], project: FalProject, no_logging: bool):
+def run_scripts(list: List[FalScript], project: FalProject, logger: FalLogger):
     faldbt = project._faldbt
     for script in list:
         model = script.model
@@ -55,20 +55,18 @@ def run_scripts(list: List[FalScript], project: FalProject, no_logging: bool):
         context_config = ContextConfig(_get_target_path(faldbt._config))
         context = Context(current_model=current_model, config=context_config)
 
-        if not no_logging:
-            logger.info("Running script {} for model {}", script.path, model.name)
+        logger.info("Running script {} for model {}", script.path, model.name)
 
         script.exec(context, faldbt)
 
 
-def run_global_scripts(list: List[FalScript], project: FalProject, no_logging: bool):
+def run_global_scripts(list: List[FalScript], project: FalProject, logger: FalLogger):
     faldbt = project._faldbt
     for script in list:
         context_config = ContextConfig(_get_target_path(faldbt._config))
         context = Context(current_model=None, config=context_config)
 
-        if not no_logging:
-            logger.info("Running global script {}", script.path)
+        logger.info("Running global script {}", script.path)
 
         script.exec(context, faldbt)
 

--- a/src/fal/utils.py
+++ b/src/fal/utils.py
@@ -1,16 +1,34 @@
 """Fal utilities."""
-from dbt.logger import print_timestamped_line
-from faldbt.project import DbtModel
-from typing import List
+from dataclasses import dataclass
+from dbt.logger import print_timestamped_line, GLOBAL_LOGGER as logger
+from typing import List, Any
 
 
-def print_run_info(models: List[DbtModel], keyword: str):
-    """Print information on the current fal run."""
-    models_arr = []
-    for model in models:
-        models_arr.append(f"{model.name}: {', '.join(model.get_scripts(keyword))}")
+@dataclass
+class FalLogger:
+    disabled: bool
 
-    models_str = "\n".join(models_arr)
-    print_timestamped_line(
-        f"Starting fal run for following models and scripts: \n{models_str}\n"
-    )
+    def print_run_info(self, models: List[Any], keyword: str):
+        """Print information on the current fal run."""
+        if self.disabled:
+            return
+        models_arr = []
+        for model in models:
+            models_arr.append(f"{model.name}: {', '.join(model.get_scripts(keyword))}")
+
+        models_str = "\n".join(models_arr)
+        print_timestamped_line(
+            f"Starting fal run for following models and scripts: \n{models_str}\n"
+        )
+
+    def warn(self, *args, **kwargs):
+        if not self.disabled:
+            logger.warn(*args, **kwargs)
+
+    def info(self, *args, **kwargs):
+        if not self.disabled:
+            logger.info(*args, **kwargs)
+
+    def re_enable(self):
+        if not self.disabled and logger.disabled:
+            logger.enable()

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -45,7 +45,7 @@ class FlagsArgs:
     use_colors: bool
 
 
-def initialize_dbt_flags(profiles_dir: str):
+def initialize_dbt_flags(profiles_dir: str, no_logging: bool):
     """
     Initializes the flags module from dbt, since it's accessed from around their code.
     """
@@ -64,7 +64,7 @@ def initialize_dbt_flags(profiles_dir: str):
 
     # Re-enable logging for 1.0.0 through old API of logger
     # TODO: migrate for 1.0.0 code to new event system
-    if DBT_VCURRENT.compare(DBT_V1) >= 0:
+    if DBT_VCURRENT.compare(DBT_V1) >= 0 and not no_logging:
         flags.ENABLE_LEGACY_LOGGER = "1"
         if logger.disabled:
             logger.enable()

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -118,6 +118,7 @@ class FalDbt:
     project_dir: str
     profiles_dir: str
     keyword: str
+    no_logging: bool
     features: List[Feature]
 
     _config: RuntimeConfig
@@ -140,13 +141,15 @@ class FalDbt:
         exclude: List[str] = tuple(),
         selector_name: str = None,
         keyword: str = "fal",
+        no_logging: bool = False
     ):
         self.project_dir = project_dir
         self.profiles_dir = profiles_dir
         self.keyword = keyword
+        self.no_logging = no_logging
         self._firestore_client = None
 
-        lib.initialize_dbt_flags(profiles_dir=profiles_dir)
+        lib.initialize_dbt_flags(profiles_dir=profiles_dir, no_logging=no_logging)
 
         self._config = parse.get_dbt_config(project_dir, profiles_dir)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,15 +2,18 @@ import os
 from pathlib import Path
 
 from fal import FalDbt
+from fal.utils import FalLogger
 
 profiles_dir = os.path.join(Path.cwd(), "tests/mock/mockProfile")
 project_dir = os.path.join(Path.cwd(), "tests/mock")
+logger = FalLogger(disabled=False)
 
 
 def test_scripts():
     faldbt = FalDbt(
         profiles_dir=profiles_dir,
         project_dir=project_dir,
+        logger=logger
     )
 
     assert 0 == len(faldbt._global_script_paths)
@@ -30,6 +33,7 @@ def test_features():
     faldbt = FalDbt(
         profiles_dir=profiles_dir,
         project_dir=project_dir,
+        logger=logger
     )
 
     # Feature definitions


### PR DESCRIPTION
Adds `--disable-logging` flag that disable run information logging from fal. Doesn't affect warnings and log or print statements in user scripts. Proposed mitigation for #97 