### PR TITLE
tests: Test all Python versions supported only for scheduled runs

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -7,13 +7,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  matrix-python:
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ steps.include-step.outputs.out }}
+    steps:
+      - id: include-step
+        run: |
+          echo '::set-output name=out::["3.8"]'
+          if [[ '${{ github.event_name }}' == 'scheduled' ]]
+          then
+            # overwrites the output
+            echo '::set-output name=out::["3.7", "3.8", "3.9", "3.10"]'
+          fi
   run:
+    needs: [matrix-python]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         profile: ["postgres", "bigquery", "snowflake", "redshift", "duckdb"]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ${{ fromJSON(needs.matrix-python.outputs.list) }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now manually triggering a "different profiles" GH Action will only test on `3.8` to reduce usage.

https://github.com/fal-ai/fal/actions/runs/2464247613