### PR TITLE
feat: make fal work with local dev envs

### DIFF
--- a/src/fal/packages/dependency_analysis.py
+++ b/src/fal/packages/dependency_analysis.py
@@ -44,10 +44,6 @@ def _get_dbt_packages() -> Iterator[Tuple[str]]:
         if dbt_plugin_name == "dbt-fal" and _is_fal_pre_release():
             adapter_path = _get_fal_root_path() / "adapter"
             yield str(adapter_path), None
-        elif distribution._path.suffix == ".egg-info":
-            # HACK: This is a hack to make dependency analysis work
-            # with local installations of dbt-core/dbt-postgres
-            yield str(distribution.locate_file(".")), None
         else:
             yield dbt_plugin_name, distribution.version
 

--- a/src/fal/packages/environments/virtual_env.py
+++ b/src/fal/packages/environments/virtual_env.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import hashlib
 import subprocess
 from dataclasses import dataclass, field
@@ -25,11 +26,13 @@ _BASE_VENV_DIR.mkdir(exist_ok=True)
 @dataclass
 class VirtualPythonEnvironment(BaseEnvironment[Path], make_thread_safe=True):
     requirements: List[str]
+    inherit_from_local: bool = False
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> VirtualPythonEnvironment:
         requirements = config.get("requirements", [])
-        return cls(requirements)
+        inherit_from_local = config.get("_inherit_from_local", False)
+        return cls(requirements, inherit_from_local=inherit_from_local)
 
     @property
     def key(self) -> str:
@@ -62,15 +65,24 @@ class VirtualPythonEnvironment(BaseEnvironment[Path], make_thread_safe=True):
                 pip_path = get_executable_path(path, "pip")
                 subprocess.check_call([pip_path, "install"] + self.requirements)
 
-            primary_env = get_primary_virtual_env()
-            if self is not primary_env:
-                self._verify_dependencies(primary_env._get_or_create(), path)
+            if not self.inherit_from_local:
+                primary_env = get_primary_virtual_env()
+                if self is not primary_env:
+                    self._verify_dependencies(primary_env._get_or_create(), path)
 
         return path
 
     def open_connection(self, conn_info: Path) -> DualPythonIPC:
-        primary_venv = get_primary_virtual_env()
-        primary_venv_path = primary_venv.get_or_create()
+        if self.inherit_from_local:
+            # Instead of creating a separate environment that only has
+            # the same versions of fal/dbt-core etc. you have locally,
+            # we can also use your environment as the primary. This is
+            # mainly for the development time where the fal or dbt-core
+            # you are using is not available on PyPI yet.
+            primary_venv_path = Path(sys.exec_prefix)
+        else:
+            primary_venv = get_primary_virtual_env()
+            primary_venv_path = primary_venv.get_or_create()
         secondary_venv_path = conn_info
         return DualPythonIPC(self, primary_venv_path, secondary_venv_path)
 


### PR DESCRIPTION
This introduces an option to allow Fal use your local Python as the primary environment. With this, if you have dbt-core installed from a local repository (or actually any python package), we can use them on the isolated environments.

```
environments:
  - name: not-funny
    type: venv
    _inherit_from_local: true

  - name: funny
    type: venv
    requirements:
      - pyjokes==0.5.0
    _inherit_from_local: true
```

Currently a private option.