### PR TITLE
 feat: Add target to context object in fal scripts

### DIFF
--- a/integration_tests/features/context_info.feature
+++ b/integration_tests/features/context_info.feature
@@ -7,6 +7,18 @@ Feature: Context object information
       dbt run --profiles-dir $profilesDir --project-dir $baseDir
       """
 
+  Scenario: Get target info in post hook
+    When the following command is invoked:
+      """
+      fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select some_model
+      """
+    Then the following models are calculated:
+      | some_model |
+    Then the following scripts are ran:
+      | some_model.lists.py | some_model.context.py |
+    And the script some_model.context.py output file has the lines:
+      | target profile: fal_test |
+
   Scenario: Get rows affected in post hook for fal flow run
     When the following command is invoked:
       """

--- a/integration_tests/projects/005_functions_and_variables/fal_scripts/context.py
+++ b/integration_tests/projects/005_functions_and_variables/fal_scripts/context.py
@@ -6,6 +6,10 @@ assert context.current_model
 extra = ""
 extra += f"context: {context}\n"
 extra += f"model: {context.current_model}\n"
+extra += f"target: {context.target}\n"
+extra += f"target name: {context.target.name}\n"
+extra += f"target profile: {context.target.profile_name}\n"
+extra += f"target database: {context.target.database}\n"
 
 response = context.current_model.adapter_response
 assert response


### PR DESCRIPTION
resolves #535 

Now available in the context:
```py
extra = f"target name: {context.target.name}\n"
extra += f"target profile: {context.target.profile_name}\n"
extra += f"target database: {context.target.database}\n"
```

class:
```py
@dataclass
class ContextTarget:
    def __init__(self, config: RuntimeConfig):
        self.profile_name = config.profile_name
        self.name = config.target_name
        self.threads = config.threads
        self.type = config.credentials.type
        self.database = config.credentials.database
        self.schema = config.credentials.schema

```

<!--
If this closes a Linear issue, you can add it in a <details> section like so:

    closes FEA-403
-->


### Integration tests

Adapter to test:
- postgres
<!-- - snowflake -->
<!-- - bigquery -->
<!-- - redshift -->
<!-- - duckdb -->
<!-- - athena -->

Python version to test:
- 3.7
- 3.8
- 3.10
