### PR TITLE
fix: reference {{ this }} for ephemeral models to get correct schema and table every time

### DIFF
--- a/integration_tests/projects/008_pure_python_models/dbt_project.yml
+++ b/integration_tests/projects/008_pure_python_models/dbt_project.yml
@@ -9,3 +9,6 @@ snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"
 vars:
   fal-scripts-path: "scripts"
+
+models:
+  +schema: custom

--- a/integration_tests/projects/008_pure_python_models/models/fal/model_e.sql
+++ b/integration_tests/projects/008_pure_python_models/models/fal/model_e.sql
@@ -1,7 +1,7 @@
 
 {{ config(materialized='ephemeral') }}
 /*
-FAL_GENERATED 4ece7938c7f764bd94f3955f868ab5c5
+FAL_GENERATED d5d59e7be72d81f154140338f730e38c
 
 Script dependencies:
 
@@ -9,4 +9,4 @@ Script dependencies:
 
 */
 
-SELECT * FROM {{ target.schema }}.{{ model.alias }}
+SELECT * FROM {{ this }}

--- a/integration_tests/projects/008_pure_python_models/models/fal/staging/model_c.sql
+++ b/integration_tests/projects/008_pure_python_models/models/fal/staging/model_c.sql
@@ -1,7 +1,7 @@
 
 {{ config(materialized='ephemeral') }}
 /*
-FAL_GENERATED 8575017c3d1726fc82796a665c9a60a9
+FAL_GENERATED 5703f4afba785d3cf956a51bcb4dc564
 
 Script dependencies:
 
@@ -10,4 +10,4 @@ Script dependencies:
 
 */
 
-SELECT * FROM {{ target.schema }}.{{ model.alias }}
+SELECT * FROM {{ this }}

--- a/src/fal/cli/model_generator/model_generator.py
+++ b/src/fal/cli/model_generator/model_generator.py
@@ -23,7 +23,7 @@ __deps__
 
 */
 
-SELECT * FROM {{ target.schema }}.{{ model.alias }}
+SELECT * FROM {{ this }}
 """
 
 


### PR DESCRIPTION
related to #441

In the target dir, it went from: `SELECT * FROM SELECT * FROM dbt_fal.fal_008_model_c` to `SELECT * FROM "test"."dbt_fal_custom"."fal_008_model_c"`.

Now dbt takes care of quoting and everything.

<details>
closes FEA-250
</details>