### PR TITLE
Remove support passing --select/--script/--exclude flags multiple times

### DIFF
--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -125,21 +125,18 @@ def _add_experimental_flow_option(parser: argparse.ArgumentParser):
     )
 
 
-def _build_dbt_selectors(sub: argparse.ArgumentParser, extend: bool):
+def _build_dbt_selectors(sub: argparse.ArgumentParser):
 
     # fmt: off
-    # TODO: remove `action="extend"` to match exactly what dbt does
     sub.add_argument(
         "-s", "--select",
         nargs="+",
-        action="extend" if extend else None, # For backwards compatibility with past fal version
         dest="select",
         help="Specify the nodes to include.",
     )
     sub.add_argument(
         "-m", "--models",
         nargs="+",
-        action="extend" if extend else None, # For backwards compatibility with past fal version
         dest="select",
         help="Specify the nodes to include.",
     )
@@ -150,7 +147,6 @@ def _build_dbt_selectors(sub: argparse.ArgumentParser, extend: bool):
     sub.add_argument(
         "--exclude",
         nargs="+",
-        action="extend" if extend else None, # For backwards compatibility with past fal version
         help="Specify the nodes to exclude.",
     )
     # fmt: on
@@ -159,8 +155,7 @@ def _build_dbt_selectors(sub: argparse.ArgumentParser, extend: bool):
 def _build_run_parser(sub: argparse.ArgumentParser):
 
     # fmt: off
-    # TODO: remove `action="extend"` to match exactly what dbt does
-    _build_dbt_selectors(sub, extend=True)
+    _build_dbt_selectors(sub)
     _build_dbt_common_options(sub)
     _build_fal_common_options(sub)
     _add_threads_option(sub)
@@ -174,7 +169,6 @@ def _build_run_parser(sub: argparse.ArgumentParser):
     sub.add_argument(
         "--scripts",
         nargs="+",
-        action="extend", # For backwards compatibility with past fal version
         help="Specify scripts to run, overrides schema.yml",
     )
 
@@ -201,7 +195,7 @@ def _build_flow_parser(sub: argparse.ArgumentParser):
         name="run",
         help="Execute fal and dbt run in correct order",
     )
-    _build_dbt_selectors(flow_run_parser, extend=False)
+    _build_dbt_selectors(flow_run_parser)
     _build_dbt_common_options(flow_run_parser)
     _build_fal_common_options(flow_run_parser)
     _add_threads_option(flow_run_parser)

--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -1,11 +1,15 @@
 from typing import List
 import sys
-from dbt.logger import log_manager, GLOBAL_LOGGER as logger
+
 from fal.cli.flow_runner import fal_flow_run
 from faldbt.lib import DBT_VCURRENT, DBT_V1
 from .args import parse_args
 from .fal_runner import fal_run
 from fal.telemetry import telemetry
+
+import dbt.exceptions
+import dbt.ui
+from dbt.logger import log_manager, GLOBAL_LOGGER as logger
 
 
 def cli(argv: List[str] = sys.argv):
@@ -20,16 +24,8 @@ def cli(argv: List[str] = sys.argv):
 def _cli(argv: List[str]):
     parsed = parse_args(argv[1:])
 
-    # TODO: remove `action="extend"` to match exactly what dbt does
-    selects_count = (
-        argv.count("-s")
-        + argv.count("--select")
-        + argv.count("-m")
-        + argv.count("--models")
-        + argv.count("--model")
-    )
-    exclude_count = argv.count("--exclude")
-    script_count = argv.count("--script") + argv.count("--scripts")
+    # TODO: remove in fal version 0.4.0
+    _warn_selectors_multiple_times(argv, parsed)
 
     # Disabling the dbt.logger.DelayedFileHandler manually
     # since we do not use the new dbt logging system
@@ -51,9 +47,41 @@ def _cli(argv: List[str]):
                 fal_flow_run(parsed)
 
         elif parsed.command == "run":
-            fal_run(
-                parsed,
-                selects_count=selects_count,
-                exclude_count=exclude_count,
-                script_count=script_count,
-            )
+            fal_run(parsed)
+
+
+# TODO: remove in fal version 0.4.0
+def _warn_selectors_multiple_times(argv, parsed):
+    """
+    Warn about past behaviour of flags no longer supported
+    """
+    selects_count = (
+        argv.count("-s")
+        + argv.count("--select")
+        + argv.count("-m")
+        + argv.count("--models")
+        + argv.count("--model")
+    )
+
+    if selects_count > 1:
+        dbt.exceptions.warn_or_error(
+            "Passing multiple --select/--models flags to fal is deprecated and will be removed in fal version 0.4.\n"
+            + f"Please use model selection like dbt. Use: --select {' '.join(parsed.select)}",
+            log_fmt=dbt.ui.warning_tag("{}"),
+        )
+
+    exclude_count = argv.count("--exclude")
+    if exclude_count > 1:
+        dbt.exceptions.warn_or_error(
+            "Passing multiple --exclude flags to fal is deprecated and will be removed in fal version 0.4.\n"
+            + f"Please use model exclusion like dbt. Use: --exclude {' '.join(parsed.exclude)}",
+            log_fmt=dbt.ui.warning_tag("{}"),
+        )
+
+    script_count = argv.count("--script") + argv.count("--scripts")
+    if script_count > 1:
+        dbt.exceptions.warn_or_error(
+            "Passing multiple --script flags to fal is deprecated and will be removed in fal version 0.4.\n"
+            + f"Please use: --script {' '.join(parsed.scripts)}",
+            log_fmt=dbt.ui.warning_tag("{}"),
+        )

--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -24,9 +24,6 @@ def cli(argv: List[str] = sys.argv):
 def _cli(argv: List[str]):
     parsed = parse_args(argv[1:])
 
-    # TODO: remove in fal version 0.4.0
-    _warn_selectors_multiple_times(argv, parsed)
-
     # Disabling the dbt.logger.DelayedFileHandler manually
     # since we do not use the new dbt logging system
     # This fixes issue https://github.com/fal-ai/fal/issues/97
@@ -47,6 +44,9 @@ def _cli(argv: List[str]):
                 fal_flow_run(parsed)
 
         elif parsed.command == "run":
+            # TODO: remove in fal version 0.4.0
+            _warn_selectors_multiple_times(argv, parsed)
+
             fal_run(parsed)
 
 
@@ -65,7 +65,7 @@ def _warn_selectors_multiple_times(argv, parsed):
 
     if selects_count > 1:
         dbt.exceptions.warn_or_error(
-            "Passing multiple --select/--models flags to fal is deprecated and will be removed in fal version 0.4.\n"
+            "Passing multiple --select/--models flags to fal is no longer supported.\n"
             + f"Please use model selection like dbt. Use: --select {' '.join(parsed.select)}",
             log_fmt=dbt.ui.warning_tag("{}"),
         )
@@ -73,7 +73,7 @@ def _warn_selectors_multiple_times(argv, parsed):
     exclude_count = argv.count("--exclude")
     if exclude_count > 1:
         dbt.exceptions.warn_or_error(
-            "Passing multiple --exclude flags to fal is deprecated and will be removed in fal version 0.4.\n"
+            "Passing multiple --exclude flags to fal is no longer supported.\n"
             + f"Please use model exclusion like dbt. Use: --exclude {' '.join(parsed.exclude)}",
             log_fmt=dbt.ui.warning_tag("{}"),
         )
@@ -81,7 +81,7 @@ def _warn_selectors_multiple_times(argv, parsed):
     script_count = argv.count("--script") + argv.count("--scripts")
     if script_count > 1:
         dbt.exceptions.warn_or_error(
-            "Passing multiple --script flags to fal is deprecated and will be removed in fal version 0.4.\n"
-            + f"Please use: --script {' '.join(parsed.scripts)}",
+            "Passing multiple --script flags to fal is no longer supported.\n"
+            + f"Please dbt-style selection. Use: --script {' '.join(parsed.scripts)}",
             log_fmt=dbt.ui.warning_tag("{}"),
         )

--- a/src/fal/cli/fal_runner.py
+++ b/src/fal/cli/fal_runner.py
@@ -3,8 +3,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 import os
 
-import dbt.exceptions
-import dbt.ui
 from dbt.config.profile import DEFAULT_PROFILES_DIR
 
 from fal.run_scripts import raise_for_run_results_failures, run_scripts
@@ -41,12 +39,7 @@ def create_fal_dbt(args: argparse.Namespace):
     )
 
 
-def fal_run(
-    args: argparse.Namespace,
-    selects_count=0,  # TODO: remove `action="extend"` to match exactly what dbt does
-    exclude_count=0,
-    script_count=0,
-):
+def fal_run(args: argparse.Namespace):
     "Runs the fal run command in a subprocess"
 
     selector_flags = args.select or args.exclude or args.selector
@@ -57,8 +50,6 @@ def fal_run(
 
     faldbt = create_fal_dbt(args)
     models = _get_filtered_models(faldbt, args.all, selector_flags, args.before)
-
-    _handle_selector_warnings(selects_count, exclude_count, script_count, args)
 
     scripts = _select_scripts(args, models, faldbt)
 
@@ -77,28 +68,6 @@ def fal_run(
         if not _scripts_flag(args):
             # run globals when no --script is passed
             _run_global_scripts(faldbt, args.before)
-
-
-def _handle_selector_warnings(selects_count, exclude_count, script_count, args):
-    # TODO: remove `action="extend"` to match exactly what dbt does
-    if selects_count > 1:
-        dbt.exceptions.warn_or_error(
-            "Passing multiple --select/--models flags to fal is deprecated and will be removed in fal version 0.4.\n"
-            + f"Please use model selection like dbt. Use: --select {' '.join(args.select)}",
-            log_fmt=dbt.ui.warning_tag("{}"),
-        )
-    if exclude_count > 1:
-        dbt.exceptions.warn_or_error(
-            "Passing multiple --select/--models flags to fal is deprecated and will be removed in fal version 0.4.\n"
-            + f"Please use model exclusion like dbt. Use: --exclude {' '.join(args.exclude)}",
-            log_fmt=dbt.ui.warning_tag("{}"),
-        )
-    if script_count > 1:
-        dbt.exceptions.warn_or_error(
-            "Passing multiple --select/--models flags to fal is deprecated and will be removed in fal version 0.4.\n"
-            + f"Please use: --script {' '.join(args.scripts)}",
-            log_fmt=dbt.ui.warning_tag("{}"),
-        )
 
 
 def _scripts_flag(args: argparse.Namespace) -> bool:

--- a/tests/mock/models/other_with_scripts.sql
+++ b/tests/mock/models/other_with_scripts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+SELECT 1 AS a

--- a/tests/mock/models/schema.yml
+++ b/tests/mock/models/schema.yml
@@ -15,6 +15,12 @@ models:
         scripts:
           - fal_scripts/test.py
 
+  - name: other_with_scripts
+    meta:
+      fal:
+        scripts:
+          - fal_scripts/test.py
+
   - name: model_with_before_scripts
     meta:
       fal:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,7 +160,7 @@ def test_selection(capfd):
         assert "model_with_scripts" not in captured.out
         assert "other_with_scripts" in captured.out
         assert (
-            "Passing multiple --select/--models flags to fal is deprecated"
+            "Passing multiple --select/--models flags to fal is no longer supported"
             in captured.out
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,15 @@ profiles_dir = os.path.join(Path.cwd(), "tests/mock/mockProfile")
 project_dir = os.path.join(Path.cwd(), "tests/mock")
 
 
+class ProjectTemporaryDirectory(tempfile.TemporaryDirectory):
+    def __init__(self, *args, **kargs):
+        super().__init__(*args, **kargs)
+
+        # Copy project_dir to a clean temp directory
+        shutil.rmtree(self.name, ignore_errors=True)
+        shutil.copytree(project_dir, self.name)
+
+
 def test_run():
     try:
         cli(["fal", "run", "--profiles-dir", profiles_dir])
@@ -32,23 +41,21 @@ def test_no_arg(capfd):
     assert "the following arguments are required: COMMAND" in captured.err
 
 
-def test_run_with_project_dir():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+def test_run_with_project_dir(capfd):
+    with ProjectTemporaryDirectory() as tmp_dir:
         cli(["fal", "run", "--project-dir", tmp_dir, "--profiles-dir", profiles_dir])
 
 
 def test_version(capfd):
-    import importlib.metadata
+    import pkg_resources
 
-    version = importlib.metadata.version("fal")
+    version = pkg_resources.get_distribution("fal").version
     captured = _run_fal(["--version"], capfd)
     assert f"fal {version}" in captured.out
 
 
 def test_flow_run_with_project_dir(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
                 # fmt: off
@@ -68,8 +75,7 @@ def test_flow_run_with_project_dir(capfd):
 
 
 def test_flow_run_with_project_dir_and_select(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
                 # fmt: off
@@ -95,8 +101,7 @@ def test_flow_run_with_project_dir_and_select(capfd):
 
 
 def test_flow_run_with_defer(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
                 # fmt: off
@@ -117,8 +122,7 @@ def test_flow_run_with_defer(capfd):
 
 
 def test_flow_run_with_vars(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
                 # fmt: off
@@ -139,8 +143,7 @@ def test_flow_run_with_vars(capfd):
 
 
 def test_selection(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         captured = _run_fal(
             [
                 # fmt: off
@@ -198,8 +201,7 @@ def test_selection(capfd):
 
 
 def test_no_run_results(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
         shutil.rmtree(os.path.join(tmp_dir, "mockTarget"))
 
         # Without selection flag
@@ -222,8 +224,7 @@ def test_no_run_results(capfd):
 
 
 def test_before(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
 
         captured = _run_fal(
             [
@@ -263,8 +264,7 @@ def test_before(capfd):
 
 
 def test_flag_level(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
 
         captured = _run_fal(
             [
@@ -297,8 +297,7 @@ def test_flag_level(capfd):
 
 
 def test_target(capfd):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree(project_dir, tmp_dir, dirs_exist_ok=True)
+    with ProjectTemporaryDirectory() as tmp_dir:
 
         captured = _run_fal(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,18 +147,15 @@ def test_selection(capfd):
                 "run",
                 "--project-dir", tmp_dir,
                 "--profiles-dir", profiles_dir,
-                "--select", "model_feature_store", "model_empty_scripts",
-                "--select", "model_with_scripts",
-                # included (extend)
+                "--select", "model_with_scripts", # not included (overwritten)
+                "--select", "other_with_scripts",
                 # fmt: on
             ],
             capfd,
         )
 
-        assert "model_with_scripts" in captured.out
-        assert "model_no_fal" not in captured.out
-        assert "model_feature_store" in captured.out
-        assert "model_empty_scripts" in captured.out
+        assert "model_with_scripts" not in captured.out
+        assert "other_with_scripts" in captured.out
         assert (
             "Passing multiple --select/--models flags to fal is deprecated"
             in captured.out
@@ -181,10 +178,6 @@ def test_selection(capfd):
         assert "model_no_fal" not in captured.out
         assert "model_feature_store" in captured.out
         assert "model_empty_scripts" in captured.out
-        assert (
-            "Passing multiple --select/--models flags to fal is deprecated"
-            not in captured.out
-        )
 
         captured = _run_fal(
             [


### PR DESCRIPTION
We had warned we would remove support for this in 0.4, but Python 3.7 does not support extend action. I think we can prioritize Python 3.7

For #274 