### PR TITLE
make database and schema no longer needed in credentials config

### DIFF
--- a/adapter/src/dbt/adapters/fal/connections.py
+++ b/adapter/src/dbt/adapters/fal/connections.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Tuple
 
 from dbt.adapters.base import Credentials
@@ -18,8 +19,14 @@ class FalConnectionManager(PythonConnectionManager):
         raise NotImplementedError
 
 
+@dataclass
 class FalCredentials(Credentials):
     default_environment: str = "local"
+
+    # NOTE: So we can not set them in profiles.yml
+    # they are ignored for now
+    database: str = ''
+    schema: str = ''
 
     @property
     def type(self):


### PR DESCRIPTION
now this works:

```
  duckdb:
    type: duckdb
    path: "/Users/<user>/duck_db_dbt_dump.db" 
    python_adapter:
      type: fal
````

no more `database: None` or `schema: None`

<details>
closes fea-426
</details>