### PR TITLE
Add dtypes args to write_to_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ This operation appends to the existing source by default and should only be used
 # Upload a `pandas.DataFrame` back to the datawarehouse
 write_to_source(df, 'source_name', 'table_name2')
 ```
+`write_to_source` also accepts an optional `dtype` argument, which lets you specify datatypes of columns. It works the same way as `dtype` argument for [`DataFrame.to_sql` function](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html).
 
 ## Lifecycle and State Management
 By default, the `fal run` command runs the Python scripts as a post-hook, **only** on the models that were run on the last `dbt run` (So if you are using model selectors, `fal` will only run on the selected models).

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -177,6 +177,7 @@ def write_target(
     project_path: str,
     profiles_dir: str,
     target: Union[ParsedModelNode, ParsedSourceDefinition],
+    dtype=None
 ) -> RemoteRunResult:
     adapter = _get_adapter(project_path, profiles_dir)
 
@@ -184,7 +185,7 @@ def write_target(
 
     engine = _alchemy_engine(adapter, target)
     pddb = pdsql.SQLDatabase(engine, schema=target.schema)
-    pdtable = pdsql.SQLTable(target.name, pddb, data, index=False)
+    pdtable = pdsql.SQLTable(target.name, pddb, data, index=False, dtype=dtype)
     alchemy_table: sqlalchemy.Table = pdtable.table.to_metadata(pdtable.pd_sql.meta)
 
     column_names: List[str] = list(data.columns)

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -350,7 +350,11 @@ class FalDbt:
         )
 
     def write_to_source(
-        self, data: pd.DataFrame, target_source_name: str, target_table_name: str
+        self,
+        data: pd.DataFrame,
+        target_source_name: str,
+        target_table_name: str,
+        dtype: Any = None
     ):
         """
         Write a pandas.DataFrame to a dbt source automagically.
@@ -371,6 +375,7 @@ class FalDbt:
             self.project_dir,
             self.profiles_dir,
             target_source,
+            dtype
         )
 
     def write_to_firestore(self, df: pd.DataFrame, collection: str, key_column: str):


### PR DESCRIPTION
Addresses #120 

When calling `write_source` user now has one optional argument: `dtype`, which works the same way as described here: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html