### PR TITLE
Set EL API client parameters in profiles.yml

### DIFF
--- a/src/fal/el/airbyte.py
+++ b/src/fal/el/airbyte.py
@@ -51,7 +51,7 @@ class AirbyteClient:
                 response.raise_for_status()
                 return response.json()
             except RequestException as e:
-                logger.warn("Airbyte API request failed: %s", e)
+                logger.warn(f"Airbyte API request failed: {e}")
                 if num_retries == self.max_retries:
                     break
                 num_retries += 1

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -39,6 +39,8 @@ class FalScript:
                     "list_models_ids": faldbt.list_models_ids,
                     "list_sources": faldbt.list_sources,
                     "list_features": faldbt.list_features,
+                    "airbyte_sync": faldbt.airbyte_sync,
+                    "fivetran_sync": faldbt.fivetran_sync,
                 },
             )
             sys.path.remove(local_path)

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -39,8 +39,7 @@ class FalScript:
                     "list_models_ids": faldbt.list_models_ids,
                     "list_sources": faldbt.list_sources,
                     "list_features": faldbt.list_features,
-                    "airbyte_sync": faldbt.airbyte_sync,
-                    "fivetran_sync": faldbt.fivetran_sync,
+                    "el": faldbt.el,
                 },
             )
             sys.path.remove(local_path)

--- a/src/faldbt/el_client.py
+++ b/src/faldbt/el_client.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass
+from enum import Enum
+from fal.el.airbyte import AirbyteClient
+from fal.el.fivetran import FivetranClient
+from typing import Dict
+
+
+class ELConfigTypes(Enum):
+    AIRBYTE = 1
+    FIVETRAN = 2
+
+
+CONNECTION_KEYS = {"AIRBYTE": "connections", "FIVETRAN": "connectors"}
+
+
+@dataclass
+class FalElClient:
+    configs: Dict[str, Dict]
+
+    def airbyte_sync(
+        self,
+        config_name: str,
+        connection_id: str = None,
+        connection_name: str = None,
+        poll_interval: float = 10,
+        poll_timeout: float = None,
+        max_retries: int = 10,
+    ) -> Dict[str, Dict]:
+        return self._run_el_sync(
+            config_name=config_name,
+            connection_id=connection_id,
+            connection_name=connection_name,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
+        )
+
+    def fivetran_sync(
+        self,
+        config_name: str,
+        connector_id: str = None,
+        connector_name: str = None,
+        poll_interval: float = 10,
+        poll_timeout: float = None,
+    ) -> Dict[str, Dict]:
+        return self._run_el_sync(
+            config_name=config_name,
+            connection_id=connector_id,
+            connection_name=connector_name,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
+        )
+
+    def _run_el_sync(
+        self,
+        config_name: str,
+        connection_id: str,
+        connection_name: str,
+        poll_interval: float = 10,
+        poll_timeout: float = None,
+    ) -> Dict[str, Dict]:
+
+        el_config = self.configs.get(config_name, None)
+
+        if el_config is None:
+            raise Exception(f"EL configuration {config_name} is not found.")
+
+        if connection_id is None and connection_name is None:
+            raise Exception(
+                "Either connection id or connection name have to be provided."
+            )
+
+        config_type = el_config.get("type", None)
+
+        if config_type not in [el.name for el in ELConfigTypes]:
+            raise Exception(f"EL configuration type {config_type} is not supported.")
+
+        connection_key = CONNECTION_KEYS[config_type]
+
+        if connection_id is None:
+            connections = el_config[connection_key]
+            connection = next(
+                (c for c in connections if c["name"] == connection_name), None
+            )
+            if connection is None:
+                raise Exception(f"Connection {connection_name} not found.")
+            connection_id = connection["id"]
+
+        if config_type == ELConfigTypes.AIRBYTE.name:
+            client = AirbyteClient(host=el_config["host"])
+            return client.sync_and_wait(connection_id)
+
+        elif config_type == ELConfigTypes.FIVETRAN.name:
+            client = FivetranClient(
+                api_key=el_config["api_key"], api_secret=el_config["api_secret"]
+            )
+            return client.sync_and_wait(connector_id=connection_id)
+
+        raise Exception("Not implemented")

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -41,31 +41,13 @@ def get_dbt_config(
     return RuntimeConfig.from_args(args)
 
 
-def get_el_configs(profiles_dir: str, profile_name: str):
+def get_el_configs(profiles_dir: str, profile_name: str, target_name: str):
     path = os.path.join(profiles_dir, "profiles.yml")
     yml = load_yaml(path)
-    adapters = yml.get(profile_name, {}).get("fal", {}).get("el", [])
-    config_map = {"fivetran": {}, "airbyte": {}}
-    for adapter in adapters:
-        if adapter["type"] == "fivetran":
-            config_map["fivetran"]["client"] = FivetranClient(
-                api_key=adapter["api_key"],
-                api_secret=adapter["api_secret"],
-                disable_schedule_on_trigger=adapter.get(
-                    "disable_schedule_trigger", None
-                ),
-                max_retries=adapter.get("max_retries", 3),
-                retry_delay=adapter.get("retry_delay", 0.25),
-            )
-            config_map["fivetran"]["connectors"] = adapter.get("connectors", [])
-        elif adapter["type"] == "airbyte":
-            config_map["airbyte"]["client"] = AirbyteClient(
-                host=adapter["host"],
-                max_retries=adapter.get("max_retries", 5),
-                retry_delay=adapter.get("retry_delay", 5),
-            )
-            config_map["airbyte"]["connections"] = adapter.get("connections", [])
-    return config_map
+    sync_configs = (
+        yml.get(profile_name, {}).get("fal_extract_load", {}).get(target_name, [])
+    )
+    return sync_configs
 
 
 def get_dbt_manifest(config) -> Manifest:

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -11,6 +11,8 @@ from dbt.contracts.project import UserConfig
 from dbt.config.profile import read_user_config
 from dbt.exceptions import IncompatibleSchemaException, RuntimeException
 from dbt.logger import GLOBAL_LOGGER as logger
+from fal.el.airbyte import AirbyteClient
+from fal.el.fivetran import FivetranClient
 
 from faldbt.utils.yaml_helper import load_yaml
 
@@ -37,6 +39,33 @@ def get_dbt_config(
     # Construct a phony config
     args = RuntimeArgs(project_dir, profiles_dir, threads, single_threaded=False)
     return RuntimeConfig.from_args(args)
+
+
+def get_el_adapters(profiles_dir: str, profile_name: str):
+    path = os.path.join(profiles_dir, "profiles.yml")
+    yml = load_yaml(path)
+    adapters = yml.get(profile_name, {}).get("fal", {}).get("el", [])
+    adapter_map = {"fivetran": {}, "airbyte": {}}
+    for adapter in adapters:
+        if adapter["type"] == "fivetran":
+            adapter_map["fivetran"]["client"] = FivetranClient(
+                api_key=adapter["api_key"],
+                api_secret=adapter["api_secret"],
+                disable_schedule_on_trigger=adapter.get(
+                    "disable_schedule_trigger", None
+                ),
+                max_retries=adapter.get("max_retries", 3),
+                retry_delay=adapter.get("retry_delay", 0.25),
+            )
+            adapter_map["fivetran"]["connectors"] = adapter.get("connectors", [])
+        elif adapter["type"] == "airbyte":
+            adapter_map["airbyte"]["client"] = AirbyteClient(
+                host=adapter["host"],
+                max_retries=adapter.get("max_retries", 5),
+                retry_delay=adapter.get("retry_delay", 5),
+            )
+            adapter_map["airbyte"]["connections"] = adapter.get("connections", [])
+    return adapters
 
 
 def get_dbt_manifest(config) -> Manifest:

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -41,14 +41,14 @@ def get_dbt_config(
     return RuntimeConfig.from_args(args)
 
 
-def get_el_adapters(profiles_dir: str, profile_name: str):
+def get_el_configs(profiles_dir: str, profile_name: str):
     path = os.path.join(profiles_dir, "profiles.yml")
     yml = load_yaml(path)
     adapters = yml.get(profile_name, {}).get("fal", {}).get("el", [])
-    adapter_map = {"fivetran": {}, "airbyte": {}}
+    config_map = {"fivetran": {}, "airbyte": {}}
     for adapter in adapters:
         if adapter["type"] == "fivetran":
-            adapter_map["fivetran"]["client"] = FivetranClient(
+            config_map["fivetran"]["client"] = FivetranClient(
                 api_key=adapter["api_key"],
                 api_secret=adapter["api_secret"],
                 disable_schedule_on_trigger=adapter.get(
@@ -57,15 +57,15 @@ def get_el_adapters(profiles_dir: str, profile_name: str):
                 max_retries=adapter.get("max_retries", 3),
                 retry_delay=adapter.get("retry_delay", 0.25),
             )
-            adapter_map["fivetran"]["connectors"] = adapter.get("connectors", [])
+            config_map["fivetran"]["connectors"] = adapter.get("connectors", [])
         elif adapter["type"] == "airbyte":
-            adapter_map["airbyte"]["client"] = AirbyteClient(
+            config_map["airbyte"]["client"] = AirbyteClient(
                 host=adapter["host"],
                 max_retries=adapter.get("max_retries", 5),
                 retry_delay=adapter.get("retry_delay", 5),
             )
-            adapter_map["airbyte"]["connections"] = adapter.get("connections", [])
-    return adapters
+            config_map["airbyte"]["connections"] = adapter.get("connections", [])
+    return config_map
 
 
 def get_dbt_manifest(config) -> Manifest:

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -11,8 +11,6 @@ from dbt.contracts.project import UserConfig
 from dbt.config.profile import read_user_config
 from dbt.exceptions import IncompatibleSchemaException, RuntimeException
 from dbt.logger import GLOBAL_LOGGER as logger
-from fal.el.airbyte import AirbyteClient
-from fal.el.fivetran import FivetranClient
 
 from faldbt.utils.yaml_helper import load_yaml
 
@@ -41,11 +39,13 @@ def get_dbt_config(
     return RuntimeConfig.from_args(args)
 
 
-def get_el_configs(profiles_dir: str, profile_name: str, target_name: str):
+def get_el_configs(
+    profiles_dir: str, profile_name: str, target_name: str
+) -> Dict[str, Dict]:
     path = os.path.join(profiles_dir, "profiles.yml")
     yml = load_yaml(path)
     sync_configs = (
-        yml.get(profile_name, {}).get("fal_extract_load", {}).get(target_name, [])
+        yml.get(profile_name, {}).get("fal_extract_load", {}).get(target_name, {})
     )
     return sync_configs
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -191,6 +191,8 @@ class FalDbt:
 
     _firestore_client: Union[FirestoreClient, None]
 
+    _el_adapters: Dict[str, Any]
+
     def __init__(
         self,
         project_dir: str,
@@ -209,6 +211,10 @@ class FalDbt:
         lib.initialize_dbt_flags(profiles_dir=profiles_dir)
 
         self._config = parse.get_dbt_config(project_dir, profiles_dir, threads)
+
+        self._el_adapters = parse.get_el_adapter_data(
+            profiles_dir, self._config.profile_name
+        )
 
         # Necessary for manifest loading to not fail
         dbt.tracking.initialize_tracking(profiles_dir)

--- a/tests/mock/mockProfile/profiles.yml
+++ b/tests/mock/mockProfile/profiles.yml
@@ -2,8 +2,8 @@ fal_test:
   target: dev
   fal_extract_load:
     dev:
-      - name: 'my_fivetran_el'
-        type: fivetran
+      my_fivetran_el:
+        type: FIVETRAN
         api_key: my_fivetran_key
         api_secret: my_fivetran_secret
         connectors:
@@ -11,8 +11,8 @@ fal_test:
             id: id_fivetran_connector_1
           - name: fivetran_connector_2
             id: id_fivetran_connector_2
-      - name: 'my_airbyte_el'
-        type: airbyte
+      my_airbyte_el:
+        type: AIRBYTE
         host: http://localhost:8001
         connections:
           - name: airbyte_connection_1

--- a/tests/mock/mockProfile/profiles.yml
+++ b/tests/mock/mockProfile/profiles.yml
@@ -1,8 +1,9 @@
 fal_test:
   target: dev
-  fal:
-    el:
-      - type: fivetran
+  fal_extract_load:
+    dev:
+      - name: 'my_fivetran_el'
+        type: fivetran
         api_key: my_fivetran_key
         api_secret: my_fivetran_secret
         connectors:
@@ -10,7 +11,8 @@ fal_test:
             id: id_fivetran_connector_1
           - name: fivetran_connector_2
             id: id_fivetran_connector_2
-      - type: airbyte
+      - name: 'my_airbyte_el'
+        type: airbyte
         host: http://localhost:8001
         connections:
           - name: airbyte_connection_1

--- a/tests/mock/mockProfile/profiles.yml
+++ b/tests/mock/mockProfile/profiles.yml
@@ -1,5 +1,22 @@
 fal_test:
   target: dev
+  fal:
+    el:
+      - type: fivetran
+        api_key: my_fivetran_key
+        api_secret: my_fivetran_secret
+        connectors:
+          - name: fivetran_connector_1
+            id: id_fivetran_connector_1
+          - name: fivetran_connector_2
+            id: id_fivetran_connector_2
+      - type: airbyte
+        host: http://localhost:8001
+        connections:
+          - name: airbyte_connection_1
+            id: id_airbyte_connection_1
+          - name: airbyte_connection_2
+            id: id_airbyte_connection_2
   outputs:
     dev:
       type: postgres

--- a/tests/test_el/test_fivetran.py
+++ b/tests/test_el/test_fivetran.py
@@ -1,5 +1,4 @@
-from mock import patch, Mock
-from unittest.mock import ANY
+from mock import patch, Mock, ANY
 import requests
 
 from fal.el.fivetran import FivetranClient, ScheduleType

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from mock import Mock
 
 from fal import FalDbt
 
@@ -14,7 +15,7 @@ def test_scripts():
     )
 
     assert isinstance(faldbt._global_script_paths, dict)
-    assert 0 == len(faldbt._global_script_paths['after'])
+    assert 0 == len(faldbt._global_script_paths["after"])
 
     faldbt._global_script_paths
     models = faldbt.list_models()
@@ -44,3 +45,115 @@ def test_features():
     fs_def = features[0]
     assert "a" == fs_def.entity_column
     assert "model_feature_store" == fs_def.model
+
+
+def test_adapter_setup():
+    faldbt = FalDbt(
+        profiles_dir=profiles_dir,
+        project_dir=project_dir,
+    )
+
+    fivetran_client = faldbt._el_configs["fivetran"].get("client", None)
+    assert fivetran_client is not None
+    assert fivetran_client.api_key == "my_fivetran_key"
+    assert fivetran_client.api_secret == "my_fivetran_secret"
+
+    connectors = faldbt._el_configs["fivetran"].get("connectors", None)
+    assert len(connectors) == 2
+    assert connectors[0]["name"] is not None
+    assert connectors[0]["id"] is not None
+
+    airbyte_client = faldbt._el_configs["airbyte"].get("client", None)
+    assert airbyte_client is not None
+    assert airbyte_client.host == "http://localhost:8001"
+
+    connections = faldbt._el_configs["airbyte"].get("connections", None)
+    assert len(connections) == 2
+    assert connections[0]["name"] is not None
+    assert connections[0]["id"] is not None
+
+
+def test_airbyte_sync():
+    faldbt = FalDbt(
+        profiles_dir=profiles_dir,
+        project_dir=project_dir,
+    )
+    airbyte_client = faldbt._el_configs["airbyte"].get("client", None)
+    airbyte_client.sync_and_wait = Mock()
+
+    faldbt.airbyte_sync(connection_id="id_airbyte_connection_1")
+    airbyte_client.sync_and_wait.assert_called_with(
+        "id_airbyte_connection_1", interval=10, timeout=None
+    )
+
+    airbyte_client.sync_and_wait.reset_mock()
+
+    faldbt.airbyte_sync(connection_name="airbyte_connection_1")
+    airbyte_client.sync_and_wait.assert_called_with(
+        "id_airbyte_connection_1", interval=10, timeout=None
+    )
+
+    airbyte_client.sync_and_wait.reset_mock()
+
+    try:
+        faldbt.airbyte_sync()
+
+    except Exception as e:
+        assert str(e) == "Either connection id or connection name have to be provided."
+
+    airbyte_client.sync_and_wait.reset_mock()
+
+    try:
+        faldbt.airbyte_sync(connection_name="not_there")
+        assert False is True
+    except Exception as e:
+        assert (
+            str(e)
+            == "Couldn't find connection not_there. Did you add it to profiles.yml?"
+        )
+
+
+def test_fivetran_sync():
+    faldbt = FalDbt(
+        profiles_dir=profiles_dir,
+        project_dir=project_dir,
+    )
+    fivetran_client = faldbt._el_configs["fivetran"].get("client", None)
+    fivetran_client.sync_and_wait = Mock()
+    fivetran_client.resync_and_wait = Mock()
+
+    faldbt.fivetran_sync(connector_id="id_fivetran_connector_1")
+    fivetran_client.sync_and_wait.assert_called_with(
+        "id_fivetran_connector_1", interval=10, timeout=None
+    )
+
+    fivetran_client.sync_and_wait.reset_mock()
+
+    faldbt.fivetran_sync(connector_name="fivetran_connector_1")
+    fivetran_client.sync_and_wait.assert_called_with(
+        "id_fivetran_connector_1", interval=10, timeout=None
+    )
+
+    fivetran_client.sync_and_wait.reset_mock()
+
+    try:
+        faldbt.fivetran_sync()
+
+    except Exception as e:
+        assert str(e) == "Either connector id or connector name have to be provided."
+
+    fivetran_client.sync_and_wait.reset_mock()
+
+    try:
+        faldbt.fivetran_sync(connector_name="not_there")
+        assert False is True
+    except Exception as e:
+        assert (
+            str(e)
+            == "Couldn't find connector not_there. Did you add it to profiles.yml?"
+        )
+
+    faldbt.fivetran_sync(connector_name="fivetran_connector_1", historical=True)
+    fivetran_client.resync_and_wait.assert_called_with(
+        "id_fivetran_connector_1", interval=10, timeout=None
+    )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -54,18 +54,18 @@ def test_adapter_setup():
         project_dir=project_dir,
     )
 
-    config_list = faldbt._el_configs
-    assert len(config_list) == 2
+    config_dict = faldbt.el.configs
+    keys = list(config_dict.keys())
+    assert len(keys) == 2
+    fivetran_config = config_dict[keys[0]]
 
-    fivetran_config = config_list[0]
-
-    assert fivetran_config["name"] == "my_fivetran_el"
+    assert keys[0] == "my_fivetran_el"
     assert len(fivetran_config["connectors"]) == 2
     assert fivetran_config["connectors"][0]["name"] == "fivetran_connector_1"
 
-    airbyte_config = config_list[1]
+    airbyte_config = config_dict[keys[1]]
 
-    assert airbyte_config["name"] == "my_airbyte_el"
+    assert keys[1] == "my_airbyte_el"
     assert len(airbyte_config["connections"]) == 2
     assert airbyte_config["connections"][0]["name"] == "airbyte_connection_1"
 
@@ -76,7 +76,7 @@ def test_airbyte_sync():
         project_dir=project_dir,
     )
     with patch("fal.el.airbyte.AirbyteClient.sync_and_wait") as mock_sync:
-        faldbt.airbyte_sync(
+        faldbt.el.airbyte_sync(
             config_name="my_airbyte_el", connection_id="id_airbyte_connection_1"
         )
 
@@ -84,14 +84,14 @@ def test_airbyte_sync():
 
         mock_sync.reset_mock()
 
-        faldbt.airbyte_sync(
+        faldbt.el.airbyte_sync(
             config_name="my_airbyte_el", connection_name="airbyte_connection_1"
         )
 
         mock_sync.assert_called_with("id_airbyte_connection_1")
 
         try:
-            faldbt.airbyte_sync(
+            faldbt.el.airbyte_sync(
                 config_name="not_there", connection_name="airbyte_connection_1"
             )
 
@@ -99,7 +99,7 @@ def test_airbyte_sync():
             assert str(e) == "EL configuration not_there is not found."
 
         try:
-            faldbt.airbyte_sync(
+            faldbt.el.airbyte_sync(
                 config_name="my_airbyte_el", connection_name="not_there"
             )
 
@@ -107,7 +107,7 @@ def test_airbyte_sync():
             assert str(e) == "Connection not_there not found."
 
         try:
-            faldbt.airbyte_sync(config_name="my_airbyte_el")
+            faldbt.el.airbyte_sync(config_name="my_airbyte_el")
 
         except Exception as e:
             assert (
@@ -121,22 +121,22 @@ def test_fivetran_sync():
         project_dir=project_dir,
     )
     with patch("fal.el.fivetran.FivetranClient.sync_and_wait") as mock_sync:
-        faldbt.airbyte_sync(
-            config_name="my_fivetran_el", connection_id="id_fivetran_connection_1"
+        faldbt.el.fivetran_sync(
+            config_name="my_fivetran_el", connector_id="id_fivetran_connector_1"
         )
 
-        mock_sync.assert_called_with(connector_id="id_fivetran_connection_1")
+        mock_sync.assert_called_with(connector_id="id_fivetran_connector_1")
 
         mock_sync.reset_mock()
 
-        faldbt.fivetran_sync(
+        faldbt.el.fivetran_sync(
             config_name="my_fivetran_el", connector_name="fivetran_connector_1"
         )
 
         mock_sync.assert_called_with(connector_id="id_fivetran_connector_1")
 
         try:
-            faldbt.fivetran_sync(
+            faldbt.el.fivetran_sync(
                 config_name="not_there", connector_name="fivetran_connector_1"
             )
 
@@ -144,7 +144,7 @@ def test_fivetran_sync():
             assert str(e) == "EL configuration not_there is not found."
 
         try:
-            faldbt.fivetran_sync(
+            faldbt.el.fivetran_sync(
                 config_name="my_fivetran_el", connector_name="not_there"
             )
 
@@ -152,7 +152,7 @@ def test_fivetran_sync():
             assert str(e) == "Connection not_there not found."
 
         try:
-            faldbt.fivetran_sync(config_name="my_fivetran_el")
+            faldbt.el.fivetran_sync(config_name="my_fivetran_el")
 
         except Exception as e:
             assert (


### PR DESCRIPTION
- Magic functions `airbyte_sync` and `fivetran_sync`
- Setting EL client properties in profiles.yml

Users can now define EL client properties in a profile:
```yaml
fal_test:
  target: dev
  fal_extract_load:
    dev:
      - name: 'my_fivetran_el'
        type: fivetran
        api_key: my_fivetran_key
        api_secret: my_fivetran_secret
        connectors:
          - name: fivetran_connector_1
            id: id_fivetran_connector_1
          - name: fivetran_connector_2
            id: id_fivetran_connector_2
      - name: 'my_airbyte_el'
        type: airbyte
        host: http://localhost:8001
        connections:
          - name: airbyte_connection_1
            id: id_airbyte_connection_1
          - name: airbyte_connection_2
            id: id_airbyte_connection_2
  outputs:
    dev:
      type: postgres
      host: localhost
      user: pguser
      password: pass
      port: 5432
      dbname: test
      schema: dbt_fal
      threads: 4
```
`dev` under `fal_extract_load` is a target and fal will use the same target as used in the prior dbt run.

The magic functions work like this:

```python
airbyte_sync(config_name="my_airbyte_el", connection_name="airbyte_connection_1")

fivetran_sync(config_name="my_fivetran_el", connector_name="fivetran_connector_1")
```

Both commands trigger sync jobs and wait for them to finish.