### PR TITLE
Remove ref to non-yet-existent relation in integration test

### DIFF
--- a/integration_tests/projects/002_jaffle_shop/load_data.py
+++ b/integration_tests/projects/002_jaffle_shop/load_data.py
@@ -8,12 +8,6 @@ model_name = context.current_model.name
 output = f"Model name: {model_name}"
 output = output + f"\nStatus: {context.current_model.status}"
 
-df: pd.DataFrame = ref(model_name)
-buf = io.StringIO()
-df.info(buf=buf, memory_usage=False)
-info = buf.getvalue()
-
-output = output + f"\nModel dataframe information:\n{info}"
 temp_dir = os.environ["temp_dir"]
 write_dir = open(reduce(os.path.join, [temp_dir, model_name + ".load_data.py"]), "w")
 write_dir.write(output)


### PR DESCRIPTION
This test was doing a `ref(context.current_model.name)` in a `before` script. For clean environments (GitHub actions), there was no data yet. 

This exposes a possible problem for other tests that we clean the directories but do not truncate the whole database between tests. I will look into that.