### PR TITLE
fix: adapt profiles_dir info import for new location in dbt 1.3

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -56,6 +56,7 @@ on:
           - "1.0.*"
           - "1.1.*"
           - "1.2.*"
+          - "1.3.0rc2" # TODO: update when released
 
 jobs:
   matrix-adapter:
@@ -117,7 +118,12 @@ jobs:
       - id: matrix-step
         shell: python
         run: |
-          OPTIONS = ["3.7", "3.8", "3.9", "3.10"]
+          OPTIONS = [
+            "3.7",
+            "3.8",
+            "3.9",
+            "3.10",
+          ]
           OUTPUT = ["3.8"]
 
           if '${{ github.event_name }}' == 'pull_request':
@@ -161,7 +167,12 @@ jobs:
       - id: matrix-step
         shell: python
         run: |
-          OPTIONS = ["1.0.*", "1.1.*", "1.2.*"]
+          OPTIONS = [
+            "1.0.*",
+            "1.1.*",
+            "1.2.*",
+            "1.3.0rc2", # TODO: update when released
+          ]
           OUTPUT = OPTIONS
 
           if '${{ github.event_name }}' == 'workflow_dispatch':

--- a/src/fal/cli/fal_runner.py
+++ b/src/fal/cli/fal_runner.py
@@ -1,11 +1,8 @@
 import argparse
-from itertools import chain
 from pathlib import Path
-from pydoc import ModuleScanner
-from typing import Dict, List, Iterable
-import os
+from typing import Dict, List
 
-from dbt.config.profile import DEFAULT_PROFILES_DIR
+from dbt.flags import PROFILES_DIR
 from fal.planner.executor import parallel_executor
 from fal.planner.schedule import Scheduler
 from fal.planner.tasks import FalLocalHookTask, Status, TaskGroup
@@ -17,13 +14,9 @@ from faldbt.project import DbtModel, FalDbt, FalGeneralException
 def create_fal_dbt(
     args: argparse.Namespace, generated_models: Dict[str, Path] = {}
 ) -> FalDbt:
-    env_profiles_dir = os.getenv("DBT_PROFILES_DIR")
-
-    profiles_dir = DEFAULT_PROFILES_DIR
+    profiles_dir = PROFILES_DIR
     if args.profiles_dir is not None:
         profiles_dir = args.profiles_dir
-    elif env_profiles_dir:
-        profiles_dir = env_profiles_dir
 
     real_state = None
     if hasattr(args, "state") and args.state is not None:


### PR DESCRIPTION
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

We were getting 

```
ImportError: cannot import name 'DEFAULT_PROFILES_DIR' from 'dbt.config.profile' (/Users/omer/fal-dev/dbt_snowflake_env/lib/python3.8/site-packages/dbt/config/profile.py)
```

For 1.3 candidate releases.

closes FEA-423


### Integration tests

Adapter to test:
- postgres
- snowflake
- bigquery
- duckdb

Python version to test:
<!-- - 3.7 -->
- 3.8
<!-- - 3.9 -->
<!-- - 3.10 -->
