### PR TITLE
ci: Fix poetry installation in GH actions

### DIFF
--- a/.github/actions/setup-local-fal/action.yml
+++ b/.github/actions/setup-local-fal/action.yml
@@ -21,9 +21,9 @@ runs:
       with:
         python-version: ${{ inputs.python }}
 
-    - uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: "1.1.4"
+    - name: Install poetry
+      shell: bash
+      run: pip install poetry-core=="1.0.*" poetry=="1.1.4"
 
     - name: Fix jinja
       shell: sh

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           python-version: "3.8"
 
-      - uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: "1.1.4"
+      - name: Install poetry
+        shell: bash
+        run: pip install poetry-core=="1.0.*" poetry=="1.1.4"
 
       - name: Build package
         env:


### PR DESCRIPTION
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Getting this in GH Actions:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/bin/poetry", line 5, in <module>
    from poetry.console import main
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/__init__.py", line 1, in <module>
    from .application import Application
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/application.py", line 7, in <module>
    from .commands.about import AboutCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/__init__.py", line 2, in <module>
    from .add import AddCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/add.py", line 8, in <module>
    from .init import InitCommand
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/console/commands/init.py", line 16, in <module>
    from poetry.core.pyproject import PyProjectException
ImportError: cannot import name 'PyProjectException' from 'poetry.core.pyproject' (/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/poetry/core/pyproject/__init__.py)
```

When building. https://github.com/fal-ai/fal/actions/runs/3098822890/jobs/5017203736


<!--
If this closes a Linear issue, you can add it in a <details> section like so:

    closes FEA-405
-->
