### PR TITLE
feat: support quote-grouped `--select` arguments

### DIFF
--- a/integration_tests/features/flow_run_with_jaffle_shop.feature
+++ b/integration_tests/features/flow_run_with_jaffle_shop.feature
@@ -12,3 +12,13 @@ Feature: `flow run` command
       | stg_customers | customers | stg_orders | stg_payments |
     And the following scripts are ran:
       | stg_customers.load_data.py | customers.send_slack_message.py |
+
+  Scenario: fal flow run command with selectors as a mixed single string
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select "load_data.py+ stg_orders" stg_payments
+      """
+    Then the following models are calculated:
+      | stg_customers | customers | stg_orders | stg_payments |
+    And the following scripts are ran:
+      | stg_customers.load_data.py | customers.send_slack_message.py |


### PR DESCRIPTION
- Add support for `--select` with `"x y z"` (more discussion [here](https://github.com/fal-ai/fal/pull/353#discussion_r891072798)).
- Remove the `SetOperator` (noticed it was easier if we don't depend on it since we only have 2 operators).