### PR TITLE
tests: add support for testing pure-python models

### DIFF
--- a/integration_tests/features/flow_run_middle_nodes.feature
+++ b/integration_tests/features/flow_run_middle_nodes.feature
@@ -55,7 +55,7 @@ Feature: `flow run` command with py nodes in the middle
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select model_a+,model_c+ --experimental-models
       """
     Then the following models are calculated:
-      | model_d |
+      | model_c.py | model_d | model_e.ipynb |
     And the following scripts are ran:
       | model_c.after.py | model_e.after.py |
 

--- a/integration_tests/features/python_nodes.feature
+++ b/integration_tests/features/python_nodes.feature
@@ -7,11 +7,8 @@ Feature: Python nodes
       """
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models
       """
-    # TODO: Python generated models are not included in the run_results.json because they are ephemeral
-    # Then the following models are calculated:
-    #   | model_a | model_b | model_c | model_d |
     Then the following models are calculated:
-      | model_a | model_b | model_d |
+      | model_a | model_b | model_c.py | model_d | model_e.ipynb |
     Then the following scripts are ran:
       | model_c.after.py | model_e.after.py |
 
@@ -20,6 +17,7 @@ Feature: Python nodes
       """
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --select model_c
       """
-    # TODO: Python generated models are not included in the run_results.json because they are ephemeral
-    # Then the following models are calculated:
-    #   | model_c |
+    Then the following models are calculated:
+      | model_c.py |
+    Then the following scripts are not ran:
+      | model_c.after.py |

--- a/integration_tests/features/steps/fal_steps.py
+++ b/integration_tests/features/steps/fal_steps.py
@@ -1,5 +1,6 @@
 from functools import reduce
 import os
+from pyexpat import model
 from typing import Dict
 from behave import *
 from fal.cli import cli
@@ -182,23 +183,40 @@ def no_scripts_are_run(context):
 
 @then("the following models are calculated")
 def check_model_results(context):
-    models = _get_models_from_result(
+    dbt_models = _get_models_from_result(
         context.temp_dir.name,
         reduce(os.path.join, [context.temp_dir.name, "target", "run_results.json"]),
     )
-    unittest.TestCase().assertCountEqual(_flatten_list(models), context.table.headings)
+    python_models = _get_python_models(
+        context.temp_dir.name,
+    )
+
+    models = dbt_models + python_models
+    expected_models = list(map(_script_filename, context.table.headings))
+    unittest.TestCase().assertCountEqual(models, expected_models)
 
 
 def _script_filename(script: str):
-    return script.replace(".py", ".txt")
+    return script.replace(".ipynb", ".txt").replace(".py", ".txt")
 
 
 def _temp_dir_path(context, file):
     return os.path.join(context.temp_dir.name, file)
 
 
+def _get_python_models(dir_name):
+    directory = Path(dir_name)
+    return [
+        model.name
+        for model in directory.glob("*.txt")
+        # Pure Python models use <model_name>.txt and scripts use <model_name>.<script>.txt,
+        # so this check ensures that we are only capturing the models (and not scripts).
+        if len(model.suffixes) == 1
+    ]
+
+
 def _get_models_from_result(dir_name, file_name):
-    return list(
+    return _flatten(
         map(
             lambda result: result["unique_id"].split(".")[2],
             _load_result(dir_name, file_name),
@@ -224,19 +242,18 @@ def _get_fal_results_file_name(context):
     return list(filter(lambda file: pattern.match(file), target_files))
 
 
-def _flatten_list(target_list):
+def _flatten(target_iterable):
     flat_list = []
-    for element in target_list:
-        if type(element) is list:
-            for item in element:
-                flat_list.append(item)
+    for element in target_iterable:
+        if isinstance(element, list):
+            flat_list.extend(element)
         else:
             flat_list.append(element)
     return flat_list
 
 
 def _set_profiles_dir(context) -> Path:
-    #TODO: Ideally this needs to change in just one place
+    # TODO: Ideally this needs to change in just one place
     available_profiles = ["postgres", "bigquery", "redshift", "snowflake", "duckdb"]
     if "profile" in context.config.userdata:
         profile = context.config.userdata["profile"]

--- a/integration_tests/features/steps/fal_steps.py
+++ b/integration_tests/features/steps/fal_steps.py
@@ -1,6 +1,5 @@
 from functools import reduce
 import os
-from pyexpat import model
 from typing import Dict
 from behave import *
 from fal.cli import cli

--- a/integration_tests/projects/008_pure_python_models/models/model_e.ipynb
+++ b/integration_tests/projects/008_pure_python_models/models/model_e.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from functools import reduce\n",
     "from faldbt.magics import init_fal\n",
     "%init_fal project_dir=../.. profiles_dir=../../.. default_model_name=model_e_notebook"
    ]
@@ -56,6 +58,32 @@
    "outputs": [],
    "source": [
     "write_to_model(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Leave behind an artifact for tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = context.current_model.name\n",
+    "\n",
+    "output = f\"Model name: {model_name}\"\n",
+    "output = output + f\"\\nStatus: {context.current_model.status}\"\n",
+    "\n",
+    "output = output + \"\\nModel dataframe name: {model_name}\"\n",
+    "temp_dir = os.environ[\"temp_dir\"]\n",
+    "\n",
+    "write_dir = open(reduce(os.path.join, [temp_dir, model_name + \".txt\"]), \"w\")\n",
+    "write_dir.write(output)\n",
+    "write_dir.close()"
    ]
   }
  ],

--- a/integration_tests/projects/008_pure_python_models/models/staging/model_c.py
+++ b/integration_tests/projects/008_pure_python_models/models/staging/model_c.py
@@ -2,9 +2,24 @@
 DEPENDENCY: ref("model_b")
 - ref('model_a')
 """
+import os
+from functools import reduce
+
 # weird way to call, but added in the docstring
 df = ref(*["model_b"])
 
 df["my_bool"] = True
 
 write_to_model(df)
+
+model_name = context.current_model.name
+
+output = f"Model name: {model_name}"
+output = output + f"\nStatus: {context.current_model.status}"
+
+output = output + "\nModel dataframe name: {model_name}"
+temp_dir = os.environ["temp_dir"]
+
+write_dir = open(reduce(os.path.join, [temp_dir, model_name + ".txt"]), "w")
+write_dir.write(output)
+write_dir.close()


### PR DESCRIPTION
As discussed in FEA-37, the convention is `<model>.txt` for output files and `<model>.{py, ipynb}` in the feature files. Blocked by: #361 