### PR TITLE
Change readme for modified selection flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ models:
 ## 5. Run `dbt` and `fal` consecutively
 ```bash
 $ dbt run
-# Your dbt models are ran
+# Your dbt models are run
 
 $ fal run
-# Your python scripts are ran
+# Your python scripts are run
 ```
 
 # Examples
@@ -113,14 +113,14 @@ models:
       fal:
         scripts:
           - send_slack_message.py
-          - another_python_script.py # will be ran after the first script
+          - another_python_script.py # will be run after the first script
 ```
 
 `fal` also provides useful helpers within the Python context to seamlessly interact with dbt models: `ref("my_dbt_model_name")` will pull a dbt model into your Python script as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 ## Model scripts selection
 
-By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
+By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were run on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
 
 If you are running `fal` in a clean environment (no `run_results.json` available) or just want to specify which models you want to run the scripts for, `fal` handles [dbt's selection flags](https://docs.getdbt.com/reference/node-selection/syntax) for `dbt run` as well as offering an extra flag for just running _all_ models:
 
@@ -213,7 +213,7 @@ write_to_source(df, 'source_name', 'table_name2')
 ```
 
 ## Lifecycle and State Management
-By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run` (So if you are using model selectors, `fal` will only run on the selected models).
+By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were run on the last `dbt run` (So if you are using model selectors, `fal` will only run on the selected models).
 
 If you want to run all Python scripts regardless, you can do so by using the `--all` flag with the `fal` CLI:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To explore what is possible with fal, take a look at the in-depth examples below
 - [Example 11: Anomaly Detection](examples/anomaly-detection.md)
 
 # How it works?
+
 `fal` is a command line tool that can read the state of your `dbt` project and help you run Python scripts after your `dbt run`s by leveraging the [`meta` config](https://docs.getdbt.com/reference/resource-configs/meta).
 
 ```yaml
@@ -115,6 +116,8 @@ models:
           - another_python_script.py # will be ran after the first script
 ```
 
+`fal` also provides useful helpers within the Python context to seamlessly interact with dbt models: `ref("my_dbt_model_name")` will pull a dbt model into your Python script as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
+
 ## Model scripts selection
 
 By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
@@ -122,23 +125,24 @@ By default, the `fal run` command runs the Python scripts as a post-hook, **only
 If you are running `fal` in a clean environment (no `run_results.json` available) or just want to specify which models you want to run the scripts for, `fal` handles [dbt's selection flags](https://docs.getdbt.com/reference/node-selection/syntax) for `dbt run` as well as offering an extra flag for just running _all_ models:
 
 ```
---all                    Run scripts for all models.
--s, --select TEXT        Specify the nodes to include.
--m, --models TEXT        Specify the nodes to include. (Deprecated)
---exclude TEXT           Specify the models to exclude.
---selector TEXT          The selector name to use, as defined in selectors.yml
+--all                 Run scripts for all models.
+-s SELECT [SELECT ...], --select SELECT [SELECT ...]
+                      Specify the nodes to include.
+-m SELECT [SELECT ...], --models SELECT [SELECT ...]
+                      Specify the nodes to include.
+--exclude EXCLUDE [EXCLUDE ...]
+                      Specify the nodes to exclude.
+--selector SELECTOR   The selector name to use, as defined in selectors.yml
 ```
 
-For passing more than one selection or exlusion, you must specify the flag multiple times:
+You may pass more than one selection at a time:
 
 ```bash
-$ fal run -s model_alpha -s model_beta
+$ fal run --select model_alpha model_beta
 ... | Starting fal run for following models and scripts:
 model_alpha: script.py
 model_beta: script.py, other.py
 ```
-
-`fal` also provides useful helpers within the Python context to seamlessly interact with dbt models: `ref("my_dbt_model_name")` will pull a dbt model into your Python script as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 # Concepts
 ## profile.yml and Credentials

--- a/docsite/docs/cli/fal scripts/lifecycle.md
+++ b/docsite/docs/cli/fal scripts/lifecycle.md
@@ -1,9 +1,0 @@
-# Lifecycle and State Management
-
-By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run` (So if you are using model selectors, `fal` will only run on the selected models).
-
-If you want to run all Python scripts regardless, you can do so by using the `--all` flag with the `fal` CLI:
-
-```bash
-$ fal run --all
-```

--- a/docsite/docs/cli/fal scripts/model-scripts-selection.md
+++ b/docsite/docs/cli/fal scripts/model-scripts-selection.md
@@ -1,0 +1,25 @@
+# Model scripts selection
+
+By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
+
+If you are running `fal` in a clean environment (no `run_results.json` available) or just want to specify which models you want to run the scripts for, `fal` handles [dbt's selection flags](https://docs.getdbt.com/reference/node-selection/syntax) for `dbt run` as well as offering an extra flag for just running _all_ models:
+
+```
+--all                 Run scripts for all models.
+-s SELECT [SELECT ...], --select SELECT [SELECT ...]
+                      Specify the nodes to include.
+-m SELECT [SELECT ...], --models SELECT [SELECT ...]
+                      Specify the nodes to include.
+--exclude EXCLUDE [EXCLUDE ...]
+                      Specify the nodes to exclude.
+--selector SELECTOR   The selector name to use, as defined in selectors.yml
+```
+
+You may pass more than one selection at a time:
+
+```bash
+$ fal run --select model_alpha model_beta
+... | Starting fal run for following models and scripts:
+model_alpha: script.py
+model_beta: script.py, other.py
+```

--- a/docsite/docs/cli/fal scripts/model-scripts-selection.md
+++ b/docsite/docs/cli/fal scripts/model-scripts-selection.md
@@ -1,6 +1,6 @@
 # Model scripts selection
 
-By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
+By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were run on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
 
 If you are running `fal` in a clean environment (no `run_results.json` available) or just want to specify which models you want to run the scripts for, `fal` handles [dbt's selection flags](https://docs.getdbt.com/reference/node-selection/syntax) for `dbt run` as well as offering an extra flag for just running _all_ models:
 

--- a/docsite/docs/cli/getting-started.md
+++ b/docsite/docs/cli/getting-started.md
@@ -75,10 +75,10 @@ models:
 
 ```bash
 $ dbt run
-# Your dbt models are ran
+# Your dbt models are run
 
 $ fal run
-# Your python scripts are ran
+# Your python scripts are run
 ```
 
 # How it works?
@@ -93,7 +93,7 @@ models:
       fal:
         scripts:
           - send_slack_message.py
-          - another_python_script.py # will be ran after the first script
+          - another_python_script.py # will be run after the first script
 ```
 
 `fal` also provides useful helpers within the Python context to seamlessly interact with dbt models: `ref("my_dbt_model_name")` will pull a dbt model into your Python script as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).

--- a/docsite/docs/cli/getting-started.md
+++ b/docsite/docs/cli/getting-started.md
@@ -96,27 +96,4 @@ models:
           - another_python_script.py # will be ran after the first script
 ```
 
-## Model scripts selection
-
-By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were ran on the last `dbt run`; that means that if you are using model selectors, `fal` will only run on the models `dbt` ran. To achieve this, fal needs the dbt-generated file `run_results.json` available.
-
-If you are running `fal` in a clean environment (no `run_results.json` available) or just want to specify which models you want to run the scripts for, `fal` handles [dbt's selection flags](https://docs.getdbt.com/reference/node-selection/syntax) for `dbt run` as well as offering an extra flag for just running _all_ models:
-
-```
---all                    Run scripts for all models.
--s, --select TEXT        Specify the nodes to include.
--m, --models TEXT        Specify the nodes to include. (Deprecated)
---exclude TEXT           Specify the models to exclude.
---selector TEXT          The selector name to use, as defined in selectors.yml
-```
-
-For passing more than one selection or exlusion, you must specify the flag multiple times:
-
-```bash
-$ fal run -s model_alpha -s model_beta
-... | Starting fal run for following models and scripts:
-model_alpha: script.py
-model_beta: script.py, other.py
-```
-
 `fal` also provides useful helpers within the Python context to seamlessly interact with dbt models: `ref("my_dbt_model_name")` will pull a dbt model into your Python script as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).

--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -191,7 +191,8 @@ def _run(
         # TODO: remove `action="extend"` to match exactly what dbt does
         if selects_count > 1:
             dbt.exceptions.warn_or_error(
-                "Passing multiple --select/--model flags to fal is deprecatd. Please use model selection like dbt.",
+                "Passing multiple --select/--model flags to fal is deprecatd.\n"
+                + f"Please use model selection like dbt. Use: --select {' '.join(select)}",
                 log_fmt=dbt.ui.warning_tag("{}"),
             )
 


### PR DESCRIPTION
New warning:

```
$ fal run --profiles-dir . -s boston -s lombardia_covid -m boston

23:45:44  Found 6 models, 0 tests, 0 snapshots, 0 analyses, 188 macros, 0 operations, 2 seed files, 1 source, 0 exposures, 0 metrics
23:45:44  [WARNING]: Passing multiple --select/--model flags to fal is deprecatd.
Please use model selection like dbt. Use: --select boston lombardia_covid boston
```