### PR TITLE
chore: Bug report template details

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,8 +4,9 @@ about: Report an issue to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
+
+<!-- *** Make sure you have searched for an existing bug report for this issue *** -->
 
 **Describe the bug**
 Please describe the issue.
@@ -13,10 +14,10 @@ Please describe the issue.
 **Your environment**
 - OS: 
 - Paste the following commands output:
-  ```
-  fal --version
-  dbt --version
-  ```
+```
+fal --version
+dbt --version
+```
 - Adapter being used: <!-- (if more than one dbt plugin installed) --> 
 
 **How to reproduce**
@@ -33,6 +34,3 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
-
-**Is there an existing bug report for this?**
- * [ ]  I have searched the existing issues


### PR DESCRIPTION
Sometimes `Paste the following commands output` with indentation would break the formatting.