### PR TITLE
Make ipynb write_to_model work with a default model name

### DIFF
--- a/integration_tests/projects/007_ipynb_scripts/fal_scripts/notebooks/my_notebook.ipynb
+++ b/integration_tests/projects/007_ipynb_scripts/fal_scripts/notebooks/my_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "344819e4",
+   "id": "62a31b37",
    "metadata": {
     "collapsed": false
    },
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7242e47e",
+   "id": "e7a3a70d",
    "metadata": {
     "collapsed": false
    },
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f934c790",
+   "id": "256f078d",
    "metadata": {
     "collapsed": false
    },
@@ -39,18 +39,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "066fb17e",
+   "id": "8a3d27de",
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "%init_fal project_dir=../.. profiles_dir=../../.."
+    "%init_fal project_dir=../.. profiles_dir=../../.. default_model_name=zendesk_ticket_data"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "deb1c52c",
+   "id": "e3cc7e7c",
    "metadata": {
     "collapsed": false
    },
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dca2be9",
+   "id": "f998243f",
    "metadata": {
     "collapsed": false
    },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cbbe4b4",
+   "id": "e32e0e2b",
    "metadata": {
     "collapsed": false
    },
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91c1d602",
+   "id": "021f4d26",
    "metadata": {
     "collapsed": false
    },
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1059be6",
+   "id": "41f47376",
    "metadata": {
     "collapsed": false
    },
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "258b83ee",
+   "id": "9c99dab1",
    "metadata": {
     "collapsed": false
    },
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b547055",
+   "id": "f8e7490d",
    "metadata": {
     "collapsed": false
    },
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89fb88d8",
+   "id": "5f3e47dc",
    "metadata": {
     "collapsed": false
    },

--- a/src/faldbt/magics.py
+++ b/src/faldbt/magics.py
@@ -1,4 +1,5 @@
 from IPython.core.magic import register_line_magic, needs_local_scope
+from functools import partial
 from fal import FalDbt
 
 
@@ -38,4 +39,18 @@ def init_fal(line="", local_ns={}):
         "el": faldbt.el,
     }
 
+    if args.get("default_model_name"):
+        fal_globals["write_to_model"] = partial(
+            faldbt.write_to_model,
+            target_1=args.get("default_model_name"),
+            target_2=None,
+        )
+
+    else:
+        fal_globals["write_to_model"] = _raise_no_model_exception
+
     local_ns.update(fal_globals)
+
+
+def _raise_no_model_exception():
+    raise Exception("Model not found. Please provide a default model name.")

--- a/src/faldbt/magics.py
+++ b/src/faldbt/magics.py
@@ -13,7 +13,7 @@ def init_fal(line="", local_ns={}):
     """
     from faldbt.magics import init_fal
 
-    %init_fal project_dir=/my_project_dir profiles_dir=/my_profiles_dir
+    %init_fal project_dir=/my_project_dir profiles_dir=/my_profiles_dir default_model_name=my_model
     """
     '''
     args = dict([arg.split("=") for arg in line.split()])
@@ -53,4 +53,11 @@ def init_fal(line="", local_ns={}):
 
 
 def _raise_no_model_exception():
-    raise Exception("Model not found. Please provide a default model name.")
+    raise Exception(
+        '''
+        Model not found. Please provide a default model name. Example:
+        """
+        %init_fal project_dir=/my_project_dir profiles_dir=/my_profiles_dir default_model_name=my_model
+        """
+        '''
+    )


### PR DESCRIPTION
Looks like there isn't an easy way to find a file name for Jupyter Notebook: https://stackoverflow.com/questions/52119454/how-to-obtain-jupyter-notebooks-path

So, instead, in this PR we ask the user to enter the target model name:

```
%init_fal project_dir=../.. profiles_dir=../../.. default_model_name=zendesk_ticket_data
```

`default_model_name` is can be overridden by fal during fal runtime.