### PR TITLE
feat: allow selection of non-existent nodes

### DIFF
--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -297,3 +297,35 @@ Feature: `flow run` command
       | Status: success |
     And the script some_model.post_hook.py output file has the lines:
       | Status: error |
+
+  Scenario: fal flow run command with non-existent selectors
+    Given the project 001_flow_run_with_selectors
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select xxx yyy
+      """
+    Then no models are calculated
+
+  Scenario: fal flow run command with mixed non-existent selectors
+    Given the project 001_flow_run_with_selectors
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select intermediate_model_1 xxx yyy
+      """
+    Then the following models are calculated:
+      | intermediate_model_1 |
+
+  Scenario: fal flow run command with mixed non-existent selectors intersection
+    Given the project 001_flow_run_with_selectors
+    When the data is seeded
+
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select intermediate_model_1,xxx yyy intermediate_model_2
+      """
+    Then the following models are calculated:
+      | intermediate_model_2 |


### PR DESCRIPTION
This used to fail, now we just skip those failures (since DBT already shows the selection does not match any nodes, we don't need any extra logging).

```
$ temp_dir=$(mktemp -d) fal flow run --profiles-dir ../ --select model_X+     
12:39:41  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
12:39:41  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
Could not read dbt run_results artifact
12:39:41  Partial parse save file not found. Starting full parse.
12:39:42  Found 6 models, 0 tests, 0 snapshots, 0 analyses, 168 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
12:39:42  The selection criterion 'model_X+' does not match any nodes
Could not read dbt sources artifact
Traceback (most recent call last):
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/classes/digraph.py", line 815, in successors
    return iter(self._succ[n])
KeyError: 'model.fal_008.model_X'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/seaworth/.pyenv/versions/3.9.13/bin/fal", line 8, in <module>
    sys.exit(cli())
  File "/home/seaworth/projects/fal/src/fal/cli/cli.py", line 18, in cli
    _cli(argv)
  File "/home/seaworth/projects/fal/src/fal/telemetry/telemetry.py", line 338, in wrapper
    result = func(*func_args, **func_kwargs)
  File "/home/seaworth/projects/fal/src/fal/cli/cli.py", line 44, in _cli
    fal_flow_run(parsed)
  File "/home/seaworth/projects/fal/src/fal/cli/flow_runner.py", line 74, in fal_flow_run
    run_serial(fal_dbt=fal_dbt, parsed=parsed, node_graph=node_graph)
  File "/home/seaworth/projects/fal/src/fal/cli/flow_runner.py", line 41, in run_serial
    execution_plan = ExecutionPlan.create_plan_from_graph(parsed, node_graph, fal_dbt)
  File "/home/seaworth/projects/fal/src/fal/cli/selectors.py", line 46, in create_plan_from_graph
    ids_to_execute = _filter_node_ids(
  File "/home/seaworth/projects/fal/src/fal/cli/selectors.py", line 104, in _filter_node_ids
    plan_outputs = [
  File "/home/seaworth/projects/fal/src/fal/cli/selectors.py", line 105, in <listcomp>
    set(SelectorPlan(selector, unique_ids, fal_dbt).execute(nodeGraph))
  File "/home/seaworth/projects/fal/src/fal/cli/selectors.py", line 195, in execute
    children = nodeGraph.get_descendants(id)
  File "/home/seaworth/projects/fal/src/fal/node_graph.py", line 158, in get_descendants
    return list(nx.descendants(self.graph, id))
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/algorithms/dag.py", line 66, in descendants
    return {child for parent, child in nx.bfs_edges(G, source)}
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/algorithms/dag.py", line 66, in <setcomp>
    return {child for parent, child in nx.bfs_edges(G, source)}
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/algorithms/traversal/breadth_first_search.py", line 168, in bfs_edges
    yield from generic_bfs_edges(G, source, successors, depth_limit, sort_neighbors)
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/algorithms/traversal/breadth_first_search.py", line 76, in generic_bfs_edges
    queue = deque([(source, depth_limit, neighbors(source))])
  File "/home/seaworth/.pyenv/versions/3.9.13/lib/python3.9/site-packages/networkx/classes/digraph.py", line 817, in successors
    raise NetworkXError(f"The node {n} is not in the digraph.") from err
networkx.exception.NetworkXError: The node model.fal_008.model_X is not in the digraph.
```