### PR TITLE
feat: offer run_result for models in context

### DIFF
--- a/integration_tests/projects/005_functions_and_variables/fal_scripts/context.py
+++ b/integration_tests/projects/005_functions_and_variables/fal_scripts/context.py
@@ -11,6 +11,8 @@ extra += f"target name: {context.target.name}\n"
 extra += f"target profile: {context.target.profile_name}\n"
 extra += f"target database: {context.target.database}\n"
 
+extra += f"run result: {context.current_model.run_result}\n"
+
 response = context.current_model.adapter_response
 assert response
 

--- a/src/fal/fal_script.py
+++ b/src/fal/fal_script.py
@@ -74,6 +74,7 @@ class CurrentModel:
     columns: Dict[str, ColumnInfo]
     tests: List[Any]
     meta: Dict[Any, Any]
+    run_result: Optional[Any]
     adapter_response: Optional[CurrentAdapterResponse]
 
 
@@ -272,6 +273,7 @@ class FalScript:
             columns=model.columns,
             tests=tests,
             meta=meta,
+            run_result=model.run_result,
             adapter_response=current_adapter_response,
         )
 

--- a/src/fal/packages/isolated_runner.py
+++ b/src/fal/packages/isolated_runner.py
@@ -87,7 +87,7 @@ def _get_shell_bootstrap() -> str:
     )
 
 
-def _fal_main() -> None:
+def _fal_main():
     from faldbt.logger import LOGGER
     from fal.packages import bridge
 

--- a/src/faldbt/project.py
+++ b/src/faldbt/project.py
@@ -209,6 +209,8 @@ class DbtModel(_DbtTestableNode):
 
     _adapter_response: Optional[AdapterResponse] = field(default=None)
 
+    run_result = Optional[Any]
+
     def __repr__(self):
         attrs = ["name", "alias", "unique_id", "columns", "tests", "status"]
         props = ", ".join([f"{item}={repr(getattr(self, item))}" for item in attrs])
@@ -382,6 +384,7 @@ class DbtManifest:
             if result:
                 model.status = result.status.value
                 model.adapter_response = result.adapter_response
+                model.run_result = result
 
             models.append(model)
 


### PR DESCRIPTION
## Description
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Add `run_result` information for a model. We are missing tests.

```
run result: RunResultOutput(status=<RunStatus.Success: 'success'>, timing=[TimingInfo(name='compile', started_at=datetime.datetime(2022, 10, 17, 21, 16, 31, 52868, tzinfo=tzutc()), completed_at=datetime.datetime(2022, 10, 17, 21, 16, 31, 54862, tzinfo=tzutc())), TimingInfo(name='execute', started_at=datetime.datetime(2022, 10, 17, 21, 16, 31, 55018, tzinfo=tzutc()), completed_at=datetime.datetime(2022, 10, 17, 21, 16, 31, 105600, tzinfo=tzutc()))], thread_id='Thread-1', execution_time=0.05340003967285156, adapter_response={'_message': 'SELECT 1', 'code': 'SELECT', 'rows_affected': 1}, message='SELECT 1', failures=None, unique_id='model.fal_005.some_model')
```

cc: @cmlad

### Integration tests

Adapter to test:
<!-- Add relevant ones -->
- postgres
<!--
- snowflake
- bigquery
- redshift
- duckdb
- athena
-->

Python version to test:
<!-- Add relevant ones -->
- 3.8
<!--
- 3.7
- 3.9
- 3.10
-->
