### PR TITLE
Swap ref and write_to_model package and model arguments

### DIFF
--- a/integration_tests/projects/005_functions_and_variables/fal_scripts/complete_other_model.py
+++ b/integration_tests/projects/005_functions_and_variables/fal_scripts/complete_other_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from functools import reduce
+from sqlalchemy import Integer
 import os
 
 model_name = context.current_model.name
@@ -11,7 +12,9 @@ df: pd.DataFrame = ref(model_name)
 output += f"my_float {df.my_float[0]}\n"
 
 df.my_float = 2.3
-write_to_model(df, mode="overwrite")
+write_to_model(df, mode="append")
+write_to_model(df, dtype={"my_float": Integer})
+write_to_model(df)  # default: overwrite
 
 df: pd.DataFrame = ref(model_name)
 output += f"my_float {df.my_float[0]}\n"

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -94,10 +94,11 @@ class FalScript:
 
             if self.model is not None:
                 # Hard-wire the model
+                def write_to_model(tg1, tg2, data, /, **kwargs):
+                    return faldbt.write_to_model(data, tg1, tg2, **kwargs)
+
                 exec_globals["write_to_model"] = partial(
-                    faldbt.write_to_model,
-                    target_model_name=self.model.name,
-                    target_package_name=None,
+                    write_to_model, self.model.name, None
                 )
 
             exec(source_code, exec_globals)

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -501,7 +501,6 @@ class FalDbt:
             target_package_name = target_1
             target_model_name = target_2
 
-
         target_model = self._model(target_model_name, target_package_name)
 
         if mode.lower().strip() == WriteToSourceModeEnum.APPEND.value:

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -382,12 +382,15 @@ class FalDbt:
         return target_model
 
     @telemetry.log_call("ref")
-    def ref(
-        self, target_model_name: str, target_package_name: Optional[str] = None
-    ) -> pd.DataFrame:
+    def ref(self, target_1: str, target_2: Optional[str] = None, /) -> pd.DataFrame:
         """
         Download a dbt model as a pandas.DataFrame automagically.
         """
+        target_model_name = target_1
+        target_package_name = None
+        if target_2 is not None:
+            target_package_name = target_1
+            target_model_name = target_2
 
         target_model = self._model(target_model_name, target_package_name)
 
@@ -482,8 +485,9 @@ class FalDbt:
     def write_to_model(
         self,
         data: pd.DataFrame,
-        target_model_name: str,
-        target_package_name: Optional[str] = None,
+        target_1: str,
+        target_2: Optional[str] = None,
+        /,
         *,
         dtype: Any = None,
         mode: Literal["append", "overwrite"] = WriteToSourceModeEnum.OVERWRITE.value,
@@ -491,6 +495,12 @@ class FalDbt:
         """
         Write a pandas.DataFrame to a dbt source automagically.
         """
+        target_model_name = target_1
+        target_package_name = None
+        if target_2 is not None:
+            target_package_name = target_1
+            target_model_name = target_2
+
 
         target_model = self._model(target_model_name, target_package_name)
 


### PR DESCRIPTION
We used to accept `ref('model', 'package')`, it should match dbt `ref('package', 'model')`