### PR TITLE
tests: allow representing parallel executions in order tests

### DIFF
--- a/integration_tests/features/flow_run_order.feature
+++ b/integration_tests/features/flow_run_order.feature
@@ -9,7 +9,12 @@ Feature: `flow run` command with ensured order
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select middle_1+
       """
     Then the following nodes are calculated in the following order:
-      | middle_1 | middle_2 | after_middle | middle_2.middle_script.py |
+      """
+      1. middle_1
+      2. middle_2
+      3. after_middle,
+      4. middle_2.middle_script.py
+      """
 
   Scenario: fal flow run order with --experimental-flow
     When the following command is invoked:
@@ -17,7 +22,12 @@ Feature: `flow run` command with ensured order
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-flow --select middle_1+
       """
     Then the following nodes are calculated in the following order:
-      | middle_1 | middle_2 | middle_2.middle_script.py | after_middle |
+      """
+      1. middle_1
+      2. middle_2
+      3. middle_2.middle_script.py
+      4. after_middle
+      """
 
   Scenario: fal flow run order with pure python models
     Given the project 008_pure_python_models
@@ -28,7 +38,14 @@ Feature: `flow run` command with ensured order
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --exclude broken_model
       """
     Then the following nodes are calculated in the following order:
-      | model_a | model_a.after.py | model_b | model_c.py | model_c.post_hook.py | model_c.after.py | model_d | model_e.ipynb | model_e.after.py |
+      """
+      1. model_a
+      2. model_a.after.py
+      3. model_b
+      4. model_c.py
+      5. model_c.post_hook.py, model_c.after.py
+      6. model_d, model_e.ipynb, model_e.after.py
+      """
 
   Scenario: fal flow run order with pure python models on a selection
     Given the project 008_pure_python_models
@@ -39,4 +56,7 @@ Feature: `flow run` command with ensured order
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --select model_c
       """
     Then the following nodes are calculated in the following order:
-      | model_c.py | model_c.post_hook.py |
+      """
+      1. model_c.py
+      2. model_c.post_hook.py
+      """


### PR DESCRIPTION
We are switching from tables to our own format, since tables in cucumber needs to have the exact same number of columns in each row which is something that doesn't quite work for us (see the examples below). This PR adds a new way to write order based tests, with the ability of specifiying whether a row might be executed in parallel.

```
    Then the following nodes are calculated in the following order:
      """
      1. model_a, model_a.after.py, model_b, model_c.py
      2. (unordered) model_c.post_hook.py, model_c.after.py
      3. (unordered) model_d, model_e.ipynb, model_e.after.py
      """
```