### PR TITLE
tests: add a little delay to the post-hook script

### DIFF
--- a/integration_tests/projects/008_pure_python_models/scripts/post_hook.py
+++ b/integration_tests/projects/008_pure_python_models/scripts/post_hook.py
@@ -1,6 +1,12 @@
 import pandas as pd
 from functools import reduce
 import os
+import time
+
+# Delay just a little bit in order to make sure the file is created
+# just after the model file.
+time.sleep(0.05)
+
 
 model_name = context.current_model.name
 


### PR DESCRIPTION
The `features/flow_run_order.feature:50` test randomly fails, and from what I've gathered it seems like the timings are the problem. I am not sure whether it is definitely resolved, but I've run it ~10 times locally and it didn't fail yet.