### PR TITLE
Add extend action for exclude and scripts flags

### DIFF
--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -85,6 +85,7 @@ def run_fal(argv):
     run_parser.add_argument(
         "--exclude",
         nargs="+",
+        action="extend", # For backwards compatibility with past fal version
         help="Specify the nodes to exclude.",
     )
     run_parser.add_argument(
@@ -94,6 +95,7 @@ def run_fal(argv):
     run_parser.add_argument(
         "--scripts",
         nargs="+",
+        action="extend", # For backwards compatibility with past fal version
         help="Specify scripts to run, overrides schema.yml",
     )
 


### PR DESCRIPTION
I focused in #132 on select and models and forgot about `exclude`. I also added `scripts` to maintain the same behavior across flags.

What do you think? Should we merge this or is it ok how it is?

*****

Current behavior

```
fal run --select a --select b --exclude c --exclude d
# select=[a,b]
# exclude=[d] (overwritten with the second flag)
```


Behavior in this branch

```
fal run --select a --select b --exclude c --exclude d
# select=[a,b]
# exclude=[c,d] (consistent with select)
```

*****

# TODO

- [ ] Add warning when using multiple times the same flag