### PR TITLE
Add --target arg to `fal run` and `fal flow run`

### DIFF
--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -178,3 +178,20 @@ Feature: `flow run` command
       | agent_wait_time.after.py |
     And the following scripts are ran:
       | agent_wait_time.before.py |
+
+Scenario: fal flow run with target
+  Given the project 001_flow_run_with_selectors
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir profiles/broken --project-dir $baseDir --select zendesk_ticket_data+ --threads 1
+      """
+    Then it throws an RuntimeError exception with message 'Error running dbt run'
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir profiles/broken --project-dir $baseDir --select zendesk_ticket_data+ --threads 1 --target custom
+      """
+    Then the following models are calculated:
+      | zendesk_ticket_data |

--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -89,6 +89,15 @@ def _add_threads_option(parser: argparse.ArgumentParser):
     )
 
 
+def _add_target_option(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--target",
+        type=str,
+        default=None,
+        help="Specify a custom target from profiles.yml",
+    )
+
+
 def _add_state_option(parser: argparse.ArgumentParser):
     parser.add_argument("--state", type=str, help="Specify dbt state artifact path")
 
@@ -155,6 +164,7 @@ def _build_run_parser(sub: argparse.ArgumentParser):
     _build_dbt_common_options(sub)
     _build_fal_common_options(sub)
     _add_threads_option(sub)
+    _add_target_option(sub)
 
     sub.add_argument(
         "--all",
@@ -166,12 +176,6 @@ def _build_run_parser(sub: argparse.ArgumentParser):
         nargs="+",
         action="extend", # For backwards compatibility with past fal version
         help="Specify scripts to run, overrides schema.yml",
-    )
-
-    sub.add_argument(
-        "--target",
-        type=str,
-        help="Specify a custom target from profiles.yml",
     )
 
     sub.add_argument(
@@ -204,6 +208,7 @@ def _build_flow_parser(sub: argparse.ArgumentParser):
     _add_state_option(flow_run_parser)
     _add_experimental_flow_option(flow_run_parser)
     _add_vars_option(flow_run_parser)
+    _add_target_option(flow_run_parser)
 
 
 def _build_cli_parser():

--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -169,6 +169,12 @@ def _build_run_parser(sub: argparse.ArgumentParser):
     )
 
     sub.add_argument(
+        "--target",
+        type=str,
+        help="Specify a custom target from profiles.yml",
+    )
+
+    sub.add_argument(
         "--before",
         action="store_true",
         help="Run scripts specified in model `before` tag",

--- a/src/fal/cli/dbt_runner.py
+++ b/src/fal/cli/dbt_runner.py
@@ -70,6 +70,9 @@ def get_dbt_command_list(args: argparse.Namespace, models_list: List[str]) -> Li
     if args.state:
         command_list += ["--state", args.state]
 
+    if args.target:
+        command_list += ["--target", args.target]
+
     if args.vars is not None and args.vars != "{}":
         command_list += ["--vars", args.vars]
 

--- a/src/fal/cli/fal_runner.py
+++ b/src/fal/cli/fal_runner.py
@@ -37,6 +37,7 @@ def create_fal_dbt(args: argparse.Namespace):
         args.keyword,
         args.threads,
         real_state,
+        args.target,
     )
 
 

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -394,6 +394,7 @@ def _clean_args_list(args: List[str]) -> List[str]:
         "flow",
         "--vars",
         "--var",
+        "--target",
     ]
     REDACTED = "[REDACTED]"
     output = []

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -208,13 +208,14 @@ class FalDbt:
         keyword: str = "fal",
         threads: Optional[int] = None,
         state: Optional[Path] = None,
+        profile_target: Optional[str] = None,
     ):
         self.project_dir = project_dir
         self.profiles_dir = profiles_dir
         self.keyword = keyword
         self._firestore_client = None
         self._state = state
-        self._profile_target = None
+        self._profile_target = profile_target
 
         self.scripts_dir = parse.get_scripts_dir(project_dir)
 
@@ -230,7 +231,8 @@ class FalDbt:
 
         if self._run_results.nativeRunResult:
             self.method = self._run_results.nativeRunResult.args["rpc_method"]
-            self._profile_target = _get_custom_target(self._run_results)
+            if self._profile_target is None:
+                self._profile_target = _get_custom_target(self._run_results)
 
         if self._profile_target is not None:
             self._config = parse.get_dbt_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -303,6 +303,28 @@ def test_flag_level(capfd):
         assert "model_with_scripts" in captured.out
 
 
+def test_target(capfd):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+
+        captured = _run_fal(
+            [
+                "run",
+                "--project-dir",
+                tmp_dir,
+                "--profiles-dir",
+                profiles_dir,
+                "--target",
+                "false_target",
+            ],
+            capfd,
+        )
+        assert (
+            "The profile 'fal_test' does not have a target named 'false_target'"
+            in captured.out
+        )
+
+
 def _run_fal(args, capfd):
     # Given fal arguments, runs fal and returns capfd output
     try:


### PR DESCRIPTION
You can now run:

```
fal flow run --target my_custom_target
```
and
```
fal run --target my_custom_target
```

In `fal run` the `--target` argument will take precedent over the target specified in run_results.json.