### PR TITLE
chore: add status to DbtModel repr

### DIFF
--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -104,7 +104,7 @@ class DbtModel(_DbtNode):
     python_model: Optional[Path] = field(init=False, default=None)
 
     def __repr__(self):
-        attrs = ["name", "alias", "unique_id", "columns", "tests"]
+        attrs = ["name", "alias", "unique_id", "columns", "tests", "status"]
         props = ", ".join([f"{item}={repr(getattr(self, item))}" for item in attrs])
         return f"DbtModel({props})"
 


### PR DESCRIPTION
This is what printing a DbtModel object will look like:

```
DbtModel(name='zendesk_ticket_data', alias='fal_000_zendesk_ticket_data', unique_id='model.fal_000.zendesk_ticket_data', columns={}, tests=[], status=<NodeStatus.Success: 'success'>)
```