### PR TITLE
ci: Add GitHub action that generates typing and commits it

### DIFF
--- a/.github/workflows/generate_typing.yml
+++ b/.github/workflows/generate_typing.yml
@@ -1,0 +1,38 @@
+name: Generate typing module
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths-ignore:
+      - "examples/**"
+      - "docsite/**"
+      - "README.md"
+      - "LICENSE"
+      - "docker/**"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    # Run only the latest commit pushed to PR
+    concurrency:
+      group: "${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ matrix.profile }}-${{ matrix.dbt }}-${{ matrix.python }}"
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Setup black
+        run: pip install black
+
+      - name: Generate typing
+        run: |
+          python tools/generate_typing_context.py
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Generate typing

--- a/.github/workflows/generate_typing.yml
+++ b/.github/workflows/generate_typing.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.RELEASER_GITHUB_PAT }}
 
       - uses: actions/setup-python@v2
         with:
@@ -36,3 +38,5 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Generate typing
+          commit_user_email: batuhan+bot@fal.ai
+          commit_user_name: Fal Bot

--- a/src/fal/typing.py
+++ b/src/fal/typing.py
@@ -15,24 +15,28 @@ if TYPE_CHECKING:
             """
             List tables available for `source` usage
             """
+            ...
 
     class _List_Models_Ids(Protocol):
         def __call__(self) -> Dict[str, str]:
             """
             List model ids available for `ref` usage, formatting like `[ref_name, ...]`
             """
+            ...
 
     class _List_Models(Protocol):
         def __call__(self) -> List[DbtModel]:
             """
             List models
             """
+            ...
 
     class _List_Tests(Protocol):
         def __call__(self) -> List[DbtTest]:
             """
             List tests
             """
+            ...
 
     class _List_Features(Protocol):
         def __call__(self) -> List[Feature]:
@@ -45,6 +49,7 @@ if TYPE_CHECKING:
             """
             Download a dbt model as a pandas.DataFrame automagically.
             """
+            ...
 
     class _Source(Protocol):
         def __call__(
@@ -53,6 +58,7 @@ if TYPE_CHECKING:
             """
             Download a dbt source as a pandas.DataFrame automagically.
             """
+            ...
 
     class _Write_To_Source(Protocol):
         def __call__(
@@ -67,16 +73,19 @@ if TYPE_CHECKING:
             """
             Write a pandas.DataFrame to a dbt source automagically.
             """
+            ...
 
     class _Write_To_Firestore(Protocol):
         def __call__(self, df: pd.DataFrame, collection: str, key_column: str):
             """
             Write a pandas.DataFrame to a GCP Firestore collection. You must specify the column to use as key.
             """
+            ...
 
     class _Execute_Sql(Protocol):
         def __call__(self, sql: str) -> pd.DataFrame:
             """Execute a sql query."""
+            ...
 
     # Manually introduced annotations, update manually in tools/generate_typing_context.py template.
     class _Write_To_Model(Protocol):
@@ -92,6 +101,7 @@ if TYPE_CHECKING:
             """
             Write a pandas.DataFrame to a dbt model automagically.
             """
+            ...
 
 
 context: Context

--- a/tools/generate_typing_context.py
+++ b/tools/generate_typing_context.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
             '''
             Write a pandas.DataFrame to a dbt model automagically.
             '''
+            ...
 
 
 context: Context
@@ -84,7 +85,9 @@ def generate_protocols(file, class_name):
         if ast.get_docstring(call_function):
             call_function.body = call_function.body[:1]
         else:
-            call_function.body = [ast.Expr(ast.Constant(...))]
+            call_function.body = []
+
+        call_function.body.append(ast.Expr(ast.Constant(...)))
 
         protocols.append(
             ast.ClassDef(


### PR DESCRIPTION
Problem: https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs

> Commits made by this Action do not trigger new Workflow runs
> 
> The resulting commit will not trigger another GitHub Actions Workflow run. This is due to [limitations set by GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
> 
>     When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.
> 
> You can change this by creating a new [Personal Access Token (PAT)](https://github.com/settings/tokens/new), storing the token as a secret in your repository and then passing the new token to the [actions/checkout](https://github.com/actions/checkout#usage) Action step.
> 
> ```
> - uses: actions/checkout@v2
>   with:
>     token: ${{ secrets.PAT }}
> ```
> 
> If you create a personal access token, apply the repo and workflow scopes.
> 
> If you work in an organization and don't want to create a PAT from your personal account, we recommend using a [robot account](https://docs.github.com/en/github/getting-started-with-github/types-of-github-accounts) for the token.

<details>
closes FEA-358
</details>