### PR TITLE
Better stack trace for errors in user scripts 

### DIFF
--- a/integration_tests/mock/fal_scripts/john_test.py
+++ b/integration_tests/mock/fal_scripts/john_test.py
@@ -1,7 +1,10 @@
 import pandas as pd
+from utils import model_info
+
+info_str = model_info.model_info_str(context.current_model)
 
 df: pd.DataFrame = ref(context.current_model.name)
+print(info_str)
 print(df)
 print(df.dtypes)
-df.to_records()
 write_to_source(df, "results", "john_source")

--- a/integration_tests/mock/fal_scripts/test.py
+++ b/integration_tests/mock/fal_scripts/test.py
@@ -1,13 +1,13 @@
 import pandas as pd
 import io
-import my_util
+from utils.my_util import handle_dbt_test, model_info_str
 
+model_info = model_info_str(context.current_model)
 model_name = context.current_model.name
-
 output = f"Model name: {model_name}"
 
 if context.current_model.status == "tested":
-    my_util.handle_dbt_test(context.current_model.tests, output, model_name)
+    handle_dbt_test(context.current_model.tests, output, model_name)
 
 else:
     output = f"Model name: {model_name}"
@@ -20,11 +20,10 @@ else:
 
     output = output + f"\nModel dataframe information:\n{info}"
 
-    f = open(f"temp/{model_name}", "w")
-    f.write(output)
-    f.close()
+    with open(f"temp/{model_name}", "w") as f:
+        f.write(output)
 
-    # Pass information to outside of this script
+    # TODO: Pass information to outside of this script
     RESULT = df.size
 
-print(f"Test done for {model_name}")
+print(f"Script test.py done for {model_info}")

--- a/integration_tests/mock/fal_scripts/utils/model_info.py
+++ b/integration_tests/mock/fal_scripts/utils/model_info.py
@@ -1,0 +1,6 @@
+def model_info_str(model):
+    output = f"{model.__class__.__name__}("
+    output += f"name='{model.name}',"
+    output += f"status={model.status}"
+    output += ")"
+    return output

--- a/integration_tests/mock/fal_scripts/utils/my_util.py
+++ b/integration_tests/mock/fal_scripts/utils/my_util.py
@@ -1,3 +1,6 @@
+from .model_info import model_info_str
+
+
 def handle_dbt_test(tests, output, model_name):
     for test in tests:
         output += f"\nRan {test.name} for {test.column}, result: {test.status}"

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -23,12 +23,18 @@ class FalScript:
 
         # Enable local imports
         local_path = str(self.path.parent)
-        sys.path.append(local_path)
+        try:
+            # NOTE: since this happens in threads, the `local_path` available
+            # in `sys.path` for all scripts running at the same time.
+            # This may introduce undesired race conditions for users.
+            # We probably want to pass the `sys.path` of each separately
+            sys.path.append(local_path)
 
-        with open(self.path) as file:
-            a_script = file.read()
+            with open(self.path) as file:
+                source_code = compile(file.read(), self.path, "exec")
+
             exec(
-                a_script,
+                source_code,
                 {
                     "context": context,
                     "ref": faldbt.ref,
@@ -42,4 +48,5 @@ class FalScript:
                     "el": faldbt.el,
                 },
             )
+        finally:
             sys.path.remove(local_path)

--- a/src/fal/run_scripts.py
+++ b/src/fal/run_scripts.py
@@ -1,10 +1,10 @@
 """Run fal scripts."""
-from multiprocessing.pool import Pool
 import os
 from typing import Dict, Any, List, Union
 from dataclasses import dataclass
 from pathlib import Path
 
+from multiprocessing.pool import Pool
 from multiprocessing.dummy import Pool as ThreadPool
 
 from dbt.contracts.results import RunStatus
@@ -66,13 +66,12 @@ def _prepare_exec_script(script: FalScript, project: FalProject) -> bool:
 
     try:
         script.exec(context, faldbt)
-    except Exception as err:
-        err_str = str.join("\n", traceback.format_exception(err.__class__, err, None))
+    except:
         logger.error(
             "Error in script {} with model {}:\n{}",
             script.path,
             _get_script_model(script),
-            err_str,
+            traceback.format_exc(),
         )
         # TODO: what else to do?
         success = False


### PR DESCRIPTION
Now it looks like:
```
Error in script /Users/matteo/Projects/fal/fal/integration_tests/mock/fal_scripts/test.py with model zendesk_ticket_data:
Traceback (most recent call last):
  File "/Users/matteo/Projects/fal/fal/src/fal/run_scripts.py", line 68, in _prepare_exec_script
    script.exec(context, faldbt)
  File "/Users/matteo/Projects/fal/fal/src/fal/fal_script.py", line 36, in exec
    exec(
  File "/Users/matteo/Projects/fal/fal/integration_tests/mock/fal_scripts/test.py", line 5, in <module>
    model_info = model_info_str(context.current_model)
  File "/Users/matteo/Projects/fal/fal/integration_tests/mock/fal_scripts/utils/model_info.py", line 6, in model_info_str
    return outputs
NameError: name 'outputs' is not defined
```

Notice the file is accurate, vs `<string>` before.