### PR TITLE
feat: include before/after scripts in nodes failed/skipped report

### DIFF
--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -30,6 +30,7 @@ def _collect_nodes(groups: List[TaskGroup], fal_dbt: FalDbt) -> Iterator[str]:
             yield from group.task.model_ids
         if isinstance(group.task, FalHookTask):
             # Is a before/after script
+            assert not group.task.is_hook
             yield group.task.build_fal_script(fal_dbt).id
 
 

--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -28,11 +28,9 @@ def _collect_nodes(groups: List[TaskGroup], fal_dbt: FalDbt) -> Iterator[str]:
     for group in groups:
         if isinstance(group.task, DBTTask):
             yield from group.task.model_ids
-        if isinstance(group.task, FalHookTask):
+        if isinstance(group.task, FalHookTask) and not group.task.is_hook:
             # Is a before/after script
-            assert not group.task.is_hook
             yield group.task.build_fal_script(fal_dbt).id
-
 
 
 def _show_failed_groups(scheduler: Scheduler, fal_dbt: FalDbt) -> None:


### PR DESCRIPTION
Example

```
integration_tests/projects/003_runtime_errors failed-skipped-messaging* ≡
❯ fal flow run

File 'fal/runtime_error_model.sql' was generated from 'runtime_error_model.py'.
Please do not modify it directly. We recommend committing it to your repository.
14:08:38  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
14:08:38  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
14:08:38  Unable to do partial parsing because profile has changed
14:08:38  Unable to do partial parsing because a project dependency has been added
14:08:39  Found 3 models, 0 tests, 0 snapshots, 0 analyses, 182 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
Could not read dbt sources artifact
Using before/after scripts are now deprecated. Please consider migrating to pre-hooks/post-hooks or Python models.
10:08:39 | Starting fal run for following models and scripts:
(working_model, fal_scripts/before.py)

Running command: dbt run --threads 1 --project-dir /Users/matteo/Projects/fal/fal/integration_tests/projects/003_runtime_errors --select some_model
Error in script (working_model, fal_scripts/before.py):
Traceback (most recent call last):
  File "/Users/matteo/Projects/fal/fal/src/fal/planner/tasks.py", line 79, in _run_script
    script.exec()
  File "/Users/matteo/Projects/fal/fal/src/fal/fal_script.py", line 128, in exec
    exec(program, exec_globals)
  File "/Users/matteo/Projects/fal/fal/integration_tests/projects/003_runtime_errors/fal_scripts/before.py", line 1, in <module>
    raise Exception("Before error")
Exception: Before error

14:08:46  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
14:08:46  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
14:08:46  Running with dbt=1.1.1
14:08:46  Found 3 models, 0 tests, 0 snapshots, 0 analyses, 182 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
14:08:46
14:08:51  Concurrency: 1 threads (target='snowflake')
14:08:51
14:08:51  1 of 1 START table model matteo.fal_003_some_model ............................. [RUN]
14:08:54  1 of 1 ERROR creating table model matteo.fal_003_some_model .................... [ERROR in 3.41s]
14:08:54
14:08:54  Finished running 1 table model in 8.28s.
14:08:54
14:08:54  Completed with 1 error and 0 warnings:
14:08:54
14:08:54  Database Error in model some_model (models/some_model.sql)
14:08:54    100051 (22012): Division by zero
14:08:54    compiled SQL at ./target/run/fal_003/models/some_model.sql
14:08:54
14:08:54  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
10:08:55 | Starting fal run for following models and scripts:
(some_model, fal_scripts/post_hook.py)

Failed calculating the following nodes: model.fal_003.some_model, (working_model, fal_scripts/before.py)
Skipped calculating the following nodes: model.fal_003.working_model, (working_model, fal_scripts/after.py), model.fal_003.runtime_error_model
```