### PR TITLE
Handle exceptions better in telemetry

### DIFF
--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -10,8 +10,10 @@ from fal.telemetry import telemetry
 
 def cli(argv: List[str] = sys.argv):
     # Wrapper to be able to shutdown telemetry afterwards
-    _cli(argv)
-    telemetry.shutdown()
+    try:
+        _cli(argv)
+    finally:
+        telemetry.shutdown()
 
 
 @telemetry.log_call("cli")

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -316,11 +316,11 @@ def log_call(action):
                     total_runtime=str(datetime.datetime.now() - start),
                     additional_props={
                         # can we log None to posthog?
-                        "exception": type(e),
+                        "exception": str(type(e)),
                         "argv": sys.argv,
                     },
                 )
-                raise e
+                raise
             else:
                 log_api(
                     action=f"{action}_success",

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -283,7 +283,7 @@ def test_log_call_exception(mock_telemetry):
                 action="some_action_error",
                 total_runtime="1",
                 additional_props={
-                    "exception": type(ValueError()),
+                    "exception": str(type(ValueError())),
                     "argv": sys.argv,
                 },
             ),


### PR DESCRIPTION
I was getting errors when sending the information like
```
Dictionary values must be serializeable to JSON "exception" value <class 'RuntimeError'> of type <class 'type'> is unsupported.
```
