### PR TITLE
feat: model-scoped environments

### DIFF
--- a/integration_tests/features/structured_hooks.feature
+++ b/integration_tests/features/structured_hooks.feature
@@ -29,3 +29,21 @@ Feature: Structured Hooks
       | model_b.local_hook.py | model_b.funny_hook.py | model_b.check_imports.py |
     And the script model_b.funny_hook.py output file has the lines
       | PyJokes version: 0.6.0 |
+
+  Scenario: Run isolated models
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select model_c+
+      """
+    Then the following models are calculated:
+      | model_c | model_d.py | model_e.py |
+    And the following scripts are ran:
+      | model_c.check_imports.py | model_d.check_imports.py | model_e.check_imports.py | model_e.joke_version.py | model_e.funny_hook.py |
+    And the script model_d.py output file has the lines
+      | PyJokes version: 0.5.0 |
+    And the script model_e.py output file has the lines
+      | PyJokes version: 0.6.0 |
+    And the script model_e.funny_hook.py output file has the lines
+      | PyJokes version: 0.5.0 |
+    And the script model_e.joke_version.py output file has the lines
+      | PyJokes version: 0.6.0 |

--- a/integration_tests/projects/013_structured_hooks/fal_project.yml
+++ b/integration_tests/projects/013_structured_hooks/fal_project.yml
@@ -3,3 +3,9 @@ environments:
   - name: funny
     requirements:
       - pyjokes==0.6.0
+  - name: pyjokes-0.5.0
+    requirements:
+      - pyjokes==0.5.0
+  - name: pyjokes-0.6.0
+    requirements:
+      - pyjokes==0.6.0

--- a/integration_tests/projects/013_structured_hooks/models/fal/model_d.sql
+++ b/integration_tests/projects/013_structured_hooks/models/fal/model_d.sql
@@ -1,0 +1,12 @@
+
+{{ config(materialized='ephemeral') }}
+/*
+FAL_GENERATED d5d59e7be72d81f154140338f730e38c
+
+Script dependencies:
+
+{{ ref('model_c') }}
+
+*/
+
+SELECT * FROM {{ this }}

--- a/integration_tests/projects/013_structured_hooks/models/fal/model_e.sql
+++ b/integration_tests/projects/013_structured_hooks/models/fal/model_e.sql
@@ -1,0 +1,12 @@
+
+{{ config(materialized='ephemeral') }}
+/*
+FAL_GENERATED d5d59e7be72d81f154140338f730e38c
+
+Script dependencies:
+
+{{ ref('model_c') }}
+
+*/
+
+SELECT * FROM {{ this }}

--- a/integration_tests/projects/013_structured_hooks/models/model_c.sql
+++ b/integration_tests/projects/013_structured_hooks/models/model_c.sql
@@ -1,0 +1,8 @@
+WITH model_c AS (
+
+    SELECT
+        'some text' AS my_text
+)
+
+SELECT *
+FROM model_c

--- a/integration_tests/projects/013_structured_hooks/models/model_d.py
+++ b/integration_tests/projects/013_structured_hooks/models/model_d.py
@@ -1,0 +1,11 @@
+import pyjokes
+from fal.typing import *
+from _fal_testing import create_model_artifact
+
+df = ref("model_c")
+
+df["model_e_data"] = True
+
+write_to_model(df)
+
+create_model_artifact(context, f"PyJokes version: {pyjokes.__version__}")

--- a/integration_tests/projects/013_structured_hooks/models/model_e.py
+++ b/integration_tests/projects/013_structured_hooks/models/model_e.py
@@ -1,0 +1,11 @@
+import pyjokes
+from fal.typing import *
+from _fal_testing import create_model_artifact
+
+df = ref("model_c")
+
+df["model_e_data"] = True
+
+write_to_model(df)
+
+create_model_artifact(context, f"PyJokes version: {pyjokes.__version__}")

--- a/integration_tests/projects/013_structured_hooks/models/schema.yml
+++ b/integration_tests/projects/013_structured_hooks/models/schema.yml
@@ -30,6 +30,7 @@ models:
               mapping:
                 key: value
 
+  # Hook with environment overrides
   - name: model_b
     meta:
       fal:
@@ -43,3 +44,49 @@ models:
             with:
               import: pyjokes
               expected_success: false
+
+  # A regular DBT model on a new environment
+  - name: model_c
+    meta:
+      fal:
+        environment: pyjokes-0.6.0
+        post-hook:
+          - path: check_imports.py
+            with:
+              import: pyjokes
+              expected_success: true
+
+  # A Python model on an environment w/pyjokes==0.5.0
+  - name: model_d
+    meta:
+      fal:
+        environment: pyjokes-0.5.0
+        post-hook:
+          - path: check_imports.py
+            with:
+              import: pyjokes
+              expected_success: true
+
+  # A Python model on an environment w/pyjokes==0.6.0
+  - name: model_e
+    meta:
+      fal:
+        environment: pyjokes-0.6.0
+        pre-hook:
+          # We override the default environment here
+          # for only this hook, and expect the import
+          # of pyjokes to fail under 'not-funny' environment.
+          - path: check_imports.py
+            environment: not-funny
+            with:
+              import: pyjokes
+              expected_success: false
+
+          # But all other hooks should still be able to
+          # access to the model's environment
+          - joke_version.py
+
+          # And they can even customize the version
+          # with another overwrite
+          - path: funny_hook.py
+            environment: pyjokes-0.5.0

--- a/integration_tests/projects/013_structured_hooks/scripts/joke_version.py
+++ b/integration_tests/projects/013_structured_hooks/scripts/joke_version.py
@@ -1,0 +1,7 @@
+from fal.typing import *
+from _fal_testing import create_dynamic_artifact
+
+import pyjokes
+
+create_dynamic_artifact(context, f"PyJokes version: {pyjokes.__version__}")
+

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -29,27 +29,29 @@ class LocalHook(Hook):
 @dataclass
 class IsolatedHook(Hook):
     path: str
-    environment: str
+    environment_name: str
     arguments: Dict[str, Any] = field(default_factory=dict)
 
 
-def create_hook(raw_hook: Any) -> Hook:
+def create_hook(raw_hook: Any, default_environment_name: Optional[str] = None) -> Hook:
     if isinstance(raw_hook, str):
-        return LocalHook(raw_hook)
-    elif isinstance(raw_hook, dict):
-        if "path" in raw_hook:
-            if "environment" in raw_hook:
-                return IsolatedHook(
-                    raw_hook["path"],
-                    raw_hook["environment"],
-                    raw_hook.get("with", {}),
-                )
-            else:
-                return LocalHook(raw_hook["path"], raw_hook.get("with", {}))
-        else:
-            raise ValueError(f"A hook must specify path.")
+        raw_hook = {"path": raw_hook}
 
-    raise ValueError(f"Unrecognized hook value: {raw_hook}")
+    if not isinstance(raw_hook, dict):
+        raise ValueError(f"Unrecognized hook value: {raw_hook}")
+
+    if "path" in raw_hook:
+        environment_name = raw_hook.get("environment", default_environment_name)
+        if environment_name:
+            return IsolatedHook(
+                raw_hook["path"],
+                environment_name,
+                raw_hook.get("with", {}),
+            )
+        else:
+            return LocalHook(raw_hook["path"], raw_hook.get("with", {}))
+    else:
+        raise ValueError(f"A hook must specify path.")
 
 
 @dataclass

--- a/src/fal/node_graph.py
+++ b/src/fal/node_graph.py
@@ -113,6 +113,7 @@ class NodeGraph:
                 kind=NodeKind.FAL_MODEL if model.python_model else NodeKind.DBT_MODEL,
                 post_hook=model.get_post_hook_paths(),
                 pre_hook=model.get_pre_hook_paths(),
+                environment=model.environment_name,
             )
 
             # Add dbt model dependencies

--- a/src/fal/packages/_run_hook.py
+++ b/src/fal/packages/_run_hook.py
@@ -13,10 +13,11 @@ def run_fal_hook(
     fal_dbt_config: Dict[str, Any],
     arguments: Dict[str, Any],
     run_index: int,
+    hook_type: str,
     disable_logging: bool,
 ) -> None:
     from fal.node_graph import DbtModelNode, NodeGraph
-    from fal.planner.tasks import FalLocalHookTask
+    from fal.planner.tasks import FalLocalHookTask, HookType
     from faldbt.project import FalDbt
 
     fal_dbt = FalDbt(**fal_dbt_config)
@@ -24,7 +25,16 @@ def run_fal_hook(
     flow_node = node_graph.get_node(bound_model_name)
     assert isinstance(flow_node, DbtModelNode)
 
-    task = FalLocalHookTask(path, flow_node.model, arguments)
+    hook_type = HookType(hook_type)
+    if hook_type is HookType.MODEL_SCRIPT:
+        flow_node.model.python_model = Path(path)
+
+    task = FalLocalHookTask(
+        Path(path),
+        flow_node.model,
+        arguments,
+        hook_type=HookType(hook_type),
+    )
     task._run_index = run_index
 
     dummy_namespace = Namespace()

--- a/src/fal/packages/environment.py
+++ b/src/fal/packages/environment.py
@@ -31,8 +31,8 @@ from platformdirs import user_cache_dir
 
 import fal.packages._run_hook as _hook_runner_module
 from faldbt.project import FalDbt
-from fal.planner.tasks import SUCCESS, FAILURE
 from dbt.logger import GLOBAL_LOGGER as logger
+from fal.planner.tasks import SUCCESS, FAILURE, HookType
 
 _BASE_CACHE_DIR = Path(user_cache_dir("fal", "fal"))
 _BASE_CACHE_DIR.mkdir(exist_ok=True)
@@ -95,7 +95,7 @@ def _get_default_requirements() -> Iterator[Tuple[str, Optional[str]]]:
         yield f"dbt-{adapter_name}", adapter_version
 
 
-HookRunner = Callable[[FalDbt, Path, str, Dict[str, Any], int, bool], int]
+HookRunner = Callable[[FalDbt, Path, str, Dict[str, Any], int, HookType, bool], int]
 
 
 @contextmanager
@@ -174,6 +174,7 @@ class VirtualPythonEnvironment(BaseEnvironment):
         arguments: Dict[str, Any],
         bound_model_name: str,
         run_index: int,
+        hook_type: HookType,
         disable_logging: bool,
     ) -> int:
         python_path = venv_path / "bin" / "python"
@@ -184,6 +185,7 @@ class VirtualPythonEnvironment(BaseEnvironment):
                 "fal_dbt_config": fal_dbt._serialize(),
                 "arguments": arguments,
                 "run_index": run_index,
+                "hook_type": hook_type.value,
                 "disable_logging": disable_logging,
             }
         )

--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -11,7 +11,14 @@ from dataclasses import dataclass, field
 from typing import Iterator, List, Optional
 
 from fal.planner.schedule import SUCCESS, Scheduler
-from fal.planner.tasks import TaskGroup, Task, Status, DBTTask, FalLocalHookTask
+from fal.planner.tasks import (
+    TaskGroup,
+    Task,
+    Status,
+    DBTTask,
+    FalLocalHookTask,
+    HookType,
+)
 from faldbt.project import FalDbt
 
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -27,7 +34,10 @@ def _collect_nodes(groups: List[TaskGroup], fal_dbt: FalDbt) -> Iterator[str]:
     for group in groups:
         if isinstance(group.task, DBTTask):
             yield from group.task.model_ids
-        if isinstance(group.task, FalLocalHookTask) and not group.task.is_hook:
+        if (
+            isinstance(group.task, FalLocalHookTask)
+            and group.task.hook_type is HookType.SCRIPT
+        ):
             # Is a before/after script
             yield group.task.build_fal_script(fal_dbt).id
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -239,7 +239,11 @@ class DbtModel(_DbtTestableNode):
     def get_depends_on_nodes(self) -> List[str]:
         return self.node.depends_on_nodes
 
-    def _get_hooks(self, hook_type: str, keyword: str = "fal") -> List["Hook"]:
+    def _get_hooks(
+        self,
+        hook_type: str,
+        keyword: str = "fal",
+    ) -> List["Hook"]:
         from fal.fal_script import create_hook
 
         meta = self.meta or {}
@@ -252,7 +256,10 @@ class DbtModel(_DbtTestableNode):
         if not isinstance(raw_hooks, list):
             return []
 
-        return [create_hook(raw_hook) for raw_hook in raw_hooks]
+        return [
+            create_hook(raw_hook, default_environment_name=self.environment_name)
+            for raw_hook in raw_hooks
+        ]
 
     get_pre_hook_paths = partialmethod(_get_hooks, hook_type="pre-hook")
     get_post_hook_paths = partialmethod(_get_hooks, hook_type="post-hook")
@@ -282,6 +289,13 @@ class DbtModel(_DbtTestableNode):
             return scripts_node.get("before") or []
         else:
             return scripts_node.get("after") or []
+
+    @property
+    def environment_name(self) -> Optional[str]:
+        meta = self.meta or {}
+        fal = meta.get("fal") or {}
+        return fal.get("environment")
+
 
 
 @dataclass

--- a/tests/planner/test_schedule.py
+++ b/tests/planner/test_schedule.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import pytest
 
+from pathlib import Path
 from fal.node_graph import NodeKind
 from fal.planner.tasks import FAILURE, SUCCESS, DBTTask, FalModelTask
 from fal.planner.tasks import DBTTask, FalModelTask, Status
@@ -138,7 +139,7 @@ def test_scheduler_task_separation(graph_info):
         )
     )
     assert all_post_hooks == {
-        post_hook.path
+        Path(post_hook.path)
         for properties in graph.nodes.values()
         for post_hook in properties.get("post_hook", [])
     }

--- a/tests/planner/test_tasks.py
+++ b/tests/planner/test_tasks.py
@@ -64,7 +64,10 @@ def test_dbt_task(mocker, return_code):
 
 
 def test_fal_model_task_when_dbt_fails(mocker):
-    task = FalModelTask(["a", "b"])
+    task = FalModelTask(
+        ["a", "b"],
+        script=FalLocalHookTask("something.py", bound_model=FakeModel("model")),
+    )
     task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")
@@ -74,7 +77,10 @@ def test_fal_model_task_when_dbt_fails(mocker):
 
 @pytest.mark.parametrize("return_code", [SUCCESS, FAILURE])
 def test_fal_model_task_when_dbt_succeeds(mocker, return_code):
-    task = FalModelTask(["a", "b"], bound_model=FakeModel("model"))
+    task = FalModelTask(
+        ["a", "b"],
+        script=FalLocalHookTask("something.py", bound_model=FakeModel("model")),
+    )
     task.set_run_index(DynamicIndexProvider())
 
     fal_dbt = FakeFalDbt("/test")

--- a/tests/planner/utils.py
+++ b/tests/planner/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import Any
+from pathlib import Path
 
 import networkx as nx
 
@@ -20,6 +21,12 @@ from fal.fal_script import LocalHook
 class ModelDict(defaultdict):
     def get(self, key):
         return super().__getitem__(key)
+
+
+class FakeDbtModel:
+    @property
+    def python_model(self):
+        return Path("...")
 
 
 def to_graph(data: list[tuple[str, dict[str, Any]]]) -> nx.DiGraph:
@@ -64,5 +71,7 @@ def to_scheduler(graph):
     if isinstance(graph, list):
         graph = to_graph(graph)
     new_graph = plan_graph(graph, to_plan(graph))
-    node_graph = NodeGraph(graph, ModelDict(lambda: DbtModelNode("...", None)))
+    node_graph = NodeGraph(
+        graph, ModelDict(lambda: DbtModelNode("...", FakeDbtModel()))
+    )
     return schedule_graph(new_graph, node_graph)


### PR DESCRIPTION
Requires #489, this PR implements support for isolation in the scope of individual models. Each model can now define an `environment:` setting directly under `fal:` block, and that setting will be applied to both Python model itself (if there is any) and all the hooks below it (unless they manually override).