### PR TITLE
fix: Replace table instead of dropping and renaming for BigQuery

### DIFF
--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -1,5 +1,4 @@
 # NOTE: INSPIRED IN https://github.com/dbt-labs/dbt-core/blob/43edc887f97e359b02b6317a9f91898d3d66652b/core/dbt/lib.py
-from time import sleep
 import six
 import os
 from datetime import datetime
@@ -128,10 +127,6 @@ def _get_target_relation(
         project_dir, profiles_dir, profile_target=profile_target
     )
     manifest = parse.get_dbt_manifest(config)
-
-    if adapter.type() == "bigquery":
-        # After creating a table, BigQuery takes some time to realize it is there
-        sleep(2)
 
     name = "relation:" + str(hash(str(target))) + ":" + str(uuid4())
     relation = None


### PR DESCRIPTION
This avoids getting a 404 error and then creating, which sometimes is cached by the BigQuery service and then reports a 404 even when the table has just been created.

https://github.com/googleapis/google-cloud-go/issues/975#issuecomment-383294334
> I think you answered your own question. Creating a table is an eventually consistent operation: it may not appear to exist everywhere until after some time has passed. In the screenshots above, the second request, which happens 2 seconds after the first, may end up at a different location where the creation hasn't yet propagated.

### Disclaimer
I think this works. There is no real way to test but to release it to users and await complaints.

<details>
closes FEA-156
</details>