### PR TITLE
feat: add --globals flag for more explicit global script execution

### DIFF
--- a/integration_tests/features/globals.feature
+++ b/integration_tests/features/globals.feature
@@ -12,11 +12,20 @@ Feature: global scripts
     Then the following scripts are ran:
       | some_model.after.py | GLOBAL.after.py |
 
-  Scenario: fal run triggers globals with select flag
+  Scenario: fal run doesn't trigger globals with select flag
     Given the project 004_globals
     When the following command is invoked:
       """
       fal run --profiles-dir $profilesDir --project-dir $baseDir --select some_model
+      """
+    Then the following scripts are ran:
+      | some_model.after.py |
+
+  Scenario: fal run triggers globals with select and globals flags
+    Given the project 004_globals
+    When the following command is invoked:
+      """
+      fal run --profiles-dir $profilesDir --project-dir $baseDir --select some_model --globals
       """
     Then the following scripts are ran:
       | some_model.after.py | GLOBAL.after.py |
@@ -34,20 +43,29 @@ Feature: global scripts
     Then the following scripts are ran:
       | GLOBAL.before.py | GLOBAL.before_b.py | some_model.before.py |
 
-  Scenario: Fal works with global before script selection
+  Scenario: --before script selection doesn't run globals
     Given the project 004_globals
     When the following command is invoked:
       """
-      fal run --profiles-dir $profilesDir --project-dir $baseDir --before --script fal_scripts/before_b.py
+      fal run --profiles-dir $profilesDir --project-dir $baseDir --before --script fal_scripts/before.py
       """
     Then the following scripts are ran:
-      | GLOBAL.before_b.py |
+      | some_model.before.py |
+
+  Scenario: global before scripts are run with --globals flag and script selection
+    Given the project 004_globals
+    When the following command is invoked:
+      """
+      fal run --profiles-dir $profilesDir --project-dir $baseDir --before --script fal_scripts/before.py --globals
+      """
+    Then the following scripts are ran:
+      | GLOBAL.before.py | some_model.before.py |
 
   Scenario: Fal selects global and not-global scripts
     Given the project 004_globals
     When the following command is invoked:
       """
-      fal run --profiles-dir $profilesDir --project-dir $baseDir --before --script fal_scripts/before.py
+      fal run --profiles-dir $profilesDir --project-dir $baseDir --before --script fal_scripts/before.py --globals
       """
     Then the following scripts are ran:
       | GLOBAL.before.py | some_model.before.py |

--- a/integration_tests/features/run.feature
+++ b/integration_tests/features/run.feature
@@ -73,7 +73,7 @@ Feature: `run` command
       """
     And the following command is invoked:
       """
-      fal run --profiles-dir $profilesDir --project-dir $baseDir --exclude '*'
+      fal run --profiles-dir $profilesDir --project-dir $baseDir --exclude '*' --globals
       """
     Then the following scripts are ran:
       | GLOBAL.freshness.py |

--- a/src/fal/cli/args.py
+++ b/src/fal/cli/args.py
@@ -202,6 +202,13 @@ def _build_run_parser(sub: argparse.ArgumentParser):
         action="store_true",
         help="Run scripts specified in model `before` tag",
     )
+
+    sub.add_argument(
+        "--globals",
+        action="store_true",
+        default=False,
+        help="Run global scripts along with selected scripts",
+    )
     # fmt: on
 
 

--- a/src/fal/cli/fal_runner.py
+++ b/src/fal/cli/fal_runner.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from dbt.flags import PROFILES_DIR
 from fal.planner.executor import parallel_executor
@@ -53,9 +53,7 @@ def fal_run(args: argparse.Namespace):
     global_scripts = _get_global_scripts(faldbt, args)
 
     if args.before:
-        if not _scripts_flag(args) or not selector_flags:
-            # run globals when no --script is passed or no selector is passed
-            _run_scripts(args, global_scripts, faldbt)
+        _handle_global_scripts(args, global_scripts, faldbt, selector_flags)
 
         pre_hook_scripts = _get_hooks_for_model(models, faldbt, "pre-hook")
 
@@ -68,10 +66,19 @@ def fal_run(args: argparse.Namespace):
 
         post_hook_scripts = _get_hooks_for_model(models, faldbt, "post-hook")
         _run_scripts(args, post_hook_scripts, faldbt)
+        _handle_global_scripts(args, global_scripts, faldbt, selector_flags)
 
-        if not _scripts_flag(args) or not selector_flags:
-            # run globals when no --script is passed
-            _run_scripts(args, global_scripts, faldbt)
+
+def _handle_global_scripts(args: argparse.Namespace,
+                           global_scripts: List[FalScript],
+                           faldbt: FalDbt,
+                           selector_flags: Any) -> None:
+    scripts_flag = _scripts_flag(args)
+    if not scripts_flag and not selector_flags:
+        # run globals when no --script is passed and no selector is passed
+        _run_scripts(args, global_scripts, faldbt)
+    if (scripts_flag or selector_flags) and args.globals:
+        _run_scripts(args, global_scripts, faldbt)
 
 
 def _run_scripts(args: argparse.Namespace, scripts: List[FalScript], faldbt: FalDbt):

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -400,6 +400,7 @@ def _clean_args_list(args: List[str]) -> List[str]:
         "--vars",
         "--var",
         "--target",
+        "--globals"
     ]
     REDACTED = "[REDACTED]"
     output = []

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -348,6 +348,7 @@ def test_redaction():
                     "--debug",
                     "--vars",
                     "{env: 'some'}",
+                    "--globals"
                 ]
             },
         )
@@ -402,6 +403,7 @@ def test_redaction():
                     "--debug",
                     "--vars",
                     "[REDACTED]",
+                    "--globals"
                 ],
             },
         )


### PR DESCRIPTION
## Description
Add `--globals` flag for more explicit global script execution. With this change, if any model selector flag OR a `--scripts` flag are passed, global scripts are NOT executed by default. In order to run them in these scenarios, users need to pass the `--globals` flag.

Following scenarios are now tested in integrations tests:

- fal runs globals by default when no model or script selection is indicated
- fal run doesn't trigger globals with select flag
- fal run triggers global scripts with model select and `--globals` flags
- script selection with `--scripts` flag doesn't run global scripts
- global scripts are run when both `--scripts` and `--globals` flags are passed

### Integration tests

Adapter to test:
- postgres

Python version to test:
- 3.8