### PR TITLE
Restrict dill version 0.3.6< since it is breaking fal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ deprecation = "^2.1.0"
 # Environment management related dependencies
 platformdirs = "^2.5.2"
 virtualenv = "^20.16.2"
-dill = "^0.3.5.1"
+dill = "^0.3.5.1, <0.3.6"
 importlib-metadata = "^4.12.0"
 
 # TODO: review any of these are bigquery-specific or for firebase


### PR DESCRIPTION
Python version to test:
- 3.8
- 3.7
- 3.9
- 3.10
