### PR TITLE
tests: exhaustive check for scripts that are ran

### DIFF
--- a/integration_tests/features/dbt_test.feature
+++ b/integration_tests/features/dbt_test.feature
@@ -12,7 +12,7 @@ Feature: `write_to_source` function
       fal run --profiles-dir $profilesDir --project-dir $baseDir
       """
     Then the following scripts are ran:
-      | some_model.write_to_source_twice.py |
+      | some_model.write_to_source_twice.py | other_model.complete_model.py | third_model.complete_model.py |
     And the script some_model.write_to_source_twice.py output file has the lines:
       | source results has 2 tests, source status is skipped   |
       | model some_model has 2 tests, model status is success  |

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -10,7 +10,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 | model_c |
     And the following scripts are ran:
-      | agent_wait_time.before.py | agent_wait_time.after.py |
+      | agent_wait_time.before.py | agent_wait_time.after.py | model_c.before.py |
 
   Scenario: fal flow run command with selectors
     Given the project 001_flow_run_with_selectors
@@ -21,7 +21,7 @@ Feature: `flow run` command
       """
     Then no models are calculated
     And the following scripts are ran:
-      | agent_wait_time.before.py |
+      | agent_wait_time.before.py | model_c.before.py |
 
   Scenario: fal flow run command with complex selectors
     Given the project 001_flow_run_with_selectors
@@ -193,9 +193,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 | zendesk_ticket_data | model_b | model_a | model_c |
     And the following scripts are ran:
-      | agent_wait_time.after.py |
-    And the following scripts are not ran:
-      | agent_wait_time.before.py |
+      | agent_wait_time.after.py | zendesk_ticket_data.check_extra.py |
 
   Scenario: fal flow run command with exclude arg with children
     Given the project 001_flow_run_with_selectors
@@ -220,8 +218,6 @@ Feature: `flow run` command
       | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 | model_c |
     And the following scripts are not ran:
       | agent_wait_time.after.py |
-    And the following scripts are ran:
-      | agent_wait_time.before.py |
 
   Scenario: fal flow run command with select @
     Given the project 001_flow_run_with_selectors
@@ -233,7 +229,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 | model_a | model_b | model_c |
     And the following scripts are ran:
-      | model_c.before.py | agent_wait_time.after.py |
+      | model_c.before.py | agent_wait_time.before.py | agent_wait_time.after.py |
 
   Scenario: fal flow run with @ in the middle
     Given the project 001_flow_run_with_selectors
@@ -245,9 +241,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 | model_a | model_b | model_c |
     And the following scripts are ran:
-      | model_c.before.py |
-    And the following scripts are not ran:
-      | agent_wait_time.after.py |
+      | model_c.before.py | agent_wait_time.before.py |
 
   @broken_profile
   Scenario: fal flow run with target

--- a/integration_tests/features/flow_run_middle_nodes.feature
+++ b/integration_tests/features/flow_run_middle_nodes.feature
@@ -79,4 +79,4 @@ Feature: `flow run` command with py nodes in the middle
     Then the following models are calculated:
       | customers |
     Then the following scripts are ran:
-      | middle_2.middle_script.py |
+      | middle_2.middle_script.py | customers.send_slack_message.py |

--- a/integration_tests/features/flow_run_with_jaffle_shop.feature
+++ b/integration_tests/features/flow_run_with_jaffle_shop.feature
@@ -11,4 +11,4 @@ Feature: `flow run` command
     Then the following models are calculated:
       | stg_customers | customers | stg_orders | stg_payments |
     And the following scripts are ran:
-      | customers.send_slack_message.py |
+      | stg_customers.load_data.py | customers.send_slack_message.py |

--- a/integration_tests/features/globals.feature
+++ b/integration_tests/features/globals.feature
@@ -24,8 +24,6 @@ Feature: global scripts
       """
     Then the following scripts are ran:
       | some_model.after.py |
-    Then the following scripts are not ran:
-      | GLOBAL.after.py |
 
   Scenario: fal run triggers globals with select flag
     Given the project 004_globals
@@ -57,5 +55,3 @@ Feature: global scripts
       """
     Then the following scripts are ran:
       | some_model.before.py | some_model.after.py |
-    Then the following scripts are not ran:
-      | GLOBAL.before.py | GLOBAL.after.py |

--- a/integration_tests/features/ipynb_scripts.feature
+++ b/integration_tests/features/ipynb_scripts.feature
@@ -67,8 +67,6 @@ Feature: fal works with ipynb features
       """
     Then the following scripts are ran:
       | zendesk_ticket_data.check_extra.py | zendesk_ticket_data.my_notebook.py |
-    Then the following scripts are not ran:
-      | agent_wait_time.after.py |
 
   Scenario: fal run works with script selection
     Given the project 007_ipynb_scripts

--- a/integration_tests/features/python_nodes.feature
+++ b/integration_tests/features/python_nodes.feature
@@ -13,7 +13,7 @@ Feature: Python nodes
     Then the following models are calculated:
       | model_a | model_b | model_d |
     Then the following scripts are ran:
-      | model_c.after.py |
+      | model_c.after.py | model_e.after.py |
 
   Scenario: Run a project with Python nodes only selecting the Python model
     When the following command is invoked:
@@ -23,6 +23,3 @@ Feature: Python nodes
     # TODO: Python generated models are not included in the run_results.json because they are ephemeral
     # Then the following models are calculated:
     #   | model_c |
-    Then the following scripts are not ran:
-      | model_c.after.py |
-

--- a/integration_tests/features/run.feature
+++ b/integration_tests/features/run.feature
@@ -26,8 +26,6 @@ Feature: `run` command
       """
     Then the following scripts are ran:
       | agent_wait_time.after.py |
-    Then the following scripts are not ran:
-      | zendesk_ticket_data.after.py |
 
   Scenario: fal run works with model selection
     When the following shell command is invoked:
@@ -40,8 +38,6 @@ Feature: `run` command
       """
     Then the following scripts are ran:
       | zendesk_ticket_data.after.py |
-    Then the following scripts are not ran:
-      | agent_wait_time.after.py |
 
   Scenario: fal run works with script selection
     When the following shell command is invoked:
@@ -53,7 +49,7 @@ Feature: `run` command
       fal run --profiles-dir $profilesDir --project-dir $baseDir --script fal_scripts/after.py
       """
     Then the following scripts are ran:
-      | agent_wait_time.after.py |
+      | agent_wait_time.after.py | zendesk_ticket_data.after.py |
 
   Scenario: fal run provides model aliases
     When the following shell command is invoked:
@@ -66,7 +62,7 @@ Feature: `run` command
       fal run --profiles-dir $profilesDir --project-dir $baseDir
       """
     Then the following scripts are ran:
-      | agent_wait_time.after.py |
+      | agent_wait_time.after.py | zendesk_ticket_data.after.py |
     And the script agent_wait_time.after.py output file has the lines:
       | Model alias is wait_time |
 

--- a/integration_tests/features/run_with_custom_target.feature
+++ b/integration_tests/features/run_with_custom_target.feature
@@ -27,8 +27,6 @@ Feature: `run` command with a custom profile target
       """
     Then the following scripts are ran:
       | agent_wait_time.after.py |
-    Then the following scripts are not ran:
-      | zendesk_ticket_data.after.py |
 
   Scenario: fal run works with model selection with custom target
     When the following shell command is invoked:
@@ -41,8 +39,6 @@ Feature: `run` command with a custom profile target
       """
     Then the following scripts are ran:
       | zendesk_ticket_data.after.py |
-    Then the following scripts are not ran:
-      | agent_wait_time.after.py |
 
   Scenario: fal run works with script selection with custom target
     When the following shell command is invoked:
@@ -54,4 +50,4 @@ Feature: `run` command with a custom profile target
       fal run --profiles-dir profiles/broken --project-dir $baseDir --script fal_scripts/after.py
       """
     Then the following scripts are ran:
-      | agent_wait_time.after.py |
+      | agent_wait_time.after.py | zendesk_ticket_data.after.py |

--- a/integration_tests/features/write_to_source_function.feature
+++ b/integration_tests/features/write_to_source_function.feature
@@ -11,6 +11,6 @@ Feature: `write_to_source` function
     Then the following models are calculated:
       | other_model | some_model | third_model |
     And the following scripts are ran:
-      | some_model.write_to_source_twice.py |
+      | some_model.write_to_source_twice.py | other_model.complete_model.py | third_model.complete_model.py |
     And the script some_model.write_to_source_twice.py output file has the lines:
       | source size 1 | source size 2 |


### PR DESCRIPTION
- `following scripts are ran` checks are now exhaustive. They need to include all the scripts that are ran on the **last** invoked command.
- For preventing conflicts (e.g on a invocation-chain when the initial command runs some scripts and the actual tested command runs a different set of scripts), we now clear all the fal-related artifacts at each session. This is similiar how DBT's run file is overwriten at every time. 
- Adjusted existing cases of `following scripts are ran` to the current format.
- Removed some redundant cases of `following scripts are not ran` cases (if there is a preceding `following scripts are ran` check, that means this case is now redundant. Didn't remove all of them since there are still some valid usages).