### PR TITLE
tests: allow testing the execution/calculation order of nodes

### DIFF
--- a/integration_tests/features/flow_run_order.feature
+++ b/integration_tests/features/flow_run_order.feature
@@ -1,0 +1,42 @@
+Feature: `flow run` command with ensured order
+  Background: Project Setup
+    Given the project 002_jaffle_shop
+    When the data is seeded
+
+  Scenario: fal flow run order without --experimental-flow
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select middle_1+
+      """
+    Then the following nodes are calculated in the following order:
+      | middle_1 | middle_2 | after_middle | middle_2.middle_script.py |
+
+  Scenario: fal flow run order with --experimental-flow
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-flow --select middle_1+
+      """
+    Then the following nodes are calculated in the following order:
+      | middle_1 | middle_2 | middle_2.middle_script.py | after_middle |
+
+  Scenario: fal flow run order with pure python models
+    Given the project 008_pure_python_models
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models
+      """
+    Then the following nodes are calculated in the following order:
+      | model_a | model_a.after.py | model_b | model_c.py | model_c.after.py | model_d | model_e.ipynb | model_e.after.py |
+
+  Scenario: fal flow run order with pure python models on a selection
+    Given the project 008_pure_python_models
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --select model_c
+      """
+    Then the following nodes are calculated in the following order:
+      | model_c.py |

--- a/integration_tests/features/python_nodes.feature
+++ b/integration_tests/features/python_nodes.feature
@@ -10,7 +10,7 @@ Feature: Python nodes
     Then the following models are calculated:
       | model_a | model_b | model_c.py | model_d | model_e.ipynb |
     Then the following scripts are ran:
-      | model_c.after.py | model_e.after.py |
+      | model_a.after.py | model_c.after.py | model_e.after.py |
 
   Scenario: Run a project with Python nodes only selecting the Python model
     When the following command is invoked:

--- a/integration_tests/projects/008_pure_python_models/models/schema.yml
+++ b/integration_tests/projects/008_pure_python_models/models/schema.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: model_a
+    meta:
+      fal:
+        scripts:
+          - after.py
   - name: model_b
   - name: model_c # Python model
     meta:


### PR DESCRIPTION
- Added support for the `Then the following nodes are calculated in the following order` condition
  - This internally collects all DBT models and their calculation (execution) time, as well as the the modification time of the Fal artifacts (from Python models or Python scripts). Which is then leveraged into sorting the list of calculated nodes.
 - Also does some refactorings on the collection of models/scripts, unifies most of the logic into a single core function we need to adapt if we change the format and a couple upper level functions.