### PR TITLE
Enable --before for global scripts

### DIFF
--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -235,11 +235,12 @@ def _run(
         run_scripts(scripts, project)
 
         # then run global scripts
-        global_scripts = list(
-            map(
-                lambda path: FalScript(None, path, []),
-                faldbt._global_script_paths,
+        if selector_flags is None and before is False:
+            global_scripts = list(
+                map(
+                    lambda path: FalScript(None, path, []),
+                    faldbt._global_script_paths,
+                )
             )
-        )
 
-        run_global_scripts(global_scripts, project)
+            run_global_scripts(global_scripts, project)

--- a/src/fal/cli.py
+++ b/src/fal/cli.py
@@ -235,12 +235,12 @@ def _run(
         run_scripts(scripts, project)
 
         # then run global scripts
-        if selector_flags is None and before is False:
-            global_scripts = list(
-                map(
-                    lambda path: FalScript(None, path, []),
-                    faldbt._global_script_paths,
-                )
+        global_key = 'before' if before else 'after'
+        global_scripts = list(
+            map(
+                lambda path: FalScript(None, path, []),
+                faldbt._global_script_paths[global_key],
             )
+        )
 
-            run_global_scripts(global_scripts, project)
+        run_global_scripts(global_scripts, project)

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -65,7 +65,7 @@ def get_scripts_list(project_dir: str) -> List[str]:
 
 
 def get_global_script_configs(source_dirs: List[Path]) -> List[str]:
-    global_scripts = []
+    global_scripts = {'before': [], 'after': []}
     for source_dir in source_dirs:
         schema_files = glob.glob(os.path.join(source_dir, "**.yml"), recursive=True)
         for file in schema_files:
@@ -75,7 +75,11 @@ def get_global_script_configs(source_dirs: List[Path]) -> List[str]:
                 if fal_config is not None:
                     # sometimes `scripts` can *be* there and still be None
                     script_paths = fal_config.get("scripts") or []
-                    global_scripts += script_paths
+                    if isinstance(script_paths, list):
+                        global_scripts['after'] += script_paths
+                    else:
+                        global_scripts['before'] += script_paths.get('before') or []
+                        global_scripts['after'] += script_paths.get('after') or []
             else:
                 raise FalParseError("Error pasing the schema file " + file)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -13,7 +13,8 @@ def test_scripts():
         project_dir=project_dir,
     )
 
-    assert 0 == len(faldbt._global_script_paths)
+    assert isinstance(faldbt._global_script_paths, dict)
+    assert 0 == len(faldbt._global_script_paths['after'])
 
     faldbt._global_script_paths
     models = faldbt.list_models()


### PR DESCRIPTION
When you pass model selection of `--before` flag, global scripts are not run.