### PR TITLE
chore: Make importing faldbt.lib not have circular dependencies

### DIFF
--- a/.github/workflows/test_profiles.yml
+++ b/.github/workflows/test_profiles.yml
@@ -85,7 +85,7 @@ jobs:
             PR_TITLE = '${{ github.event.pull_request.title }}'.lower()
             PR_BRANCH = '${{ github.head_ref }}'.lower()
             PR_DESCRIPTION = '''${{ github.event.pull_request.body }}'''.lower()
-            PR_DESCRIPTION = re.sub("<!--.*?-->", "", PR_DESCRIPTION)
+            PR_DESCRIPTION = re.sub("<!--.*?-->", "", PR_DESCRIPTION, flags=re.DOTALL)
 
             # Only test adapters mentioned in the pull request title or branch.
             # We always test postgres as a sanity check.

--- a/src/fal/cli/cli.py
+++ b/src/fal/cli/cli.py
@@ -10,7 +10,7 @@ from fal.telemetry import telemetry
 
 import dbt.exceptions
 import dbt.ui
-from fal.logger import log_manager
+from faldbt.logger import log_manager
 
 
 def cli(argv: List[str] = sys.argv):

--- a/src/fal/cli/dbt_runner.py
+++ b/src/fal/cli/dbt_runner.py
@@ -3,7 +3,7 @@ from multiprocessing.connection import Connection
 from typing import Any, Dict, Optional, List
 import warnings
 import json
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 import os
 import argparse
 

--- a/src/fal/cli/model_generator/model_generator.py
+++ b/src/fal/cli/model_generator/model_generator.py
@@ -10,7 +10,7 @@ from fal.cli.model_generator.module_check import (
     write_to_model_check,
 )
 
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 from fal.telemetry import telemetry
 

--- a/src/fal/el/airbyte.py
+++ b/src/fal/el/airbyte.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import requests
 import time
 from requests.exceptions import RequestException
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 from fal.telemetry import telemetry
 

--- a/src/fal/el/fivetran.py
+++ b/src/fal/el/fivetran.py
@@ -9,7 +9,7 @@ from requests.exceptions import RequestException
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 from dateutil import parser
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 BASE_URL = "https://api.fivetran.com/v1/connectors/"
 

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -11,7 +11,7 @@ from faldbt.project import DbtModel, FalDbt
 
 from dbt.contracts.results import RunStatus
 from dbt.config.runtime import RuntimeConfig
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 from dbt.contracts.graph.parsed import ColumnInfo
 

--- a/src/fal/packages/environments/base.py
+++ b/src/fal/packages/environments/base.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, ContextManager, Generic, Iterator, TypeVar, Di
 
 from platformdirs import user_cache_dir
 
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 from fal.packages import bridge, isolated_runner
 
 BASE_CACHE_DIR = Path(user_cache_dir("fal", "fal"))

--- a/src/fal/packages/isolated_runner.py
+++ b/src/fal/packages/isolated_runner.py
@@ -3,7 +3,7 @@ import sys
 import time
 from argparse import ArgumentParser
 
-from fal.logger import LOGGER, log_manager
+from faldbt.logger import LOGGER, log_manager
 from fal.packages import bridge
 
 # Isolated processes are really tricky to debug properly

--- a/src/fal/planner/executor.py
+++ b/src/fal/planner/executor.py
@@ -21,7 +21,7 @@ from fal.planner.tasks import (
 )
 from faldbt.project import FalDbt
 
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 
 class State(Enum):

--- a/src/fal/planner/plan.py
+++ b/src/fal/planner/plan.py
@@ -5,7 +5,7 @@ from typing import Callable, Iterator, List, Set
 import networkx as nx
 from fal.node_graph import NodeKind
 from fal.cli.selectors import ExecutionPlan, _is_before_script, _is_after_script
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 from dataclasses import dataclass
 
 

--- a/src/fal/planner/tasks.py
+++ b/src/fal/planner/tasks.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Iterator, List, Any, Optional, Dict, Tuple, Union
 
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 from fal.node_graph import FalScript
 from fal.utils import print_run_info, DynamicIndexProvider

--- a/src/fal/utils.py
+++ b/src/fal/utils.py
@@ -1,7 +1,7 @@
 """Fal utilities."""
 import copy
 import functools
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/src/faldbt/lib.py
+++ b/src/faldbt/lib.py
@@ -8,19 +8,14 @@ from typing import Iterator, List, Optional, Tuple
 from urllib.parse import quote_plus
 import threading
 
-import dbt.version
-from dbt.semver import VersionSpecifier
 import dbt.flags as flags
 import dbt.adapters.factory as adapters_factory
-from fal.logger import LOGGER
 
 from dbt.contracts.connection import AdapterResponse
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.base import BaseRelation, BaseAdapter, BaseConnectionManager
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.config import RuntimeConfig
-
-from . import parse
 
 import pandas as pd
 from pandas.io import sql as pdsql
@@ -32,19 +27,8 @@ from sqlalchemy.sql import Insert
 
 from dbt.contracts.sql import RemoteRunResult
 
-DBT_VCURRENT = dbt.version.installed
-
-
-def version_compare(version_string: str):
-    return DBT_VCURRENT.compare(VersionSpecifier.from_version_string(version_string))
-
-
-IS_DBT_V1PLUS = version_compare("1.0.0") >= 0
-
-_DBT_V1 = VersionSpecifier.from_version_string("1.0.0")
-DBT_VCURRENT = dbt.version.installed
-
-IS_DBT_V1PLUS = DBT_VCURRENT.compare(_DBT_V1) >= 0
+from faldbt import parse
+from faldbt.logger import LOGGER
 
 
 class WriteModeEnum(Enum):

--- a/src/faldbt/logger.py
+++ b/src/faldbt/logger.py
@@ -11,6 +11,8 @@ from dbt.events.base_types import (
     ErrorLevel as _ErrorLevel,
 )
 
+import faldbt.version as version
+
 
 class FireEventLogger:
     def test(self, msg: str, *args, **kwargs):
@@ -46,10 +48,7 @@ def _prepare_msg(msg: str, *args, **kwargs):
 
 LOGGER = FireEventLogger()
 
-# NOTE: fal.logger is imported in faldbt.lib, so import must be here
-import faldbt.lib as lib
-
-if lib.version_compare("1.1.0") < 0:
+if version.version_compare("1.1.0") < 0:
     from dbt.events.base_types import Cli, Event
 
     _EXTRA_CLASS_INHERIT = Cli, Event

--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -12,7 +12,7 @@ from dbt.contracts.results import RunResultsArtifact, FreshnessExecutionResultAr
 from dbt.contracts.project import UserConfig
 from dbt.config.profile import read_user_config
 from dbt.exceptions import IncompatibleSchemaException, RuntimeException
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 
 from faldbt.utils.yaml_helper import load_yaml
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -38,13 +38,13 @@ from dbt.contracts.results import (
     FreshnessExecutionResultArtifact,
     FreshnessNodeOutput,
 )
-from fal.logger import LOGGER
+from faldbt.logger import LOGGER
 from dbt.task.compile import CompileTask
 import dbt.tracking
 
-from .lib import WriteModeEnum
 from . import parse
 from . import lib
+from . import version
 from .el_client import FalElClient
 
 from fal.feature_store.feature import Feature
@@ -433,9 +433,9 @@ class FalDbt:
         args_vars: str = "{}",
         generated_models: Dict[str, Path] = {},
     ):
-        if not lib.IS_DBT_V1PLUS:
+        if not version.IS_DBT_V1PLUS:
             raise NotImplementedError(
-                f"dbt version {lib.DBT_VCURRENT} is no longer supported, please upgrade to dbt 1.0.0 or above"
+                f"dbt version {version.DBT_VCURRENT} is no longer supported, please upgrade to dbt 1.0.0 or above"
             )
 
         self.project_dir = os.path.realpath(os.path.expanduser(project_dir))
@@ -709,8 +709,8 @@ class FalDbt:
 
         target_source = self._source(target_source_name, target_table_name)
 
-        write_mode = WriteModeEnum(mode.lower().strip())
-        if write_mode == WriteModeEnum.APPEND:
+        write_mode = lib.WriteModeEnum(mode.lower().strip())
+        if write_mode == lib.WriteModeEnum.APPEND:
             lib.write_target(
                 data,
                 self.project_dir,
@@ -721,7 +721,7 @@ class FalDbt:
                 config=self._config,
             )
 
-        elif write_mode == WriteModeEnum.OVERWRITE:
+        elif write_mode == lib.WriteModeEnum.OVERWRITE:
             lib.overwrite_target(
                 data,
                 self.project_dir,
@@ -756,8 +756,8 @@ class FalDbt:
 
         target_model = self._model(target_model_name, target_package_name)
 
-        write_mode = WriteModeEnum(mode.lower().strip())
-        if write_mode == WriteModeEnum.APPEND:
+        write_mode = lib.WriteModeEnum(mode.lower().strip())
+        if write_mode == lib.WriteModeEnum.APPEND:
             lib.write_target(
                 data,
                 self.project_dir,
@@ -768,7 +768,7 @@ class FalDbt:
                 config=self._config,
             )
 
-        elif write_mode == WriteModeEnum.OVERWRITE:
+        elif write_mode == lib.WriteModeEnum.OVERWRITE:
             lib.overwrite_target(
                 data,
                 self.project_dir,

--- a/src/faldbt/version.py
+++ b/src/faldbt/version.py
@@ -1,0 +1,9 @@
+import dbt.version
+from dbt.semver import VersionSpecifier
+
+def version_compare(version_string: str):
+    return DBT_VCURRENT.compare(VersionSpecifier.from_version_string(version_string))
+
+DBT_VCURRENT = dbt.version.installed
+IS_DBT_V1PLUS = version_compare("1.0.0") >= 0
+IS_DBT_WITH_PYTHON_MODELS = version_compare("1.3.0-a1") >= 0


### PR DESCRIPTION
## Description

```
❯ python
Python 3.8.13 (default, Sep 30 2022, 17:13:29)
[Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import faldbt.lib
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matteo/Projects/fal-ai/fal/src/faldbt/lib.py", line 15, in <module>
    from fal.logger import LOGGER
  File "/Users/matteo/Projects/fal-ai/fal/src/fal/__init__.py", line 3, in <module>
    from faldbt.project import (
  File "/Users/matteo/Projects/fal-ai/fal/src/faldbt/project.py", line 41, in <module>
    from fal.logger import LOGGER
  File "/Users/matteo/Projects/fal-ai/fal/src/fal/logger.py", line 52, in <module>
    if lib.version_compare("1.1.0") < 0:
AttributeError: partially initialized module 'faldbt.lib' has no attribute 'version_compare' (most likely due to a circular import)
```

now with this

```
❯ python
Python 3.8.13 (default, Sep 30 2022, 17:13:29)
[Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import faldbt.lib
>>> faldbt.lib.
faldbt.lib.AdapterResponse(        faldbt.lib.FlagsArgs(              faldbt.lib.RuntimeConfig(          faldbt.lib.contextmanager(         faldbt.lib.parse                   faldbt.lib.threading
faldbt.lib.BaseAdapter(            faldbt.lib.Insert(                 faldbt.lib.SQLAdapter(             faldbt.lib.dataclass(              faldbt.lib.pd                      faldbt.lib.uuid4(
faldbt.lib.BaseConnectionManager(  faldbt.lib.Iterator(               faldbt.lib.Tuple(                  faldbt.lib.execute_sql(            faldbt.lib.pdsql                   faldbt.lib.write_target(
faldbt.lib.BaseRelation(           faldbt.lib.LOGGER                  faldbt.lib.WriteModeEnum(          faldbt.lib.fetch_target(           faldbt.lib.quote_plus(
faldbt.lib.CompileResultNode(      faldbt.lib.List(                   faldbt.lib.adapters_factory        faldbt.lib.flags                   faldbt.lib.register_adapters(
faldbt.lib.CreateTable(            faldbt.lib.Optional(               faldbt.lib.agate                   faldbt.lib.initialize_dbt_flags(   faldbt.lib.six
faldbt.lib.Enum(                   faldbt.lib.RemoteRunResult(        faldbt.lib.compile_sql(            faldbt.lib.overwrite_target(       faldbt.lib.sqlalchemy
```

<!-- If applicable: -->
<!--
GitHub: resolves #XXX
Linear: closes FEA-XXX
-->

### Integration tests

Adapter to test:
<!-- Add relevant ones -->
- postgres
<!--
- snowflake
- bigquery
- redshift
- duckdb
- athena
-->

Python version to test:
<!-- Add relevant ones -->
- 3.8
<!--
- 3.7
- 3.9
- 3.10
-->
