### PR TITLE
Add vars flag for fal flow run and pass to dbt 

### DIFF
--- a/integration_tests/features/environment.py
+++ b/integration_tests/features/environment.py
@@ -8,6 +8,15 @@ def before_all(context):
 def after_scenario(context, scenario):
     if hasattr(context, "temp_dir"):
         context.temp_dir.cleanup()
+
     if hasattr(context, "added_during_tests"):
         for file in context.added_during_tests:
+
             os.remove(file)
+        delattr(context, "added_during_tests")
+
+    if hasattr(context, "exc") and context.exc:
+        from traceback import print_exception
+
+        print_exception(*context.exc)
+        delattr(context, "exc")

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -123,7 +123,7 @@ Feature: `flow run` command
 
     When the following command is invoked:
       """
-      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data --threads 1
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data+ --threads 1
       """
     Then the following models are calculated:
       | zendesk_ticket_data |
@@ -132,7 +132,7 @@ Feature: `flow run` command
 
     When the following command is invoked:
       """
-      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data --vars '{extra_col: true}' --threads 1
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data+ --vars 'extra_col: true' --threads 1
       """
     Then the following models are calculated:
       | zendesk_ticket_data |

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -137,4 +137,4 @@ Feature: `flow run` command
     Then the following models are calculated:
       | zendesk_ticket_data |
     And the script zendesk_ticket_data.check_extra.py output file has the lines:
-      | extra_col: 'yes' |
+      | extra_col: yes |

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -26,8 +26,8 @@ Feature: `flow run` command
   Scenario: fal flow run command with selectors
     Given the project 001_flow_run_with_selectors
     When the data is seeded
-    And the file $baseDir/models/new_model.sql is created with the content: 
-      """ 
+    And the file $baseDir/models/new_model.sql is created with the content:
+      """
       select * 1
       """
     When the following command is invoked:
@@ -43,8 +43,8 @@ Feature: `flow run` command
       """
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --threads 1
       """
-    And the file $baseDir/models/new_model.sql is created with the content: 
-      """ 
+    And the file $baseDir/models/new_model.sql is created with the content:
+      """
       select 1
       """
     Then the following command will fail:
@@ -52,7 +52,7 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select state:new --threads 1
       """
     And no models are calculated
-  
+
   Scenario: fal flow run command with state selector and with state
     Given the project 001_flow_run_with_selectors
     When the following command is invoked:
@@ -60,8 +60,8 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --threads 1
       """
     And state is stored in old_state
-    And the file $baseDir/models/new_model.sql is created with the content: 
-      """ 
+    And the file $baseDir/models/new_model.sql is created with the content:
+      """
       select 1
       """
     And the following command is invoked:
@@ -69,7 +69,7 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select state:new --state $tempDir/old_state --threads 1
       """
     Then the following models are calculated:
-    | new_model |
+      | new_model |
 
   Scenario: fal flow run with an error in before
     Given the project 003_scripts_with_errors
@@ -103,7 +103,7 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select tag:daily
       """
     Then the following models are calculated:
-    | agent_wait_time |
+      | agent_wait_time |
 
   Scenario: fal flow run command with complex selectors and children
     Given the project 001_flow_run_with_selectors
@@ -113,6 +113,28 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select tag:daily+
       """
     Then the following models are calculated:
-    | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 |
+      | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 |
     And the following scripts are ran:
-    | agent_wait_time.after.py |
+      | agent_wait_time.after.py |
+
+  Scenario: fal flow run command with vars
+    Given the project 001_flow_run_with_selectors
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data --threads 1
+      """
+    Then the following models are calculated:
+      | zendesk_ticket_data |
+    And the script zendesk_ticket_data.check_extra.py output file has the lines:
+      | no extra_col |
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select zendesk_ticket_data --vars '{extra_col: true}' --threads 1
+      """
+    Then the following models are calculated:
+      | zendesk_ticket_data |
+    And the script zendesk_ticket_data.check_extra.py output file has the lines:
+      | extra_col: 'yes' |

--- a/integration_tests/features/steps/fal_steps.py
+++ b/integration_tests/features/steps/fal_steps.py
@@ -72,14 +72,19 @@ def invoke_command(context):
     context.exc = None
     try:
         cli(shlex.split(args))
-    except Exception as e:
-        context.exc = e
+    except Exception:
+        import sys
+
+        context.exc = sys.exc_info()
 
 
-@then("it throws an {type} exception with message '{msg}'")
-def invoke_command_error(context, type, msg):
-    assert isinstance(context.exc, eval(type)), "Invalid exception - expected " + type
-    assert msg in str(context.exc), "Invalid message - expected " + msg
+@then("it throws an {etype} exception with message '{msg}'")
+def invoke_command_error(context, etype: str, msg: str):
+    _etype, value, _tb = context.exc
+    assert isinstance(
+        value, eval(etype)
+    ), f"Invalid exception - expected {type}, got {type(value)}"
+    assert msg in str(value), "Invalid message - expected " + msg
 
 
 @then("the following command will fail")

--- a/integration_tests/features/steps/fal_steps.py
+++ b/integration_tests/features/steps/fal_steps.py
@@ -63,13 +63,15 @@ def add_model(context, file):
 @when("the following command is invoked")
 def invoke_command(context):
     profiles_dir = _set_profiles_dir(context)
-    args = context.text.replace("$baseDir", context.base_dir)
+    args: str = context.text.replace("$baseDir", context.base_dir)
     args = args.replace("$profilesDir", str(profiles_dir))
     args = args.replace("$tempDir", str(context.temp_dir.name))
 
+    import shlex
+
     context.exc = None
     try:
-        cli(args.split(" "))
+        cli(shlex.split(args))
     except Exception as e:
         context.exc = e
 

--- a/integration_tests/projects/001_flow_run_with_selectors/fal_scripts/check_extra.py
+++ b/integration_tests/projects/001_flow_run_with_selectors/fal_scripts/check_extra.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+import os
+from functools import reduce
+
+model_name = context.current_model.name
+df: pd.DataFrame = ref(model_name)
+
+if hasattr(df, "extra_col"):
+    output = "extra_col: " + df.extra_col
+else:
+    output = "no extra_col"
+
+temp_dir = os.environ["temp_dir"]
+write_dir = open(reduce(os.path.join, [temp_dir, model_name + ".check_extra.txt"]), "w")
+write_dir.write(output)
+write_dir.close()

--- a/integration_tests/projects/001_flow_run_with_selectors/fal_scripts/check_extra.py
+++ b/integration_tests/projects/001_flow_run_with_selectors/fal_scripts/check_extra.py
@@ -7,9 +7,9 @@ model_name = context.current_model.name
 df: pd.DataFrame = ref(model_name)
 
 if hasattr(df, "extra_col"):
-    output = "extra_col: " + df.extra_col
+    output = f"extra_col: {df.extra_col[0]}\n"
 else:
-    output = "no extra_col"
+    output = "no extra_col\n"
 
 temp_dir = os.environ["temp_dir"]
 write_dir = open(reduce(os.path.join, [temp_dir, model_name + ".check_extra.txt"]), "w")

--- a/integration_tests/projects/001_flow_run_with_selectors/models/schema.yml
+++ b/integration_tests/projects/001_flow_run_with_selectors/models/schema.yml
@@ -8,6 +8,12 @@ sources:
       - name: john_source
 
 models:
+  - name: zendesk_ticket_data
+    meta:
+      fal:
+        scripts:
+          after:
+            - fal_scripts/check_extra.py
   - name: agent_wait_time
     description: Agent wait time series
     config:

--- a/integration_tests/projects/001_flow_run_with_selectors/models/zendesk_ticket_data.sql
+++ b/integration_tests/projects/001_flow_run_with_selectors/models/zendesk_ticket_data.sql
@@ -2,7 +2,11 @@
 
 with source_data as (
 
-    select id,_fivetran_synced,allow_channelback,assignee_id,brand_id from {{ ref('raw_zendesk_ticket_data') }}
+    select id,_fivetran_synced,allow_channelback,assignee_id,brand_id
+    {% if env_var('extra_col', False) %}
+        , 'yes' as extra_col
+    {% endif %}
+    from {{ ref('raw_zendesk_ticket_data') }}
 )
 
 select *

--- a/integration_tests/projects/001_flow_run_with_selectors/models/zendesk_ticket_data.sql
+++ b/integration_tests/projects/001_flow_run_with_selectors/models/zendesk_ticket_data.sql
@@ -3,7 +3,7 @@
 with source_data as (
 
     select id,_fivetran_synced,allow_channelback,assignee_id,brand_id
-    {% if env_var('extra_col', False) %}
+    {% if var('extra_col', False) %}
         , 'yes' as extra_col
     {% endif %}
     from {{ ref('raw_zendesk_ticket_data') }}

--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -93,8 +93,27 @@ def _add_state_option(parser: argparse.ArgumentParser):
     parser.add_argument("--state", type=str, help="Specify dbt state artifact path")
 
 
+def _add_vars_option(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--vars",
+        type=str,
+        default="{}",
+        help="""
+        Supply variables to the project. This argument overrides variables
+        defined in your dbt_project.yml file. This argument should be a YAML
+        string, eg. '{my_variable: my_value}'
+        """,
+    )
+
+
 def _add_experimental_flow_option(parser: argparse.ArgumentParser):
-    parser.add_argument("--experimental-flow", action="store_true")
+    parser.add_argument(
+        "--experimental-flow",
+        action="store_true",
+        help="""
+        Run fal after scripts right after a dbt node has finished to before continuing with downstream nodes.
+        """,
+    )
 
 
 def _build_dbt_selectors(sub: argparse.ArgumentParser, extend: bool):
@@ -178,6 +197,7 @@ def _build_flow_parser(sub: argparse.ArgumentParser):
     _add_threads_option(flow_run_parser)
     _add_state_option(flow_run_parser)
     _add_experimental_flow_option(flow_run_parser)
+    _add_vars_option(flow_run_parser)
 
 
 def _build_cli_parser():

--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -26,9 +26,10 @@ def _cli(argv: List[str]):
         + argv.count("--select")
         + argv.count("-m")
         + argv.count("--models")
+        + argv.count("--model")
     )
     exclude_count = argv.count("--exclude")
-    script_count = argv.count("--script")
+    script_count = argv.count("--script") + argv.count("--scripts")
 
     # Disabling the dbt.logger.DelayedFileHandler manually
     # since we do not use the new dbt logging system

--- a/src/fal/cli/dbt_runner.py
+++ b/src/fal/cli/dbt_runner.py
@@ -70,7 +70,7 @@ def get_dbt_command_list(args: argparse.Namespace, models_list: List[str]) -> Li
     if args.state:
         command_list += ["--state", args.state]
 
-    if args.vars:
+    if args.vars is not None and args.vars != "{}":
         command_list += ["--vars", args.vars]
 
     if len(models_list) > 0:

--- a/src/fal/cli/dbt_runner.py
+++ b/src/fal/cli/dbt_runner.py
@@ -70,6 +70,9 @@ def get_dbt_command_list(args: argparse.Namespace, models_list: List[str]) -> Li
     if args.state:
         command_list += ["--state", args.state]
 
+    if args.vars:
+        command_list += ["--vars", args.vars]
+
     if len(models_list) > 0:
         if lib.DBT_VCURRENT.compare(lib.DBT_V1) < 0:
             command_list += ["--models"] + models_list

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -392,6 +392,8 @@ def _clean_args_list(args: List[str]) -> List[str]:
         "--version",
         "--debug",
         "flow",
+        "--vars",
+        "--var",
     ]
     REDACTED = "[REDACTED]"
     output = []

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -60,6 +60,7 @@ def get_scripts_dir(project_dir: str) -> str:
         return project_dir
 
     yml = load_yaml(path)
+    # TODO: consider `vars` flag
     scripts_dir = yml.get("vars", {}).get(FAL_SCRIPTS_PATH, project_dir)
 
     if not isinstance(scripts_dir, str):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,28 @@ def test_flow_run_with_defer(capfd):
         assert len(found) == 1
 
 
+def test_flow_run_with_vars(capfd):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+        captured = _run_fal(
+            [
+                # fmt: off
+                "flow", "run",
+                "--project-dir", tmp_dir,
+                "--profiles-dir", profiles_dir,
+                "--vars", "{some: 'value'}"
+                # fmt: on
+            ],
+            capfd,
+        )
+
+        executing_re = re.compile(
+            r"Executing command: dbt --log-format json run --project-dir [\w\/\-\_]+ --profiles-dir [\w\/\-\_]+tests/mock/mockProfile --vars {some: 'value'}"
+        )
+        found = executing_re.findall(captured.out)
+        assert len(found) == 1
+
+
 def test_selection(capfd):
     with tempfile.TemporaryDirectory() as tmp_dir:
         shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -347,6 +347,8 @@ def test_redaction():
                     "some_script",
                     "--before",
                     "--debug",
+                    "--vars",
+                    "{env: 'some'}",
                 ]
             },
         )
@@ -400,6 +402,8 @@ def test_redaction():
                     "[REDACTED]",
                     "--before",
                     "--debug",
+                    "--vars",
+                    "[REDACTED]",
                 ],
             },
         )


### PR DESCRIPTION
Maybe we should set environment variables in the scripts when running. But if we do that, we should read `dbt_project.yml#vars` too.

closes #253 