### PR TITLE
Add hack to avoid unclosed ssl warning 

### DIFF
--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -40,6 +40,9 @@ def str_param(item: Any, name: str) -> str:
 
 def shutdown():
     posthog.shutdown()
+    # HACK: while https://github.com/PostHog/posthog-python/pull/52 happens
+    from posthog.request import _session as posthog_session
+    posthog_session.close()
 
 
 def opt_str_param(item: Any, name: str) -> Optional[str]:


### PR DESCRIPTION
Hack while in https://github.com/PostHog/posthog-python/pull/52 gets addressed.