### PR TITLE
feat: implement fal_results.json

### DIFF
--- a/src/fal/cli/flow_runner.py
+++ b/src/fal/cli/flow_runner.py
@@ -1,8 +1,7 @@
-from functools import reduce
 import json
-import os
+import copy
 from pathlib import Path
-from typing import Dict, List, Optional, cast, Union
+from typing import Any, Dict, Optional, cast, Union
 
 from fal.cli.fal_runner import create_fal_dbt
 from fal.cli.selectors import ExecutionPlan
@@ -12,8 +11,10 @@ from fal.node_graph import DbtModelNode, FalFlowNode, NodeGraph, ScriptNode
 from faldbt.project import FalDbt, NodeStatus
 import argparse
 
-RUN_RESULTS_FILE_NAME = "run_results.json"
+DBT_RUN_RESULTS_FILENAME = "run_results.json"
+FAL_RUN_RESULTS_FILENAME = "fal_results.json"
 RUN_RESULTS_KEY = "results"
+SCHEMA_KEY = "schema"
 
 
 def run_threaded(
@@ -83,47 +84,41 @@ def node_to_script(node: Union[FalFlowNode, None], fal_dbt: FalDbt) -> FalScript
         raise Exception(f"Cannot convert node to script. Node: {node}")
 
 
-def _combine_fal_run_results(target_path):
-    result_files = _get_fal_run_results(target_path)
+def _combine_fal_run_results(target_path: str) -> None:
+    target_path = Path(target_path)
+    dbt_run_results, fal_run_results = [], []
+    for path in target_path.glob("fal_results_*.json"):
+        assert path.is_file()
 
-    if not result_files:
+        results = _get_all_result_content(path)
+
+        if results.get(SCHEMA_KEY) != "fal":
+            dbt_run_results.append(results)
+        fal_run_results.append(results)
+
+        # Clear out files as we go.
+        path.unlink()
+
+    if not dbt_run_results:
         return
 
-    all_results = reduce(
-        lambda all, next: all.extend(_get_result_array(next)) or all,
-        result_files,
-        [],
-    )
+    # Use the last DBT result as the framework for putting
+    # the rest of the run results.
+    result_framework = dbt_run_results[-1]
 
-    last_run_result = _get_all_result_content(result_files[-1])
-    last_run_result[RUN_RESULTS_KEY] = all_results
-    run_result_file = os.path.join(target_path, RUN_RESULTS_FILE_NAME)
+    for file, results in [
+        (DBT_RUN_RESULTS_FILENAME, dbt_run_results),
+        (FAL_RUN_RESULTS_FILENAME, fal_run_results),
+    ]:
+        combined_results = copy.deepcopy(result_framework)
+        combined_results[RUN_RESULTS_KEY] = []
+        for result in results:
+            combined_results[RUN_RESULTS_KEY].extend(result[RUN_RESULTS_KEY])
 
-    # remove all run_results_*.json files for the next fal flow run
-    _remove_all(result_files)
-
-    with open(run_result_file, "w") as file:
-        file.write(json.dumps(last_run_result))
-        file.close()
-
-
-def _remove_all(files: List[str]):
-    for file in files:
-        os.remove(file) if os.path.exists(file) else None
+        with open(target_path / file, "w") as stream:
+            json.dump(combined_results, stream)
 
 
-def _get_all_result_content(file) -> Dict:
+def _get_all_result_content(file) -> Dict[str, Any]:
     with open(file) as content:
         return json.load(content)
-
-
-def _get_result_array(file) -> List[dict]:
-    return _get_all_result_content(file)[RUN_RESULTS_KEY]
-
-
-def _get_fal_run_results(target_path) -> List[str]:
-    run_result_files = map(
-        lambda x: str(x),
-        filter(lambda p: p.is_file(), Path(target_path).glob("fal_results_*.json")),
-    )
-    return list(run_result_files)

--- a/src/fal/cli/flow_runner.py
+++ b/src/fal/cli/flow_runner.py
@@ -14,7 +14,6 @@ import argparse
 DBT_RUN_RESULTS_FILENAME = "run_results.json"
 FAL_RUN_RESULTS_FILENAME = "fal_results.json"
 RUN_RESULTS_KEY = "results"
-SCHEMA_KEY = "schema"
 
 
 def run_threaded(
@@ -92,7 +91,7 @@ def _combine_fal_run_results(target_path: str) -> None:
 
         results = _get_all_result_content(path)
 
-        if results.get(SCHEMA_KEY) != "fal":
+        if "dbt_schema_version" in results.get("metadata", {}):
             dbt_run_results.append(results)
         fal_run_results.append(results)
 

--- a/src/fal/planner/tasks.py
+++ b/src/fal/planner/tasks.py
@@ -126,7 +126,7 @@ def run_script(script: FalScript, run_index: int) -> int:
     results = _run_script(script)
     run_results_file = Path(script.faldbt.target_path) / f"fal_results_{run_index}.json"
     with open(run_results_file, "w") as stream:
-        json.dump({"schema": "fal", "results": [results]}, stream)
+        json.dump({"results": [results]}, stream)
     return SUCCESS if results["status"] == NodeStatus.Success else FAILURE
 
 

--- a/src/fal/planner/tasks.py
+++ b/src/fal/planner/tasks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import threading
+import os
+import json
 from pathlib import Path
 import sys
 import traceback
@@ -13,15 +16,24 @@ from typing import Iterator, List, Any, Optional, Dict, Tuple
 from dbt.logger import GLOBAL_LOGGER as logger
 
 from fal.node_graph import FalScript
-from fal.utils import print_run_info
+from fal.utils import print_run_info, DynamicIndexProvider
 from faldbt.project import DbtModel, FalDbt, NodeStatus
+
+from datetime import datetime, timezone
 
 SUCCESS = 0
 FAILURE = 1
 
 
 class Task:
-    _run_index: int = -1
+    def set_run_index(self, index_provider: DynamicIndexProvider) -> None:
+        self._run_index = index_provider.next()
+
+    @property
+    def run_index(self) -> int:
+        run_index = getattr(self, "_run_index", None)
+        assert run_index is not None
+        return run_index
 
     def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
         raise NotImplementedError
@@ -71,22 +83,51 @@ def _map_cli_output_model_statuses(
         yield result["unique_id"], NodeStatus(result["status"])
 
 
-def _run_script(script: FalScript):
+def _run_script(script: FalScript) -> Dict[str, Any]:
     print_run_info([script])
-    logger.debug("Running script {}", script.id)
+
+    # DBT seems to be dealing with only UTC times
+    # so we'll follow that convention.
+    started_at = datetime.now(tz=timezone.utc)
     try:
         with _modify_path(script.faldbt):
             script.exec()
     except:
         logger.error("Error in script {}:\n{}", script.id, traceback.format_exc())
         # TODO: what else to do?
-        status = FAILURE
+        status = NodeStatus.Fail
     else:
-        status = SUCCESS
+        status = NodeStatus.Success
     finally:
         logger.debug("Finished script {}", script.id)
+        finished_at = datetime.now(tz=timezone.utc)
 
-    return status
+    return {
+        "path": str(script.path),
+        "unique_id": str(script.relative_path),
+        "status": status,
+        "thread_id": threading.current_thread().name,
+        "is_hook": script.is_hook,
+        "execution_time": (finished_at - started_at).total_seconds(),
+        "timing": [
+            {
+                "name": "execute",
+                # DBT's suffix for UTC is Z, but isoformat() uses +00:00. So
+                # we'll manually cast it to the proper format.
+                # https://stackoverflow.com/a/42777551
+                "started_at": started_at.isoformat().replace("+00:00", "Z"),
+                "finished_at": finished_at.isoformat().replace("+00:00", "Z"),
+            }
+        ],
+    }
+
+
+def run_script(script: FalScript, run_index: int) -> int:
+    results = _run_script(script)
+    run_results_file = Path(script.faldbt.target_path) / f"fal_results_{run_index}.json"
+    with open(run_results_file, "w") as stream:
+        json.dump({"schema": "fal", "results": [results]}, stream)
+    return SUCCESS if results["status"] == NodeStatus.Success else FAILURE
 
 
 @contextmanager
@@ -105,11 +146,9 @@ class DBTTask(Task):
     def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
         from fal.cli.dbt_runner import dbt_run_through_python
 
-        assert self._run_index != -1
-
         model_names = _unique_ids_to_model_names(self.model_ids)
         output = dbt_run_through_python(
-            args, model_names, fal_dbt.target_path, self._run_index
+            args, model_names, fal_dbt.target_path, self.run_index
         )
 
         for node, status in _map_cli_output_model_statuses(output.run_results):
@@ -122,9 +161,17 @@ class DBTTask(Task):
 class FalModelTask(DBTTask):
     bound_model: Optional[DbtModel] = None
 
-    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
-        assert self._run_index != -1
+    def set_run_index(self, index_provider: DynamicIndexProvider) -> None:
+        super().set_run_index(index_provider)
+        self._model_script_run_index = index_provider.next()
 
+    @property
+    def model_script_run_index(self) -> int:
+        run_index = getattr(self, "_model_script_run_index", None)
+        assert run_index is not None
+        return run_index
+
+    def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
         # Run the ephemeral model
         dbt_result = super().execute(args, fal_dbt)
 
@@ -134,7 +181,7 @@ class FalModelTask(DBTTask):
 
         assert self.bound_model is not None
         bound_script = FalScript.model_script(fal_dbt, self.bound_model)
-        script_result = _run_script(bound_script)
+        script_result = run_script(bound_script, self.model_script_run_index)
 
         status = NodeStatus.Success if script_result == SUCCESS else NodeStatus.Error
         _mark_dbt_nodes_status(fal_dbt, status, self.bound_model.unique_id)
@@ -148,21 +195,15 @@ class FalHookTask(Task):
     is_hook: bool = True
 
     def execute(self, args: argparse.Namespace, fal_dbt: FalDbt) -> int:
-        if not self.is_hook:
-            # For after/before scripts
-            assert self._run_index != -1
-
         script = self.build_fal_script(fal_dbt)
-        return _run_script(script)
+        return run_script(script, self.run_index)
 
     @classmethod
     def from_fal_script(cls, script: FalScript):
         return cls(script.path, script.model, script.is_hook)
 
     def build_fal_script(self, fal_dbt: FalDbt):
-        return FalScript(
-            fal_dbt, self.bound_model, str(self.hook_path), self.is_hook
-        )
+        return FalScript(fal_dbt, self.bound_model, str(self.hook_path), self.is_hook)
 
 
 @dataclass
@@ -176,9 +217,11 @@ class TaskGroup:
     def __post_init__(self):
         self._id = str(uuid.uuid4())
 
-    def set_run_index(self, run_index: int) -> None:
-        self.task._run_index = run_index
-
     @property
     def id(self) -> str:
         return self._id
+
+    def iter_tasks(self) -> Iterator[Task]:
+        yield from self.pre_hooks
+        yield self.task
+        yield from self.post_hooks

--- a/src/fal/utils.py
+++ b/src/fal/utils.py
@@ -10,3 +10,18 @@ def print_run_info(scripts: List[FalScript]):
     print_timestamped_line(
         f"Starting fal run for following models and scripts: \n{models_str}\n"
     )
+
+
+class DynamicIndexProvider:
+    def __init__(self) -> None:
+        self._index = 0
+
+    def next(self) -> int:
+        """Increment the counter and return the last value."""
+        index = self._index
+        self._index += 1
+        return index
+
+    def __int__(self) -> int:
+        """Return the last value."""
+        return self._index

--- a/tests/planner/test_tasks.py
+++ b/tests/planner/test_tasks.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from fal.planner.tasks import FAILURE, SUCCESS, DBTTask, FalHookTask, FalModelTask
-
+from fal.utils import DynamicIndexProvider
 
 @dataclass
 class FakeCLIOutput:
@@ -47,7 +47,7 @@ def mock_script_construction(mocker, return_code):
         return_value=FakeScript(),
     )
     mocker.patch(
-        "fal.planner.tasks._run_script",
+        "fal.planner.tasks.run_script",
         return_value=return_code,
     )
 
@@ -55,7 +55,7 @@ def mock_script_construction(mocker, return_code):
 @pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
 def test_dbt_task(mocker, return_code):
     task = DBTTask(["a", "b"])
-    task._run_index = 1
+    task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")
     mock_dbt_run(mocker, return_code)
@@ -64,7 +64,7 @@ def test_dbt_task(mocker, return_code):
 
 def test_fal_model_task_when_dbt_fails(mocker):
     task = FalModelTask(["a", "b"])
-    task._run_index = 1
+    task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")
     mock_dbt_run(mocker, FAILURE)
@@ -74,7 +74,7 @@ def test_fal_model_task_when_dbt_fails(mocker):
 @pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
 def test_fal_model_task_when_dbt_succeeds(mocker, return_code):
     task = FalModelTask(["a", "b"], bound_model=FakeModel("model"))
-    task._run_index = 1
+    task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")
     mock_dbt_run(mocker, SUCCESS)
@@ -85,7 +85,7 @@ def test_fal_model_task_when_dbt_succeeds(mocker, return_code):
 @pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
 def test_fal_hook(mocker, return_code):
     task = FalHookTask("something.py", bound_model=FakeModel("model"))
-    task._run_index = 1
+    task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")
     mock_script_construction(mocker, return_code)


### PR DESCRIPTION
Implements the `fal_results.json`. It is basically a mirror of the original DBT run results, but contains additional information for `post-hook`s and Python model scripts (including execution time, their name, executed thread, etc.).