### PR TITLE
chore: ignore .python-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
>  For a library or package, you might want to ignore these files since the code is
>   intended to run in multiple environments; otherwise, check them in:

<details>
closes FEA-152
</details>