### PR TITLE
feat: Log script id with path relative to scripts_path or project_dir

### DIFF
--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -113,8 +113,7 @@ class FalScript:
 
     @property
     def id(self):
-        # TODO: maybe `self.path - project_dir`, to show only relevant path
-        return f"({self.model_name},{self.path})"
+        return f"({self.model_name},{self.path.relative_to(self._faldbt.scripts_dir)})"
 
     @property
     def is_global(self):

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -112,12 +112,27 @@ class FalScript:
             pass
 
     @property
+    def relative_path(self):
+        if self.is_model:
+            return self.path.relative_to(self._faldbt.project_dir)
+        else:
+            return self.path.relative_to(self._faldbt.scripts_dir)
+
+    @property
     def id(self):
-        return f"({self.model_name},{self.path.relative_to(self._faldbt.scripts_dir)})"
+        if self.is_model:
+            return f"(model: {self.relative_path})"
+        else:
+            return f"({self.model_name}, {self.relative_path})"
 
     @property
     def is_global(self):
         return self.model is None
+
+    @property
+    def is_model(self):
+        if self.model is not None and self.model.python_model is not None:
+            return self.model.python_model == self.path
 
     @property
     def model_name(self):

--- a/src/fal/run_scripts.py
+++ b/src/fal/run_scripts.py
@@ -18,22 +18,17 @@ import traceback
 def _prepare_exec_script(script: FalScript, faldbt: FalDbt) -> bool:
     success: bool = True
 
-    logger.debug("Running script {} for model {}", script.path, script.model_name)
+    logger.debug("Running script {}", script.id)
 
     try:
         script.exec(faldbt)
     except:
-        logger.error(
-            "Error in script {} with model {}:\n{}",
-            script.path,
-            script.model_name,
-            traceback.format_exc(),
-        )
+        logger.error("Error in script {}:\n{}", script.id, traceback.format_exc())
         # TODO: what else to do?
         success = False
 
     finally:
-        logger.debug("Finished script {} for model {}", script.path, script.model_name)
+        logger.debug("Finished script {}", script.id)
 
     return success
 

--- a/src/fal/utils.py
+++ b/src/fal/utils.py
@@ -6,12 +6,7 @@ from typing import List
 
 def print_run_info(scripts: List[FalScript]):
     """Print information on the current fal run."""
-    models_arr = []
-    for script in scripts:
-        path = str(script.path)
-        models_arr.append(f"{script.model_name}: {path}")
-
-    models_str = "\n".join(models_arr)
+    models_str = "\n".join(map(lambda script: script.id, scripts))
     print_timestamped_line(
         f"Starting fal run for following models and scripts: \n{models_str}\n"
     )


### PR DESCRIPTION
How the logs would look now:
```
19:25:00  Unable to do partial parsing because config vars, config profile, or config target have changed
19:25:01  Found 5 models, 0 tests, 0 snapshots, 0 analyses, 167 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
Executing command: dbt --log-format json run --project-dir /Users/matteo/Projects/fal/fal/integration_tests/projects/008_pure_python_models --select model_a model_c model_b
Running with dbt=1.1.0
Found 5 models, 0 tests, 0 snapshots, 0 analyses, 167 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
Concurrency: 4 threads (target='dev')
1 of 2 START view model dbt_fal.model_a ........................................ [RUN]
1 of 2 OK created view model dbt_fal.model_a ................................... [CREATE VIEW in 0.12s]
2 of 2 START view model dbt_fal.model_b ........................................ [RUN]
2 of 2 OK created view model dbt_fal.model_b ................................... [CREATE VIEW in 0.05s]
Finished running 2 view models in 0.34s.
Completed successfully
Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
15:25:06 | Starting fal run for following models and scripts:
(model: models/staging/model_c.py)         ##########       HERE       ###########

Concurrency: 4 threads
19:25:06  Unable to do partial parsing because config vars, config profile, or config target have changed
15:25:08 | Starting fal run for following models and scripts:
(model_c, after.py)         ##########       HERE       ###########
(model_c, after2.py)         ##########       HERE       ###########

Concurrency: 4 threads
Error in script (model_c, after2.py):         ##########       HERE       ###########
Traceback (most recent call last):
  File "/Users/matteo/Projects/fal/fal/src/fal/run_scripts.py", line 24, in _prepare_exec_script
    script.exec(faldbt)
  File "/Users/matteo/Projects/fal/fal/src/fal/fal_script.py", line 110, in exec
    exec(program, exec_globals)
  File "/Users/matteo/Projects/fal/fal/integration_tests/projects/008_pure_python_models/scripts/after2.py", line 10, in <module>
    raise RuntimeError("on purpose")
RuntimeError: on purpose

Traceback (most recent call last):
  File "/Users/matteo/Library/Caches/pypoetry/virtualenvs/fal-eFX98vrn-py3.10/bin/fal", line 5, in <module>
    cli()
  File "/Users/matteo/Projects/fal/fal/src/fal/cli/cli.py", line 18, in cli
    _cli(argv)
  File "/Users/matteo/Projects/fal/fal/src/fal/telemetry/telemetry.py", line 338, in wrapper
    result = func(*func_args, **func_kwargs)
  File "/Users/matteo/Projects/fal/fal/src/fal/cli/cli.py", line 44, in _cli
    fal_flow_run(parsed)
  File "/Users/matteo/Projects/fal/fal/src/fal/cli/flow_runner.py", line 45, in fal_flow_run
    _run_sub_graph(index, parsed, node_graph, execution_plan, fal_dbt)
  File "/Users/matteo/Projects/fal/fal/src/fal/cli/flow_runner.py", line 104, in _run_sub_graph
    raise_for_run_results_failures(after_scripts, results)
  File "/Users/matteo/Projects/fal/fal/src/fal/run_scripts.py", line 41, in raise_for_run_results_failures
    raise RuntimeError(f"Error in scripts {str.join(', ', failure_ids)}")
RuntimeError: Error in scripts (model_c, after2.py)         ##########       HERE       ###########
```
Marked 5 lines with `##########       HERE       ###########`. Added a `RuntimeError` on purpose so you can see error reports now.

<details> closes FEA-116 </details>