### PR TITLE
ci: only run generate typing job when originating from upstream

### DIFF
--- a/.github/workflows/generate_typing.yml
+++ b/.github/workflows/generate_typing.yml
@@ -20,9 +20,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RELEASER_GITHUB_PAT }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
It seems like the PRs coming from my fork fail at this stage, it is not big since we don't receive much outside contributions but just to make the CI green I think we can ignore this job on forks.