### PR TITLE
Handle flags present in several commands and subcommands

### DIFF
--- a/src/fal/cli/__init__.py
+++ b/src/fal/cli/__init__.py
@@ -16,7 +16,7 @@ from fal.utils import print_run_info
 from faldbt.lib import DBT_VCURRENT, DBT_V1
 from faldbt.project import FalDbt, FalGeneralException, FalProject
 
-from .args import build_cli_parser
+from .args import parse_args
 
 
 class DbtCliRuntimeError(Exception):
@@ -58,9 +58,7 @@ class DbtCliOutput:
 
 
 def cli(argv=sys.argv):
-    parser = build_cli_parser()
-
-    parsed = parser.parse_args(argv[1:])
+    parsed = parse_args(argv[1:])
 
     # TODO: remove `action="extend"` to match exactly what dbt does
     selects_count = (

--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-from email.policy import default
 from uuid import uuid4
 from typing import List
 import os
@@ -10,7 +8,10 @@ import pkg_resources
 LEVEL_FLAGS = {}
 
 
-@dataclass(init=False)
+class FalArgsError(Exception):
+    pass
+
+
 class _LevelFlag:
     levels: List[str]
     default: any
@@ -20,20 +21,26 @@ class _LevelFlag:
         self.default = default
 
 
+# This is to handle offering the same flag at several parser levels
+# e.g. fal --profiles-dir ~/somewhere run --profiles-dir ~/other_place
+# we should get profiles_dir=~/other_place (right-most wins)
 def _flag_level(name: str, default=None):
     level = uuid4()
+    # Store initial _LevelFlag value in case there is none yet
     LEVEL_FLAGS[name] = LEVEL_FLAGS.get(name, _LevelFlag(default))
     level_flag = LEVEL_FLAGS[name]
+    # Add current level, these are meant to read in order (right-most wins)
     level_flag.levels.append(level)
 
     if default != level_flag.default:
-        print(
-            f"ERROR: different defaults {default} and {level_flag.default} for flag {name}"
+        raise FalArgsError(
+            f"Different defaults '{default}' and '{level_flag.default}' for flag '{name}'"
         )
 
     return f"{name}_{level}"
 
 
+# Use right after creating the parser, before adding subparsers to it
 def _build_fal_common_options(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--disable-logging",
@@ -49,6 +56,7 @@ def _build_fal_common_options(parser: argparse.ArgumentParser):
     )
 
 
+# Use right after creating the parser, before adding subparsers to it
 def _build_dbt_common_options(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--project-dir",
@@ -193,14 +201,17 @@ cli_parser = _build_cli_parser()
 
 
 def parse_args(argv: List[str]):
-    parsed = cli_parser.parse_args(argv)
-    parsed_dict = vars(parsed)
+    args = cli_parser.parse_args(argv)
+    args_dict = vars(args)
 
-    # Handle repeating args
+    # Reduce level flags into a single one with the value to use
     for name, level_flag in LEVEL_FLAGS.items():
-        parsed_dict[name] = level_flag.default
+        args_dict[name] = level_flag.default
         for level in level_flag.levels:
-            current = parsed_dict.pop(f"{name}_{level}", None)
-            if current:
-                parsed_dict[name] = current
-    return argparse.Namespace(**parsed_dict)
+            # Read and delete the level flag to keep only the main one
+            current = args_dict.pop(f"{name}_{level}", None)
+            if current is not None:
+                args_dict[name] = current
+
+    # Build new argparse.Namespace with the correct flags
+    return argparse.Namespace(**args_dict)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,12 +50,11 @@ def test_flow_run_with_project_dir(capfd):
     with tempfile.TemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
-                "flow",
-                "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
+                # fmt: off
+                "flow", "run",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                # fmt: on
             ],
             capfd,
         )
@@ -71,16 +70,14 @@ def test_selection(capfd):
         shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
         captured = _run_fal(
             [
+                # fmt: off
                 "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
-                "--select",
-                "model_feature_store",
-                "model_empty_scripts",
-                "--select",
-                "model_with_scripts",  # included (extend)
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_feature_store", "model_empty_scripts",
+                "--select", "model_with_scripts",
+                # included (extend)
+                # fmt: on
             ],
             capfd,
         )
@@ -96,17 +93,13 @@ def test_selection(capfd):
 
         captured = _run_fal(
             [
-                "flow",
-                "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
-                "--select",
-                "model_with_scripts",  # not included (overwrites)
-                "--select",
-                "model_feature_store",
-                "model_empty_scripts",
+                # fmt: off
+                "flow", "run",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_with_scripts",  # not included (overwritten)
+                "--select", "model_feature_store", "model_empty_scripts",
+                # fmt: on
             ],
             capfd,
         )
@@ -122,13 +115,12 @@ def test_selection(capfd):
 
         captured = _run_fal(
             [
+                # fmt: off
                 "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
-                "--select",
-                "model_no_fal",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_no_fal",
+                # fmt: on
             ],
             capfd,
         )
@@ -169,14 +161,13 @@ def test_before(capfd):
 
         captured = _run_fal(
             [
+                # fmt: off
                 "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
-                "--select",
-                "model_with_scripts",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_with_scripts",
                 "--before",
+                # fmt: on
             ],
             capfd,
         )
@@ -189,12 +180,12 @@ def test_before(capfd):
 
         captured = _run_fal(
             [
+                # fmt: off
                 "run",
-                "--project-dir",
-                tmp_dir,
-                "--profiles-dir",
-                profiles_dir,
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
                 "--before",
+                # fmt: on
             ],
             capfd,
         )
@@ -203,6 +194,40 @@ def test_before(capfd):
         assert "model_empty_scripts" not in captured.out
         assert "model_no_fal" not in captured.out
         assert "model_with_before_scripts" in captured.out
+
+
+def test_flag_level(capfd):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+
+        captured = _run_fal(
+            [
+                # fmt: off
+                "--keyword", "wrong",
+                "run",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_with_scripts",
+                # fmt: on
+            ],
+            capfd,
+        )
+        assert "model_with_scripts" not in captured.out
+
+        captured = _run_fal(
+            [
+                # fmt: off
+                "--keyword", "wrong",
+                "run",
+                "--keyword", "fal",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--select", "model_with_scripts",
+                # fmt: on
+            ],
+            capfd,
+        )
+        assert "model_with_scripts" in captured.out
 
 
 def _run_fal(args, capfd):


### PR DESCRIPTION
We had a problem when using flags like `fal --profiles-dir . run` vs `fal run --profiles-dir .`, which should behave the same.

This has a "hack" where we create several `dest` for each of these flag positions, but it is all abstracted in the args file.