### PR TITLE
fix: stop resetting adapters to avoid connections being lost

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,9 +49,9 @@ jobs:
         env:
           FAL_STATS_ENABLED: false
         run: |
+          BEHAVE_ARGS=""
           if [[ '${{ matrix.dbt }}' =~ ^0.*$ ]]
           then
-            behave --tags=-dbtv1
-          else
-            behave
+            BEHAVE_ARGS="$BEHAVE_ARGS --tags=-dbtv1"
           fi
+          behave $BEHAVE_ARGS

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -275,7 +275,7 @@ Feature: `flow run` command
       """
       fal flow run --profiles-dir profiles/broken --project-dir $baseDir --select zendesk_ticket_data --threads 1
       """
-    Then it throws an exception RuntimeError with message 'Error running dbt run'
+    Then it throws an exception RuntimeError with message 'Error in script'
 
     When the following command is invoked:
       """

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -68,6 +68,12 @@ def initialize_dbt_flags(profiles_dir: str):
         flags.ENABLE_LEGACY_LOGGER = "1"
 
 
+def register_adapters(config: RuntimeConfig):
+    # HACK: to avoid 'Node package named <profile> not found'
+    adapters_factory.reset_adapters()
+    adapters_factory.register_adapter(config)
+
+
 # NOTE: Once we get an adapter, we must call `connection_for` or `connection_named` to use it
 def _get_adapter(
     project_dir: str,
@@ -177,10 +183,6 @@ def compile_sql(
         )
 
     manifest = parse.get_dbt_manifest(config)
-
-    # HACK: to avoid 'Node package named <profile> not found'
-    adapters_factory.reset_adapters()
-    adapters_factory.register_adapter(config)
 
     adapter = _get_adapter(project_dir, profiles_dir, profile_target, config)
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -373,6 +373,8 @@ class FalDbt:
                 profile_target=profile_target,
             )
 
+        lib.register_adapters(self._config)
+
         el_configs = parse.get_el_configs(
             self.profiles_dir, self._config.profile_name, self._config.target_name
         )


### PR DESCRIPTION
From the logs I got from a user, which had this:

```
...
dbt.exceptions.InvalidConnectionException: Runtime Error
  connection never acquired for thread (6013, 140139196045056), have []
```

I remembered having this same issue when introducing parallelization. So I looked at the relevant code changes and found 

https://github.com/fal-ai/fal/blob/9aec7f15277e01c47597898d647e93d828c89212/src/faldbt/lib.py#L77

Commit: https://github.com/fal-ai/fal/commit/7d9d3738fae255a6851c89a12d92eb8db24efb6f#diff-644c7d4ee481dd1f7f2e070dc15c876e1d4c6b84af31ae5ce8fade10ef136d52L77-L78

Which was the culprit for that problem. But we also had introduced those instructions in compile_sql because it would not work without it.

https://github.com/fal-ai/fal/blob/fc8e0b68d84a8a7400d68832f97ae1f79a1fd0e7/src/faldbt/lib.py#L165-L167

Commit: https://github.com/fal-ai/fal/commit/e015d1b1e4240915c8ea2f4a8f8686196f23a7a3#diff-644c7d4ee481dd1f7f2e070dc15c876e1d4c6b84af31ae5ce8fade10ef136d52R165-R167

Now we run that code only once during start-up time and it works.
