### PR TITLE
feat: Allow Python models to be the exit nodes on subgraphs.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Setup pytest
-        run: pip install pytest mock black
+        run: pip install pytest pytest-mock mock black
 
       - name: Run dbt
         run: dbt run --profiles-dir tests/mock/mockProfile/ --project-dir tests/mock

--- a/poetry.lock
+++ b/poetry.lock
@@ -934,6 +934,20 @@ checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.7.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1205,7 +1219,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <3.11"
-content-hash = "bc5ebe9d5de0986d6002c20f88a207eee4d0c195ad2301b2dcfa1ab0c4fcb8ea"
+content-hash = "75e1ae4fc1d1504bdeef3b4adbadea275380d1295fd75d7a72d929c1cef2cbea"
 
 [metadata.files]
 agate = [
@@ -1527,6 +1541,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -1539,6 +1554,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -1547,6 +1563,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -1555,6 +1572,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -1563,6 +1581,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
@@ -1839,6 +1858,8 @@ protobuf = [
     {file = "protobuf-3.20.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7403941f6d0992d40161aa8bb23e12575637008a5a02283a930addc0508982f9"},
     {file = "protobuf-3.20.1-cp39-cp39-win32.whl", hash = "sha256:db977c4ca738dd9ce508557d4fce0f5aebd105e158c725beec86feb1f6bc20d8"},
     {file = "protobuf-3.20.1-cp39-cp39-win_amd64.whl", hash = "sha256:7e371f10abe57cee5021797126c93479f59fccc9693dafd6bd5633ab67808a91"},
+    {file = "protobuf-3.20.1-py2.py3-none-any.whl", hash = "sha256:adfc6cf69c7f8c50fd24c793964eef18f0ac321315439d94945820612849c388"},
+    {file = "protobuf-3.20.1.tar.gz", hash = "sha256:adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -1997,6 +2018,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
+    {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pytest = "^5.2"
 black = "^22.3"
 behave = "^1.2.6"
 mock = "^4.0.3"
+pytest-mock = "^3.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Executor,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
+from dataclasses import dataclass, field
+from typing import List
+
+from fal.planner.schedule import SUCCESS, NodeQueue
+from fal.planner.tasks import FalHookTask, Node, Task
+from faldbt.project import FalDbt
+
+
+@dataclass
+class FutureGroup:
+    args: argparse.Namespace
+    fal_dbt: FalDbt
+    node: Node
+    executor: Executor
+    futures: list[Future] = field(default_factory=list)
+    status: int = SUCCESS
+
+    def __post_init__(self) -> None:
+        # In the case of us having pre-hooks, this is
+        # where we'll trigger them (and handle the node.task)
+        # below.
+        self._add_tasks(self.node.task)
+
+    def process(self, future: Future) -> None:
+        assert future in self.futures
+
+        self.futures.remove(future)
+        self.status |= future.result()
+        if not isinstance(future.task, FalHookTask):
+            # Once the main task gets completed, we'll populate
+            # the task queue with the post-hooks.
+            self._add_tasks(*self.node.post_hooks)
+
+    def _add_tasks(self, *tasks: Task) -> None:
+        for task in tasks:
+            future = self.executor.submit(
+                task.execute,
+                args=self.args,
+                fal_dbt=self.fal_dbt,
+            )
+            future.task, future.group = task, self
+            self.futures.append(future)
+
+    @property
+    def is_done(self) -> int:
+        return len(self.futures) == 0
+
+
+def parallel_executor(
+    args: argparse.Namespace,
+    fal_dbt: FalDbt,
+    queue: NodeQueue,
+    max_threads: int,
+) -> None:
+    def get_futures(future_groups):
+        return {
+            # Unpack all running futures into a single set
+            # to be consumed by wait().
+            future
+            for future_group in future_groups
+            for future in future_group.futures
+        }
+
+    def create_futures(executor: ThreadPoolExecutor) -> List[FutureGroup]:
+        return [
+            # FutureGroup's are the secondary layer of the executor,
+            # managing the parallelization of tasks.
+            FutureGroup(
+                args,
+                fal_dbt,
+                node=node,
+                executor=executor,
+            )
+            for node in queue.iter_available_nodes()
+        ]
+
+    with ThreadPoolExecutor(max_threads) as executor:
+        future_groups = create_futures(executor)
+        futures = get_futures(future_groups)
+        while futures:
+            # Get the first completed futures, mark them done.
+            completed_futures, _ = wait(futures, return_when=FIRST_COMPLETED)
+            for future in completed_futures:
+                group = future.group
+                group.process(future)
+                if group.is_done:
+                    queue.finish(group.node, status=group.status)
+
+            # And load all the tasks that were blocked by those futures.
+            future_groups.extend(create_futures(executor))
+            futures = get_futures(future_groups)

--- a/src/fal/planner/plan.py
+++ b/src/fal/planner/plan.py
@@ -4,11 +4,14 @@ from typing import Iterator
 
 import networkx as nx
 
+from fal.node_graph import NodeKind
+
 
 def _find_subgraphs(graph: nx.DiGraph) -> Iterator[list[str]]:
-    # Initially topologically sort the graph, and split it
-    # into chunks by using the critical node approach (post-hooks
-    # are also a thing now).
+    # Initially sort the graph, and split it
+    # into chunks by using the critical node
+    # approach (post-hooks are also a thing
+    # now!!).
 
     # Then for each chunk, check whether they have the
     # same set of ancestors. This is important because
@@ -26,7 +29,7 @@ def _find_subgraphs(graph: nx.DiGraph) -> Iterator[list[str]]:
 
     for node in nx.topological_sort(graph):
         properties = graph.nodes[node]
-        if properties["kind"] == "python model":
+        if properties["kind"] is NodeKind.FAL_MODEL:
             yield from split()
             continue
 
@@ -53,8 +56,12 @@ def _reduce_subgraph(
     subgraph = graph.subgraph(nodes).copy()
 
     # Use the same set of properties as the last
-    # node, since only it can have post hooks.
-    graph.add_node(subgraph, **graph.nodes[nodes[-1]].copy())
+    # node, since only it can have any post hooks.
+    graph.add_node(
+        subgraph,
+        **graph.nodes[nodes[-1]].copy(),
+        exit_node=nodes[-1],
+    )
 
     for node in nodes:
         for predecessor in graph.predecessors(node):

--- a/src/fal/planner/plan.py
+++ b/src/fal/planner/plan.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import networkx as nx
+
+
+def _find_subgraphs(graph: nx.DiGraph) -> Iterator[list[str]]:
+    # Initially topologically sort the graph, and split it
+    # into chunks by using the critical node approach (post-hooks
+    # are also a thing now).
+
+    # Then for each chunk, check whether they have the
+    # same set of ancestors. This is important because
+    # we want to group only the things that are in
+    # the same branch.
+
+    current_stack = []
+    allowed_ancestors = set()
+
+    def split() -> Iterator[list[str]]:
+        if len(current_stack) > 1:
+            yield current_stack.copy()
+        current_stack.clear()
+        allowed_ancestors.clear()
+
+    for node in nx.topological_sort(graph):
+        properties = graph.nodes[node]
+        if properties["kind"] == "python model":
+            yield from split()
+            continue
+
+        ancestors = nx.ancestors(graph, node)
+        if not current_stack:
+            allowed_ancestors = ancestors
+
+        if not ancestors.issubset(allowed_ancestors):
+            yield from split()
+
+        current_stack.append(node)
+        allowed_ancestors |= {node, *ancestors}
+
+        if properties.get("post-hook"):
+            yield from split()
+
+    yield from split()
+
+
+def _reduce_subgraph(
+    graph: nx.DiGraph,
+    nodes: list[str],
+) -> None:
+    subgraph = graph.subgraph(nodes).copy()
+
+    # Use the same set of properties as the last
+    # node, since only it can have post hooks.
+    graph.add_node(subgraph, **graph.nodes[nodes[-1]].copy())
+
+    for node in nodes:
+        for predecessor in graph.predecessors(node):
+            graph.add_edge(predecessor, subgraph)
+
+        for successor in graph.successors(node):
+            graph.add_edge(subgraph, successor)
+
+        graph.remove_node(node)
+
+
+def plan_graph(graph: nx.DiGraph) -> nx.DiGraph:
+    # Implementation of Gorkem's Critical Nodes Algorithm
+    # with a few modifications.
+    new_graph = graph.copy()
+
+    for nodes in _find_subgraphs(new_graph):
+        _reduce_subgraph(new_graph, nodes)
+
+    return new_graph

--- a/src/fal/planner/schedule.py
+++ b/src/fal/planner/schedule.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator
+
+import networkx as nx
+
+from fal.node_graph import DbtModelNode, NodeGraph, NodeKind
+from fal.planner.tasks import SUCCESS, DBTTask, FalHookTask, FalModelTask, Node
+
+
+def create_node(
+    node: str | nx.DiGraph, properties: dict, node_graph: NodeGraph
+) -> Node:
+    kind = properties["kind"]
+    if isinstance(node, nx.DiGraph):
+        model_ids = sorted(
+            list(node),
+            key=lambda node: node == properties["exit_node"],
+        )
+    else:
+        model_ids = [node]
+
+    if kind is NodeKind.DBT_MODEL:
+        task = DBTTask(model_ids=model_ids)
+    else:
+        assert kind is NodeKind.FAL_MODEL
+        task = FalModelTask(model_ids=model_ids)
+
+    model_node = node_graph.get_node(model_ids[-1])
+    assert model_node is not None
+
+    if isinstance(task, FalModelTask):
+        assert isinstance(model_node, DbtModelNode)
+        task.bound_model = model_node.model
+
+    post_hooks = [
+        FalHookTask(
+            hook_path=hook_path,
+            bound_model=model_node.model,
+        )
+        for hook_path in properties.get("post-hook", [])
+    ]
+    return Node(task, post_hooks=post_hooks)
+
+
+@dataclass
+class NodeQueue:
+    nodes: list[Node]
+    _staged_nodes: list[Node] = field(default_factory=list)
+    _counter: int = 0
+
+    def __bool__(self) -> bool:
+        return bool(self.nodes)
+
+    def _calculate_node_score(self, target_node: Node) -> tuple[int, int]:
+        # Determine the priority of the node by doing a bunch
+        # of calculations. This doesn't really need to be 100% precise,
+        # since if we don't have this we'll have to schedule randomly.
+
+        # 1. Number of nodes which are only waiting this node (direct dependants)
+        # 2. Number of nodes which are waiting this node and other nodes (indirect dependants)
+        # ...
+
+        direct_dependants = 0
+        indirect_dependants = 0
+
+        for node in self.nodes:
+            if node is target_node:
+                continue
+
+            if any(dependency is target_node for dependency in node.dependencies):
+                indirect_dependants += 1
+                if len(node.dependencies) == 1:
+                    direct_dependants += 1
+
+        return (direct_dependants, indirect_dependants)
+
+    def _stage_node(self, target_node: Node) -> None:
+        # When we start running a node, we don't want to simply remove it
+        # just yet (since that would unblock all of its dependencies). So
+        # we temporarily add it to a separate group of nodes (staged).
+
+        self._counter += 1
+        target_node.set_run_index(self._counter)
+
+        self.nodes.remove(target_node)
+        self._staged_nodes.append(target_node)
+
+    def finish(self, target_node: Node, status: int) -> None:
+        # When a staged node's execution is finished, we'll remove it
+        # alltogether and unblock all of its dependencies.
+        self._staged_nodes.remove(target_node)
+
+        if status == SUCCESS:
+            self._succeed(target_node)
+        else:
+            self._fail(target_node)
+
+        target_node.exit(status)
+
+    def _fail(self, target_node: Node) -> None:
+        for node in self.nodes.copy():
+            if target_node in node.dependencies:
+                self.nodes.remove(node)
+
+    def _succeed(self, target_node: Node) -> None:
+        for node in self.nodes.copy():
+            if target_node in node.dependencies:
+                node.dependencies.remove(target_node)
+
+    def iter_available_nodes(self) -> Iterator[Node]:
+        # Find all unblocked nodes (nodes without any dependencies) and
+        # use the node score algorithm to determine the priority of each
+        # node.
+        unblocked_nodes = [node for node in self.nodes if not node.dependencies]
+        unblocked_nodes.sort(key=self._calculate_node_score, reverse=True)
+
+        for node in unblocked_nodes:
+            self._stage_node(node)
+            yield node
+
+
+def schedule_graph(graph: nx.DiGraph, node_graph: NodeGraph) -> NodeQueue:
+    tasks = {
+        node: create_node(node, properties, node_graph)
+        for node, properties in graph.nodes(data=True)
+    }
+
+    for name, task in tasks.items():
+        task.dependencies = [tasks[ancestor] for ancestor in nx.ancestors(graph, name)]
+
+    return NodeQueue(list(tasks.values()))

--- a/src/fal/planner/tasks.py
+++ b/src/fal/planner/tasks.py
@@ -7,7 +7,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Iterator, Any
+from typing import Any, Iterator
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
@@ -100,7 +100,7 @@ class DBTTask(Task):
             args,
             model_names,
             fal_dbt.target_path,
-            self._run_index
+            self._run_index,
         )
 
         for node, status in _map_cli_output_model_statuses(output.run_results):

--- a/src/fal/planner/tasks.py
+++ b/src/fal/planner/tasks.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import traceback
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from functools import cached_property
+from typing import Iterator, Any
+
+from dbt.logger import GLOBAL_LOGGER as logger
+
+from fal.node_graph import FalScript
+from fal.utils import print_run_info
+from faldbt.project import DbtModel, FalDbt, NodeStatus
+
+SUCCESS = 0
+FAILURE = 1
+
+
+class Task:
+    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
+        raise NotImplementedError
+
+
+def _unique_id_to_model_name(unique_id: str) -> str:
+    split_list = unique_id.split(".")
+    # if its a unique id 'model.fal_test.model_with_before_scripts'
+    return split_list[len(split_list) - 1]
+
+
+def _unique_ids_to_model_names(id_list: list[str]) -> list[str]:
+    return list(map(_unique_id_to_model_name, id_list))
+
+
+def _mark_dbt_nodes_status(
+    fal_dbt: FalDbt,
+    status: NodeStatus,
+    dbt_node: str | None = None,
+):
+    for model in fal_dbt.models:
+        if dbt_node is not None:
+            if model.unique_id == dbt_node:
+                model.set_status(status)
+        else:
+            model.set_status(status)
+
+
+def _map_cli_output_model_statuses(
+    run_results: dict[Any, Any]
+) -> Iterator[tuple[str, NodeStatus]]:
+    if not isinstance(run_results.get("results"), list):
+        raise Exception("Could not read dbt run results")
+
+    for result in run_results["results"]:
+        if not result.get("unique_id") or not result.get("status"):
+            continue
+
+        yield result["unique_id"], NodeStatus(result["status"])
+
+
+def _run_script(script: FalScript, fal_dbt: FalDbt):
+    print_run_info([script])
+    logger.debug("Running script {}", script.id)
+    try:
+        with _modify_path(fal_dbt):
+            script.exec(fal_dbt)
+    except:
+        logger.error("Error in script {}:\n{}", script.id, traceback.format_exc())
+        # TODO: what else to do?
+        status = FAILURE
+    else:
+        status = SUCCESS
+    finally:
+        logger.debug("Finished script {}", script.id)
+
+    return status
+
+
+@contextmanager
+def _modify_path(fal_dbt: FalDbt):
+    sys.path.append(fal_dbt.scripts_dir)
+    yield
+    sys.path.remove(fal_dbt.scripts_dir)
+
+
+@dataclass
+class DBTTask(Task):
+    model_ids: list[str]
+    _run_index: int = -1
+
+    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
+        from fal.cli.dbt_runner import dbt_run
+
+        assert self._run_index != -1
+
+        model_names = _unique_ids_to_model_names(self.model_ids)
+        output = dbt_run(
+            args,
+            model_names,
+            fal_dbt.target_path,
+            self._run_index
+        )
+
+        for node, status in _map_cli_output_model_statuses(output.run_results):
+            _mark_dbt_nodes_status(fal_dbt, status, node)
+
+        return output.return_code
+
+
+@dataclass
+class FalModelTask(DBTTask):
+    bound_model: DbtModel | None = None
+
+    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
+        # Run the ephemeral model
+        dbt_result = super().execute(args, fal_dbt)
+
+        # And then run the Python script if it didn't fail.
+        if dbt_result != SUCCESS:
+            return dbt_result
+
+        assert self.bound_model is not None
+        bound_script = FalScript.model_script(fal_dbt, self.bound_model)
+        script_result = _run_script(bound_script, fal_dbt=fal_dbt)
+
+        status = NodeStatus.Success if script_result == SUCCESS else NodeStatus.Error
+        _mark_dbt_nodes_status(fal_dbt, status, self.bound_model.unique_id)
+        return script_result
+
+
+@dataclass
+class FalHookTask(Task):
+    hook_path: str
+    bound_model: DbtModel | None = None
+
+    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
+        script = FalScript(fal_dbt, self.bound_model, self.hook_path, True)
+        return _run_script(script, fal_dbt=fal_dbt)
+
+
+@dataclass
+class Node:
+    task: Task
+    post_hooks: list[Task] = field(default_factory=list)
+    dependencies: list[Node] = field(default_factory=list)
+
+    def exit(self, status: int) -> None:
+        if status != SUCCESS:
+            raise RuntimeError("Error !!!")
+
+    def set_run_index(self, run_index: int) -> None:
+        if isinstance(self.task, DBTTask):
+            self.task._run_index = run_index
+
+    @cached_property
+    def id(self) -> str:
+        return str(uuid.uuid4())

--- a/tests/planner/data.py
+++ b/tests/planner/data.py
@@ -1,35 +1,36 @@
+from fal.node_graph import NodeKind
 from tests.planner.utils import to_graph
 
 GRAPH_1 = [
-    ("A", {"kind": "dbt model", "post-hook": ["S1", "S2"], "to": ["B"]}),
-    ("B", {"kind": "dbt model", "post-hook": ["S3", "S4"], "to": ["E"]}),
-    ("C", {"kind": "dbt model", "to": ["D"]}),
-    ("D", {"kind": "dbt model", "to": ["E"]}),
-    ("E", {"kind": "python model", "post-hook": ["S5"], "to": ["F"]}),
-    ("F", {"kind": "dbt model"}),
+    ("A", {"kind": NodeKind.DBT_MODEL, "post-hook": ["S1", "S2"], "to": ["B"]}),
+    ("B", {"kind": NodeKind.DBT_MODEL, "post-hook": ["S3", "S4"], "to": ["E"]}),
+    ("C", {"kind": NodeKind.DBT_MODEL, "to": ["D"]}),
+    ("D", {"kind": NodeKind.DBT_MODEL, "to": ["E"]}),
+    ("E", {"kind": NodeKind.FAL_MODEL, "post-hook": ["S5"], "to": ["F"]}),
+    ("F", {"kind": NodeKind.DBT_MODEL}),
 ]
 
 GRAPH_2 = [
     (
         "A",
         {
-            "kind": "dbt model",
+            "kind": NodeKind.DBT_MODEL,
             "post-hook": ["SA1", "SA2", "SA3"],
             "to": ["B", "B1", "B2"],
         },
     ),
-    ("B", {"kind": "dbt model", "post-hook": ["SB1"], "to": ["L"]}),
-    ("B1", {"kind": "dbt model", "to": ["D"]}),
-    ("B2", {"kind": "dbt model", "to": ["D"]}),
-    ("C", {"kind": "dbt model", "to": ["D"]}),
-    ("D", {"kind": "dbt model", "post-hook": ["SD1"], "to": ["E"]}),
-    ("E", {"kind": "dbt model", "to": ["F"]}),
-    ("F", {"kind": "dbt model", "to": ["G"]}),
-    ("G", {"kind": "dbt model", "to": ["H", "J"]}),
-    ("H", {"kind": "python model", "to": ["K"]}),
-    ("J", {"kind": "dbt model", "to": ["K"]}),
-    ("K", {"kind": "dbt model", "post-hook": ["SK1"], "to": ["L"]}),
-    ("L", {"kind": "dbt model", "post-hook": ["SL1"]}),
+    ("B", {"kind": NodeKind.DBT_MODEL, "post-hook": ["SB1"], "to": ["L"]}),
+    ("B1", {"kind": NodeKind.DBT_MODEL, "to": ["D"]}),
+    ("B2", {"kind": NodeKind.DBT_MODEL, "to": ["D"]}),
+    ("C", {"kind": NodeKind.DBT_MODEL, "to": ["D"]}),
+    ("D", {"kind": NodeKind.DBT_MODEL, "post-hook": ["SD1"], "to": ["E"]}),
+    ("E", {"kind": NodeKind.DBT_MODEL, "to": ["F"]}),
+    ("F", {"kind": NodeKind.DBT_MODEL, "to": ["G"]}),
+    ("G", {"kind": NodeKind.DBT_MODEL, "to": ["H", "J"]}),
+    ("H", {"kind": NodeKind.FAL_MODEL, "to": ["K"]}),
+    ("J", {"kind": NodeKind.DBT_MODEL, "to": ["K"]}),
+    ("K", {"kind": NodeKind.DBT_MODEL, "post-hook": ["SK1"], "to": ["L"]}),
+    ("L", {"kind": NodeKind.DBT_MODEL, "post-hook": ["SL1"]}),
 ]
 
 

--- a/tests/planner/data.py
+++ b/tests/planner/data.py
@@ -38,6 +38,10 @@ GRAPHS = [
     {"graph": to_graph(GRAPH_1), "subgraphs": set()},
     {
         "graph": to_graph(GRAPH_2),
-        "subgraphs": {frozenset(("B1", "B2")), frozenset(("E", "F", "G"))},
+        "subgraphs": {
+            frozenset(("B1", "B2")),
+            frozenset(("E", "F", "G", "H")),
+            frozenset(("J", "K")),
+        },
     },
 ]

--- a/tests/planner/data.py
+++ b/tests/planner/data.py
@@ -1,0 +1,42 @@
+from tests.planner.utils import to_graph
+
+GRAPH_1 = [
+    ("A", {"kind": "dbt model", "post-hook": ["S1", "S2"], "to": ["B"]}),
+    ("B", {"kind": "dbt model", "post-hook": ["S3", "S4"], "to": ["E"]}),
+    ("C", {"kind": "dbt model", "to": ["D"]}),
+    ("D", {"kind": "dbt model", "to": ["E"]}),
+    ("E", {"kind": "python model", "post-hook": ["S5"], "to": ["F"]}),
+    ("F", {"kind": "dbt model"}),
+]
+
+GRAPH_2 = [
+    (
+        "A",
+        {
+            "kind": "dbt model",
+            "post-hook": ["SA1", "SA2", "SA3"],
+            "to": ["B", "B1", "B2"],
+        },
+    ),
+    ("B", {"kind": "dbt model", "post-hook": ["SB1"], "to": ["L"]}),
+    ("B1", {"kind": "dbt model", "to": ["D"]}),
+    ("B2", {"kind": "dbt model", "to": ["D"]}),
+    ("C", {"kind": "dbt model", "to": ["D"]}),
+    ("D", {"kind": "dbt model", "post-hook": ["SD1"], "to": ["E"]}),
+    ("E", {"kind": "dbt model", "to": ["F"]}),
+    ("F", {"kind": "dbt model", "to": ["G"]}),
+    ("G", {"kind": "dbt model", "to": ["H", "J"]}),
+    ("H", {"kind": "python model", "to": ["K"]}),
+    ("J", {"kind": "dbt model", "to": ["K"]}),
+    ("K", {"kind": "dbt model", "post-hook": ["SK1"], "to": ["L"]}),
+    ("L", {"kind": "dbt model", "post-hook": ["SL1"]}),
+]
+
+
+GRAPHS = [
+    {"graph": to_graph(GRAPH_1), "subgraphs": set()},
+    {
+        "graph": to_graph(GRAPH_2),
+        "subgraphs": {frozenset(("B1", "B2")), frozenset(("E", "F", "G"))},
+    },
+]

--- a/tests/planner/test_plan.py
+++ b/tests/planner/test_plan.py
@@ -1,0 +1,19 @@
+import networkx as nx
+import pytest
+from tests.planner.data import GRAPHS
+
+from fal.planner.plan import plan_graph
+
+
+@pytest.mark.parametrize("graph_info", GRAPHS)
+def test_planner_sub_graphs(graph_info):
+    graph = graph_info["graph"]
+    new_graph = plan_graph(graph)
+
+    subgraphs = [
+        maybe_subgraph
+        for maybe_subgraph in new_graph.nodes
+        if isinstance(maybe_subgraph, nx.DiGraph)
+    ]
+
+    assert {frozenset(subgraph.nodes) for subgraph in subgraphs} == graph_info["subgraphs"]

--- a/tests/planner/test_schedule.py
+++ b/tests/planner/test_schedule.py
@@ -1,0 +1,107 @@
+from collections import defaultdict
+
+import networkx as nx
+import pytest
+
+from fal.node_graph import DbtModelNode, NodeGraph, NodeKind
+from fal.planner.plan import plan_graph
+from fal.planner.schedule import SUCCESS, schedule_graph
+from fal.planner.tasks import DBTTask, FalModelTask
+from tests.planner.data import GRAPH_1, GRAPHS
+from tests.planner.utils import to_graph
+
+
+class ModelDict(defaultdict):
+    def get(self, key) -> None:
+        return super().__getitem__(key)
+
+
+def test_scheduler():
+    graph = to_graph(GRAPH_1)
+    new_graph = plan_graph(graph)
+    node_graph = NodeGraph(graph, ModelDict(lambda: DbtModelNode("...", None)))
+    node_queue = schedule_graph(new_graph, node_graph)
+
+    # A -> B \
+    #          -> E -> F
+    # C -> D /
+
+    node_A, node_C = node_queue.iter_available_nodes()
+    assert node_A.task.model_ids == ["A"]
+    assert node_C.task.model_ids == ["C"]
+
+    # When both A and C are still running, the scheduler shouldn't
+    # yield anything.
+    assert len(list(node_queue.iter_available_nodes())) == 0
+
+    # But when A is unblocked, it can successfully yield B
+    node_queue.finish(node_A, SUCCESS)
+    (node_B,) = node_queue.iter_available_nodes()
+    assert node_B.task.model_ids == ["B"]
+
+    # The rest of the graph is still blocked
+    assert len(list(node_queue.iter_available_nodes())) == 0
+
+    # When C is done, it should yield D
+    node_queue.finish(node_C, SUCCESS)
+    (node_D,) = node_queue.iter_available_nodes()
+    assert node_D.task.model_ids == ["D"]
+
+    # And when both B and D are done, it will yield E
+    node_queue.finish(node_B, SUCCESS)
+    node_queue.finish(node_D, SUCCESS)
+    (node_E,) = node_queue.iter_available_nodes()
+    assert node_E.task.model_ids == ["E"]
+
+    # And finally when E is done, it will yield F
+    node_queue.finish(node_E, SUCCESS)
+    (node_F,) = node_queue.iter_available_nodes()
+    assert node_F.task.model_ids == ["F"]
+
+
+@pytest.mark.parametrize("graph_info", GRAPHS)
+def test_scheduler_task_separation(graph_info):
+    graph = graph_info["graph"]
+    new_graph = plan_graph(graph)
+    node_graph = NodeGraph(graph, ModelDict(lambda: DbtModelNode("...", None)))
+    node_queue = schedule_graph(new_graph, node_graph)
+
+    all_dbt_tasks, all_fal_tasks, all_post_hooks = set(), set(), set()
+    for node in node_queue.nodes:
+        if isinstance(node.task, FalModelTask):
+            all_fal_tasks.update(node.task.model_ids)
+        elif isinstance(node.task, DBTTask):
+            all_dbt_tasks.update(node.task.model_ids)
+
+        all_post_hooks.update(post_hook.hook_path for post_hook in node.post_hooks)
+
+    assert all_dbt_tasks == set(
+        nx.subgraph_view(
+            graph,
+            lambda node: graph.nodes[node]["kind"] is NodeKind.DBT_MODEL,
+        )
+    )
+    assert all_fal_tasks == set(
+        nx.subgraph_view(
+            graph,
+            lambda node: graph.nodes[node]["kind"] is NodeKind.FAL_MODEL,
+        )
+    )
+    assert all_post_hooks == {
+        post_hook
+        for properties in graph.nodes.values()
+        for post_hook in properties.get("post-hook", [])
+    }
+
+
+@pytest.mark.parametrize("graph_info", GRAPHS)
+def test_scheduler_dependency_management(graph_info):
+    graph = graph_info["graph"]
+    new_graph = plan_graph(graph)
+    node_graph = NodeGraph(graph, ModelDict(lambda: DbtModelNode("...", None)))
+    node_queue = schedule_graph(new_graph, node_graph)
+
+    while node_queue:
+        for node in node_queue.iter_available_nodes():
+            assert not node.dependencies
+            node_queue.finish(node, SUCCESS)

--- a/tests/planner/test_schedule.py
+++ b/tests/planner/test_schedule.py
@@ -69,7 +69,9 @@ def test_scheduler_task_separation(graph_info):
     all_dbt_tasks, all_fal_tasks, all_post_hooks = set(), set(), set()
     for node in node_queue.nodes:
         if isinstance(node.task, FalModelTask):
-            all_fal_tasks.update(node.task.model_ids)
+            *dbt_tasks, python_task = node.task.model_ids
+            all_dbt_tasks.update(dbt_tasks)
+            all_fal_tasks.add(python_task)
         elif isinstance(node.task, DBTTask):
             all_dbt_tasks.update(node.task.model_ids)
 

--- a/tests/planner/test_tasks.py
+++ b/tests/planner/test_tasks.py
@@ -1,0 +1,90 @@
+import pytest
+from dataclasses import dataclass, field
+from fal.planner.tasks import SUCCESS, FAILURE, DBTTask, FalModelTask, FalHookTask
+
+
+@dataclass
+class FakeCLIOutput:
+    return_code: int
+    run_results: dict
+
+
+@dataclass
+class FakeFalDbt:
+    target_path: str
+    models: list = field(default_factory=list)
+
+
+@dataclass
+class FakeModel:
+    unique_id: str
+
+
+class FakeScript:
+    pass
+
+
+def mock_dbt_run(mocker, return_code):
+    mocker.patch(
+        "fal.cli.dbt_runner.dbt_run",
+        return_value=FakeCLIOutput(return_code, {}),
+    )
+    mocker.patch(
+        "fal.planner.tasks._map_cli_output_model_statuses",
+        return_value=[],
+    )
+
+
+def mock_script_construction(mocker, return_code):
+    mocker.patch(
+        "fal.fal_script.FalScript.__new__",
+        return_value=FakeScript(),
+    )
+    mocker.patch(
+        "fal.fal_script.FalScript.model_script",
+        return_value=FakeScript(),
+    )
+    mocker.patch(
+        "fal.planner.tasks._run_script",
+        return_value=return_code,
+    )
+
+
+@pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
+def test_dbt_task(mocker, return_code):
+    task = DBTTask(["a", "b"])
+    task._run_index = 1
+
+    fal_dbt = FakeFalDbt("/test")
+    mock_dbt_run(mocker, return_code)
+    assert task.execute(None, fal_dbt) == return_code
+
+
+def test_fal_model_task_when_dbt_fails(mocker):
+    task = FalModelTask(["a", "b"])
+    task._run_index = 1
+
+    fal_dbt = FakeFalDbt("/test")
+    mock_dbt_run(mocker, FAILURE)
+    assert task.execute(None, fal_dbt) == FAILURE
+
+
+@pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
+def test_fal_model_task_when_dbt_succeeds(mocker, return_code):
+    task = FalModelTask(["a", "b"], bound_model=FakeModel("model"))
+    task._run_index = 1
+
+    fal_dbt = FakeFalDbt("/test")
+    mock_dbt_run(mocker, SUCCESS)
+    mock_script_construction(mocker, return_code)
+    assert task.execute(None, fal_dbt) == return_code
+
+
+@pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
+def test_fal_hook(mocker, return_code):
+    task = FalHookTask("something.py", bound_model=FakeModel("model"))
+    task._run_index = 1
+
+    fal_dbt = FakeFalDbt("/test")
+    mock_script_construction(mocker, return_code)
+    assert task.execute(None, fal_dbt) == return_code

--- a/tests/planner/utils.py
+++ b/tests/planner/utils.py
@@ -9,7 +9,8 @@ def to_graph(data: list[tuple[str, dict[str, Any]]]) -> nx.DiGraph:
     graph = nx.DiGraph()
 
     nodes, edges = [], []
-    for node, properties in data:
+    for node, _properties in data:
+        properties = _properties.copy()
         edges.extend((node, edge) for edge in properties.pop("to", []))
         nodes.append((node, properties))
 

--- a/tests/planner/utils.py
+++ b/tests/planner/utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+
+
+def to_graph(data: list[tuple[str, dict[str, Any]]]) -> nx.DiGraph:
+    graph = nx.DiGraph()
+
+    nodes, edges = [], []
+    for node, properties in data:
+        edges.extend((node, edge) for edge in properties.pop("to", []))
+        nodes.append((node, properties))
+
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
+    return graph


### PR DESCRIPTION
We now allow ephemeral models to act like exit nodes. Previously we only supported DBT nodes to be exit nodes, but with this patch pure Python models are also supported.