### PR TITLE
tests: Reduce dbt versions to test on schedule and fix matrix option

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -72,15 +72,19 @@ jobs:
       list: ${{ steps.include-step.outputs.out }}
     steps:
       - id: include-step
+        shell: python
         run: |
-          OUTPUT='"0.20.*", "0.21.*", "1.0.*", "1.1.*"'
+          OUTPUT=["1.0.*", "1.1.*"]
 
-          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]
-          then
-            OUTPUT='latest'
-          fi
+          if '${{ github.event_name }}' == 'pull_request':
+            # Add more versions for pull requests
+            OUTPUT.extend(["0.20.*", "0.21.*"])
 
-          echo "::set-output name=out::[$OUTPUT]"
+          elif '${{ github.event_name }}' == 'workflow_dispatch':
+            OUTPUT=["latest"]
+
+          import json
+          print("::set-output name=out::" + json.dumps(OUTPUT))
 
   run:
     needs: [matrix-adapters, matrix-python, matrix-dbt]


### PR DESCRIPTION
We had too many tests scheduled: 4 Python versions and 4 dbt versions = 16 per adapter. So they were canceled because of time limits.

This brings them to 8 per adapter when scheduled and 4 per adapter for pull requests.

We can still improve by making each python version have a different schema to run adapter tests in parallel (the ones with remote data warehouse)