### PR TITLE
Disable dbt file log handler registered in logbook which is triggered from other modules that use logbook

### DIFF
--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -20,6 +20,10 @@ def cli(argv: List[str] = sys.argv):
     exclude_count = argv.count("--exclude")
     script_count = argv.count("--script")
 
+    # Disabling the dbt.logger.DelayedFileHandler manually
+    # since we do not use the new dbt logging system
+    # This fixes issue https://github.com/fal-ai/fal/issues/97
+    log_manager.set_path(None)
     if parsed.disable_logging:
         logger.disable()
     # Re-enable logging for 1.0.0 through old API of logger


### PR DESCRIPTION
I was able to reproduce the issue with @cesar-loadsmart's help. I was seeing the following errors:

```py
Traceback (most recent call last):
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/handlers.py", line 216, in handle
    self.emit(record)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/dbt/logger.py", line 481, in emit
    assert len(self._msg_buffer) < self._bufmax, \
AssertionError: too many messages received before initialization!
```

So I went into dbt's logger.py file and added stack trace printing:

```py
    def emit(self, record: logbook.LogRecord):
        """emit is not thread-safe with set_path, but it is thread-safe with
        itself
        """
        # START: added by me       #########
        traceback.print_stack()
        print(f"XXXX {self.disabled} {self.initialized} {len(self._msg_buffer)} {self._bufmax}")
        # END: added by me         #########
        if self.disabled:
            return
        elif self.initialized:
            super().emit(record)
        else:
            assert self._msg_buffer is not None, \
                '_msg_buffer should never be None if _log_path is set'
            self._msg_buffer.append(record)
            assert len(self._msg_buffer) < self._bufmax, \
                'too many messages received before initialization!'
```

The stack trace then showed something VERY unexpected:

```py
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/bin/fal", line 8, in <module>
    sys.exit(cli())
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/fal/cli/cli.py", line 39, in cli
    fal_run(
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/fal/cli/fal_runner.py", line 71, in fal_run
    run_scripts(scripts, project)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/fal/run_scripts.py", line 76, in run_scripts
    script.exec(context, faldbt)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/fal/fal_script.py", line 30, in exec
    exec(
  File "<string>", line 135, in <module>
  File "<string>", line 132, in execute
  File "<string>", line 97, in write_table
  File "<string>", line 91, in final_dataframe
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/pandas/core/frame.py", line 9025, in append
    warnings.warn(
  File "/Users/matteo/.pyenv/versions/3.9.7/lib/python3.9/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/compat.py", line 288, in showwarning
    logbook.dispatch_record(record)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/base.py", line 1124, in dispatch_record
    _default_dispatcher.call_handlers(record)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/base.py", line 1001, in call_handlers
    if handler.handle(record) and not handler.bubble:
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/handlers.py", line 216, in handle
    self.emit(record)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/dbt/logger.py", line 471, in emit
    traceback.print_stack()
XXXX False False 141 1000
```

Notice that in the middle of the trace, you can see that this log originates from pandas
```py
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/pandas/core/frame.py", line 9025, in append
    warnings.warn(
```

And the way it goes back to dbt is because dbt registers handlers in logbook:
```py
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/logbook/handlers.py", line 216, in handle
    self.emit(record)
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.9/lib/python3.9/site-packages/dbt/logger.py", line 471, in emit
    traceback.print_stack()
```

*****

So this made me go and understand where this `traceback.print_stack()` was placed: it was the `DelayedFileHandler` class. This class has a method to set the directory to write to, in which it states

```py
    def set_path(self, log_dir):
        """log_dir can be the path to a log directory, or `None` to avoid
        writing to a file (for `dbt debug`).
        """
```

And since we are not using the new logging system just yet. So I think a good approach, for now, is to disable it.