### PR TITLE
feat: BigQuery improvements for table write and replace

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           FAL_STATS_ENABLED: false
         run: |
-          BEHAVE_ARGS=""
+          BEHAVE_ARGS="--tags=-TODO-postgres"
           if [[ '${{ matrix.dbt }}' =~ ^0.*$ ]]
           then
             BEHAVE_ARGS="$BEHAVE_ARGS --tags=-dbtv1"

--- a/integration_tests/features/write_to_model_function.feature
+++ b/integration_tests/features/write_to_model_function.feature
@@ -13,11 +13,11 @@ Feature: `write_to_model` function
     And the following scripts are ran:
       | some_model.write_to_source_twice.py | other_model.complete_model.py | third_model.complete_model.py |
     And the script other_model.complete_model.py output file has the lines:
-      | my_float None | my_float 2.3 | size 1 |
+      | my_int None | my_int 3.0 | size 1 |
     And the script third_model.complete_model.py output file has the lines:
-      | my_float None | my_float 2.3 | size 1 |
+      | my_int None | my_int 3.0 | size 1 |
     And the script some_model.write_to_source_twice.py output file has the lines:
-      | my_float 2.3 |
+      | my_float 1.2 |
 
   Scenario: Use write_to_model function with mode overwrite
     When the following command is invoked:
@@ -29,4 +29,32 @@ Feature: `write_to_model` function
     And the following scripts are ran:
       | other_model.complete_model.py |
     And the script other_model.complete_model.py output file has the lines:
-      | my_float None | my_float 2.3 | size 1 |
+      | my_int None | my_int 3.0 | size 1 |
+
+  @TODO-postgres
+  @TODO-snowflake
+  @TODO-duckdb
+  @TODO-redshift
+  Scenario: Write a datetime to the datawarehouse
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --select model_with_date
+      """
+    Then the following models are calculated:
+      | model_with_date.py |
+    And the script model_with_date.py output file has the lines:
+      | my_date: 2022-01-01 00:00:00+00:00 |
+
+  @TODO-postgres
+  @TODO-snowflake
+  @TODO-duckdb
+  @TODO-redshift
+  Scenario: Write a string and int array to the datawarehouse
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --experimental-models --select model_with_array
+      """
+    Then the following models are calculated:
+      | model_with_array.py |
+    And the script model_with_array.py output file has the lines:
+      | my_array: ["some", "other"] | other_array: [1, 2, 3] |

--- a/integration_tests/projects/005_functions_and_variables/fal_scripts/complete_model.py
+++ b/integration_tests/projects/005_functions_and_variables/fal_scripts/complete_model.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from functools import reduce
-from sqlalchemy import Integer
 import os
 
 model_name = context.current_model.name
@@ -10,16 +9,19 @@ output = ""
 
 df: pd.DataFrame = ref(model_name)
 df.columns = df.columns.str.lower()  # Snowflake has uppercase columns
-output += f"my_float {df.my_float[0]}\n"
+output += f"my_int {df.my_int[0]}\n"
 
-df.my_float = 2.3
+df.my_int = 3
 write_to_model(df, mode="append")
-write_to_model(df, dtype={"my_float": Integer})
+
+float_df = df.astype({"my_int": float})
+write_to_model(float_df)
+
 write_to_model(df)  # default: overwrite
 
 df: pd.DataFrame = ref(model_name)
 df.columns = df.columns.str.lower()  # Snowflake has uppercase columns
-output += f"my_float {df.my_float[0]}\n"
+output += f"my_int {df.my_int[0]}\n"
 output += f"size {len(df)}\n"
 
 

--- a/integration_tests/projects/005_functions_and_variables/fal_scripts/write_to_source_twice.py
+++ b/integration_tests/projects/005_functions_and_variables/fal_scripts/write_to_source_twice.py
@@ -9,6 +9,7 @@ output = ""
 
 df: pd.DataFrame = ref(model_name)
 df.columns = df.columns.str.lower()  # Snowflake has uppercase columns
+
 output += f"my_float {df.my_float[0]}\n"
 
 write_to_source(df, "results", "some_source", mode="overwrite")

--- a/integration_tests/projects/005_functions_and_variables/models/model_with_array.py
+++ b/integration_tests/projects/005_functions_and_variables/models/model_with_array.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import os
+
+df = pd.DataFrame(
+    {
+        "my_array": [["some", "other"], []],
+        "other_array": [[1, 2, 3], []],
+    }
+)
+
+df.info()
+
+write_to_model(df)
+
+model_name = context.current_model.name
+df = ref(model_name)
+output = f"my_array: {df['my_array'][0]}"
+output += f"\nother_array: {df['other_array'][0]}"
+temp_dir = os.environ["temp_dir"]
+with open(os.path.join(temp_dir, model_name + ".txt"), "w") as file:
+    file.write(output)

--- a/integration_tests/projects/005_functions_and_variables/models/model_with_date.py
+++ b/integration_tests/projects/005_functions_and_variables/models/model_with_date.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from datetime import datetime as dt
+import os
+
+df = pd.DataFrame({"my_date": [dt(2022, 1, 1, 0, 0, 0), dt.now()]})
+
+df.info()
+
+write_to_model(df)
+
+model_name = context.current_model.name
+df = ref(model_name)
+output = f"my_date: {df['my_date'][0]}"
+temp_dir = os.environ["temp_dir"]
+with open(os.path.join(temp_dir, model_name + ".txt"), "w") as file:
+    file.write(output)

--- a/integration_tests/projects/005_functions_and_variables/models/other_model.sql
+++ b/integration_tests/projects/005_functions_and_variables/models/other_model.sql
@@ -5,7 +5,7 @@ WITH data AS (
     SELECT
         'some text' AS my_text,
         -- The following column will be filled in an after script with fal
-        cast(NULL AS numeric) AS my_float
+        cast(NULL AS integer) AS my_int
 )
 
 SELECT *

--- a/integration_tests/projects/005_functions_and_variables/models/schema.yml
+++ b/integration_tests/projects/005_functions_and_variables/models/schema.yml
@@ -24,7 +24,6 @@ models:
       - name: my_int
         tests:
           - not_null
-
     meta:
       fal:
         scripts:
@@ -37,6 +36,7 @@ models:
         scripts:
           after:
             - fal_scripts/complete_model.py
+
   - name: third_model
     meta:
       fal:

--- a/integration_tests/projects/005_functions_and_variables/models/some_model.sql
+++ b/integration_tests/projects/005_functions_and_variables/models/some_model.sql
@@ -2,10 +2,10 @@
 
 WITH data AS (
     SELECT 
-        cast(1 AS integer) AS my_int,
+        1.2 AS my_float,
         my_text, 
         -- the after script value should reflect here
-        my_float
+        my_int
     FROM {{ ref('other_model') }}
 )
 

--- a/integration_tests/projects/005_functions_and_variables/models/third_model.sql
+++ b/integration_tests/projects/005_functions_and_variables/models/third_model.sql
@@ -5,7 +5,7 @@ WITH data AS (
     SELECT
         'some text' AS my_text,
         -- The following column will be filled in an after script with fal
-        cast(NULL AS numeric) AS my_float
+        cast(NULL AS integer) AS my_int
 )
 
 SELECT *

--- a/integration_tests/projects/008_pure_python_models/models/staging/model_c.py
+++ b/integration_tests/projects/008_pure_python_models/models/staging/model_c.py
@@ -4,11 +4,15 @@ DEPENDENCY: ref("model_b")
 """
 import os
 from functools import reduce
+from datetime import datetime
 
-# weird way to call, but added in the docstring
+# does not get picked up, so we put it in the docstring
 df = ref(*["model_b"])
 
 df["my_bool"] = True
+
+# BigQuery only:
+# df["my_ts"] = datetime(2022, 6, 27, 17, 12, 25)
 
 write_to_model(df)
 

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -220,7 +220,10 @@ def execute_sql(
 
 
 def fetch_target(
-    project_dir: str, profiles_dir: str, target: CompileResultNode, profile_target=None
+    project_dir: str,
+    profiles_dir: str,
+    target: CompileResultNode,
+    profile_target: str,
 ) -> RemoteRunResult:
     relation = _get_target_relation(
         target, project_dir, profiles_dir, profile_target=profile_target
@@ -229,6 +232,12 @@ def fetch_target(
     if relation is None:
         raise Exception(f"Could not get relation for '{target.unique_id}'")
 
+    return _fetch_relation(project_dir, profiles_dir, profile_target, relation)
+
+
+def _fetch_relation(
+    project_dir: str, profiles_dir: str, profile_target: str, relation: BaseRelation
+) -> RemoteRunResult:
     query = f"SELECT * FROM {relation}"
     _, result = _execute_sql(
         project_dir, profiles_dir, query, profile_target=profile_target
@@ -275,6 +284,16 @@ def overwrite_target(
     adapter = _get_adapter(project_dir, profiles_dir, profile_target)
 
     relation = _build_table_from_target(adapter, target)
+
+    if adapter.type() == "bigquery":
+        return _bigquery_write_relation(
+            data,
+            project_dir,
+            profiles_dir,
+            relation,
+            profile_target,
+            mode=WriteModeEnum.OVERWRITE,
+        )
 
     # With some writing functions, it could be called twice at the same time for the same identifier
     # so we avoid overwriting temporal tables by attaching uniqueness to the name
@@ -323,6 +342,16 @@ def write_target(
 
     relation = _build_table_from_target(adapter, target)
 
+    if adapter.type() == "bigquery":
+        return _bigquery_write_relation(
+            data,
+            project_dir,
+            profiles_dir,
+            relation,
+            profile_target,
+            mode=WriteModeEnum.APPEND,
+        )
+
     return _write_relation(
         data, project_dir, profiles_dir, relation, dtype, profile_target=profile_target
     )
@@ -337,6 +366,8 @@ def _write_relation(
     profile_target: str = None,
 ) -> RemoteRunResult:
     adapter = _get_adapter(project_dir, profiles_dir, profile_target)
+
+    assert adapter.type() != "bigquery", "Should not have reached here with bigquery"
 
     database, schema, identifier = (
         relation.database,
@@ -503,3 +534,56 @@ def _alchemy_engine(adapter: SQLAdapter, database: Optional[str]):
         pass
 
     return sqlalchemy.create_mock_engine(url_string, executor=null_dump)
+
+
+def _bigquery_write_relation(
+    data: pd.DataFrame,
+    project_dir: str,
+    profiles_dir: str,
+    relation: BaseRelation,
+    profile_target: str,
+    mode: WriteModeEnum,
+) -> RemoteRunResult:
+    import google.cloud.bigquery as bigquery
+    from google.cloud.bigquery.job import WriteDisposition
+    from dbt.adapters.bigquery import BigQueryAdapter
+
+    adapter: BigQueryAdapter = _get_adapter(project_dir, profiles_dir, profile_target)  # type: ignore
+    assert adapter.type() == "bigquery"
+
+    disposition = (
+        WriteDisposition.WRITE_TRUNCATE
+        if WriteModeEnum.OVERWRITE == mode
+        else WriteDisposition.WRITE_APPEND
+    )
+
+    project: str = relation.database  # type: ignore
+    dataset: str = relation.schema  # type: ignore
+    table: str = relation.identifier  # type: ignore
+
+    # HACK: we need to include uniqueness (UUID4) to avoid clashes
+    name = "bigquery:write_relation:" + str(relation) + ":" + str(uuid4())
+    with adapter.connection_named(name):
+        conn = adapter.connections.get_thread_connection()
+        client: bigquery.Client = conn.handle  # type: ignore
+
+        table_ref = bigquery.TableReference(
+            bigquery.DatasetReference(project, dataset), table
+        )
+
+        job_config = bigquery.LoadJobConfig(
+            # Specify a (partial) schema. All columns are always written to the
+            # table. The schema is used to assist in data type definitions.
+            # TODO: use `dtype` for this? Offer a specialized option for BQ?
+            schema=[],
+            write_disposition=disposition,
+        )
+
+        job = client.load_table_from_dataframe(data, table_ref, job_config=job_config)
+
+    timeout = adapter.connections.get_job_execution_timeout_seconds(conn) or 300
+    with adapter.connections.exception_handler("LOAD TABLE"):
+        adapter.poll_until_job_completes(job, timeout)
+
+    # TODO: Do we really need this?
+    return _fetch_relation(project_dir, profiles_dir, profile_target, relation)

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -1,5 +1,6 @@
 # NOTE: INSPIRED IN https://github.com/dbt-labs/dbt-core/blob/43edc887f97e359b02b6317a9f91898d3d66652b/core/dbt/lib.py
 import six
+from enum import Enum
 from datetime import datetime
 from dataclasses import dataclass
 from uuid import uuid4
@@ -25,6 +26,12 @@ from pandas.io import sql as pdsql
 import sqlalchemy
 from sqlalchemy.sql.ddl import CreateTable
 from sqlalchemy.sql import Insert
+
+
+class WriteModeEnum(Enum):
+    APPEND = "append"
+    OVERWRITE = "overwrite"
+
 
 DBT_V1 = dbt.semver.VersionSpecifier.from_version_string("1.0.0")
 DBT_VCURRENT = dbt.version.get_installed_version()

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from enum import Enum
 import os.path
 import re
 from dataclasses import dataclass, field
@@ -26,6 +25,7 @@ from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.task.compile import CompileTask
 import dbt.tracking
 
+from .lib import WriteModeEnum
 from . import parse
 from . import lib
 from .el_client import FalElClient
@@ -312,11 +312,6 @@ class CompileArgs:
     exclude: Tuple[str]
     state: Optional[Path]
     single_threaded: Optional[bool]
-
-
-class WriteModeEnum(Enum):
-    APPEND = "append"
-    OVERWRITE = "overwrite"
 
 
 class FalDbt:


### PR DESCRIPTION
# Advantages
- [x] Native table overwrite
- [x] We can now write datetimes
- [x] We can now write arrays

# Support for large DataFrames

4.3m+ rows in BigQuery being read and written (I don't have the best internet...)

```
 ❯ fal flow run --select @questions --profiles-dir . --experimental-models

20:26:52  Unable to do partial parsing because config vars, config profile, or config target have changed
20:26:53  Found 9 models, 0 tests, 0 snapshots, 0 analyses, 191 macros, 0 operations, 3 seed files, 3 sources, 0 exposures, 0 metrics
Could not read dbt sources artifact
Executing command: dbt --log-format json run --project-dir /Users/matteo/Projects/fal/fal_dbt_examples --profiles-dir . --select stackoverflow_questions_small questions questions_analysis

Running with dbt=1.1.0
Found 9 models, 0 tests, 0 snapshots, 0 analyses, 191 macros, 0 operations, 3 seed files, 3 sources, 0 exposures, 0 metrics
The selection criterion 'stackoverflow_questions_small' does not match any nodes
Concurrency: 1 threads (target='dev')
1 of 1 START table model dbt_matteo.questions .................................. [RUN]
1 of 1 OK created table model dbt_matteo.questions ............................. [CREATE TABLE (4.3m rows, 643.1 MB processed) in 16.99s]
Finished running 1 table model in 19.12s.
Completed successfully
Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
16:36:48 | Starting fal run for following models and scripts:
(model: so_models/questions_analysis.py)

Concurrency: 1 threads
20:36:48  Unable to do partial parsing because config vars, config profile, or config target have changed

Read time: 2627.027376001 seconds

<class 'pandas.core.frame.DataFrame'>
RangeIndex: 4348921 entries, 0 to 4348920
Data columns (total 13 columns):
 #   Column              Dtype
---  ------              -----
 0   id                  float64
 1   title               object
 2   title_length        float64
 3   score               float64
 4   tags                object
 5   tags_amount         float64
 6   content_size        float64
 7   view_count          float64
 8   answer_count        float64
 9   comment_count       float64
 10  favorite_count      float64
 11  creation_date       datetime64[ns, UTC]
 12  last_activity_date  datetime64[ns, UTC]
dtypes: datetime64[ns, UTC](2), float64(9), object(2)
memory usage: 431.3+ MB

Write time: 1920.356228914 seconds
```

<details>
closes FEA-209
</details>