### PR TITLE
chore: add @TODO-profile tag to skip tests by profile

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -88,7 +88,7 @@ jobs:
             echo 'keyfile is ready'
           fi
 
-          behave --tags=~broken_profile --tags=~TODO-${{ matrix.profile }} -D profile=${{ matrix.profile }}
+          behave --tags=-broken_profile --tags=-TODO-${{ matrix.profile }} -D profile=${{ matrix.profile }}
 
       - name: Send custom JSON data to Slack workflow
         if: failure() && github.ref_name == 'main'

--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -88,7 +88,7 @@ jobs:
             echo 'keyfile is ready'
           fi
 
-          behave --tags=-broken_profile -D profile=${{ matrix.profile }}
+          behave --tags=~broken_profile --tags=~TODO-${{ matrix.profile }} -D profile=${{ matrix.profile }}
 
       - name: Send custom JSON data to Slack workflow
         if: failure() && github.ref_name == 'main'


### PR DESCRIPTION
this is to support skipping test cases by profile like:

```
  @TODO-duckdb
  Scenario: Use write_to_model and write_to_source function with mode overwrite
    When the following command is invoked:
      """
      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-flow
      """
    Then the following models are calculated:
      | other_model | some_model |
    And the following scripts are ran:
      | some_model.write_to_source_twice.py | other_model.complete_other_model.py |
    And the script other_model.complete_other_model.py output file has the lines:
      | my_float None | my_float 2.3 | size 1 |
    And the script some_model.write_to_source_twice.py output file has the lines:
      | my_float 2.3 |
```