### PR TITLE
fix: make exit code of Python non-zero if there are errors

### DIFF
--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -45,7 +45,8 @@ def _cli(argv: List[str]):
             if parsed.flow_command == "run":
                 _warn_deprecated_flags(parsed)
 
-                fal_flow_run(parsed)
+                status_code = fal_flow_run(parsed)
+                exit(status_code)
 
         elif parsed.command == "run":
             fal_run(parsed)

--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -17,8 +17,6 @@ from faldbt.project import FalDbt
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
-from functools import reduce
-
 
 class State(Enum):
     PRE_HOOKS = auto()


### PR DESCRIPTION
Like dbt:

```
integration_tests/projects/003_runtime_errors main ≡
❯ dbt run
19:44:05  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
19:44:05  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
19:44:05  Running with dbt=1.1.1
19:44:05  Found 3 models, 0 tests, 0 snapshots, 0 analyses, 168 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
19:44:05
19:44:05  Concurrency: 4 threads (target='dev')
19:44:05
19:44:05  1 of 2 START table model dbt_fal.fal_003_some_model ............................ [RUN]
19:44:05  2 of 2 START table model dbt_fal.fal_003_working_model ......................... [RUN]
19:44:06  1 of 2 ERROR creating table model dbt_fal.fal_003_some_model ................... [ERROR in 0.09s]
19:44:06  2 of 2 OK created table model dbt_fal.fal_003_working_model .................... [SELECT 1 in 0.14s]
19:44:06
19:44:06  Finished running 2 table models in 0.46s.
19:44:06
19:44:06  Completed with 1 error and 0 warnings:
19:44:06
19:44:06  Database Error in model some_model (models/some_model.sql)
19:44:06    division by zero
19:44:06    compiled SQL at ./target/run/fal_003/models/some_model.sql
19:44:06
19:44:06  Done. PASS=1 WARN=0 ERROR=1 SKIP=0 TOTAL=2

integration_tests/projects/003_runtime_errors main ≡
❯ echo $status # fish shell: https://fishshell.com
1
```

```
integration_tests/projects/003_runtime_errors main ≡
❯ dbt run --exclude some_model
19:44:26  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
19:44:26  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
19:44:26  Running with dbt=1.1.1
19:44:26  Found 3 models, 0 tests, 0 snapshots, 0 analyses, 168 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
19:44:26
19:44:26  Concurrency: 4 threads (target='dev')
19:44:26
19:44:26  1 of 1 START table model dbt_fal.fal_003_working_model ......................... [RUN]
19:44:26  1 of 1 OK created table model dbt_fal.fal_003_working_model .................... [SELECT 1 in 0.12s]
19:44:26
19:44:26  Finished running 1 table model in 0.43s.
19:44:26
19:44:26  Completed successfully
19:44:26
19:44:26  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

integration_tests/projects/003_runtime_errors main ≡
❯ echo $status
0
```
