### PR TITLE
fix: Handle any number of args for not allowed functions in post-hooks

### DIFF
--- a/integration_tests/projects/000_fal_run/fal_scripts/write_to_model.py
+++ b/integration_tests/projects/000_fal_run/fal_scripts/write_to_model.py
@@ -1,1 +1,3 @@
-write_to_model()
+from pandas import DataFrame
+
+write_to_model(DataFrame())

--- a/integration_tests/projects/000_fal_run/fal_scripts/write_to_source.py
+++ b/integration_tests/projects/000_fal_run/fal_scripts/write_to_source.py
@@ -1,1 +1,3 @@
-write_to_source()
+from pandas import DataFrame
+
+write_to_source(DataFrame({"a": [1, 2, 3]}), "results", "some_source")

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -232,7 +232,7 @@ def _process_ipynb(raw_source_code: str) -> str:
 
 
 def _not_allowed_function_maker(function_name: str) -> Callable[[Any], None]:
-    def not_allowed_function():
+    def not_allowed_function(*args):
         raise Exception(
             (
                 f"{function_name} is not allowed in post-hooks."


### PR DESCRIPTION
<details>
closes FEA-187
</details>