### PR TITLE
Use github action that handles cancels correctly

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -35,7 +35,8 @@ jobs:
 
       # Avoid running against the same profile at the same time
       - name: Set up mutex on profiles
-        uses: ben-z/gh-action-mutex@v1.0-alpha-4
+        # TODO: waiting for https://github.com/ben-z/gh-action-mutex/pull/7 to be accepted
+        uses: chamini2/gh-action-mutex@patch-1
         if: matrix.profile != 'postgres'
         with:
           branch: gh-mutex-profile-${{ matrix.profile }}


### PR DESCRIPTION
This enables us to cancel jobs waiting for the lock without breaking the mutex.