### PR TITLE
tests: add a CI run for fal flow run with experimental threads

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         python: ["3.8"]
         dbt: ["0.20.*", "0.21.*", "1.0.*", "1.1.*"]
+        experimental_threads: [0, 4]
 
     # Run only the latest commit pushed to PR
     concurrency:
@@ -48,8 +49,13 @@ jobs:
         working-directory: integration_tests
         env:
           FAL_STATS_ENABLED: false
+          FAL_TESTS_EXPERIMENTAL_THREADS: ${{ matrix.experimental_threads }}
         run: |
           BEHAVE_ARGS="--tags=-TODO-postgres"
+          if [[ $FAL_TESTS_EXPERIMENTAL_THREADS != '0' ]]
+          then
+            BEHAVE_ARGS="$BEHAVE_ARGS --tags=-TODO-parallel"
+          fi
           if [[ '${{ matrix.dbt }}' =~ ^0.*$ ]]
           then
             BEHAVE_ARGS="$BEHAVE_ARGS --tags=-dbtv1"

--- a/integration_tests/features/flow_run.feature
+++ b/integration_tests/features/flow_run.feature
@@ -124,6 +124,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | new_model |
 
+  @TODO-parallel
   Scenario: fal flow run with an error in before
     Given the project 003_scripts_with_errors
     When the following command is invoked:
@@ -132,6 +133,7 @@ Feature: `flow run` command
       """
     Then it throws an exception RuntimeError with message 'Error in scripts'
 
+  @TODO-parallel
   Scenario: fal flow run with an error in after
     Given the project 003_scripts_with_errors
     When the following command is invoked:
@@ -140,6 +142,7 @@ Feature: `flow run` command
       """
     Then it throws an exception RuntimeError with message 'Error in scripts'
 
+  @TODO-parallel
   @TODO-duckdb
   Scenario: fal flow run with an error in dbt run
     Given the project 003_scripts_with_errors
@@ -266,7 +269,7 @@ Feature: `flow run` command
     And the following scripts are ran:
       | model_c.before.py | agent_wait_time.before.py |
 
-  @broken_profile
+  @broken_profile @TODO-parallel
   Scenario: fal flow run with target
     Given the project 001_flow_run_with_selectors
     When the data is seeded
@@ -284,6 +287,7 @@ Feature: `flow run` command
     Then the following models are calculated:
       | zendesk_ticket_data |
 
+  @TODO-parallel
   Scenario: post hooks run after both successful and failed dbt models
     Given the project 003_scripts_with_errors
     When the following command is invoked:

--- a/integration_tests/features/python_nodes.feature
+++ b/integration_tests/features/python_nodes.feature
@@ -26,6 +26,7 @@ Feature: Python nodes
     And the script model_c.post_hook.py output file has the lines:
       | Status: success |
 
+  @TODO-parallel
   Scenario: Python model post hooks run even when model script fails
     When the following command is invoked:
       """


### PR DESCRIPTION
We also temporarily add support for before/after scripts (details TBD).
