### PR TITLE
fix: Find conda binary even if it is directly set in FAL_CONDA_HOME

### DIFF
--- a/src/fal/packages/environments/conda.py
+++ b/src/fal/packages/environments/conda.py
@@ -97,7 +97,17 @@ class CondaEnvironment(BaseEnvironment[Path], make_thread_safe=True):
 
 @cache_static
 def get_conda_executable() -> Path:
-    for path in [_FAL_CONDA_HOME, None]:
+    paths_to_check = [None]
+    if _FAL_CONDA_HOME is not None:
+        paths_to_check = [_FAL_CONDA_HOME, None]
+        if _FAL_CONDA_HOME.endswith('conda'):
+            paths_to_check = [_FAL_CONDA_HOME, os.path.dirname(_FAL_CONDA_HOME), None]
+
+    for path in paths_to_check:
+        if path is not None:
+            # In case the conda binary is set in _FAL_CONDA_HOME
+            path = os.path.dirname(path)
+
         conda_path = shutil.which(_CONDA_COMMAND, path=path)
         if conda_path is not None:
             return conda_path


### PR DESCRIPTION
We passed some/path/conda and it did not work, when passed some/path it worked.

### Integration tests

Adapter to test:
- postgres
<!-- - snowflake -->
<!-- - bigquery -->
<!-- - redshift -->
<!-- - duckdb -->
<!-- - athena -->

Python version to test:
<!-- - 3.7 -->
- 3.8
<!-- - 3.9 -->
<!-- - 3.10 -->
