### PR TITLE
feat: make encapsulate pass-through sql tables

### DIFF
--- a/adapter/integration_tests/projects/simple_project/models/model_c.py
+++ b/adapter/integration_tests/projects/simple_project/models/model_c.py
@@ -2,7 +2,7 @@ from _fal_testing.utils import create_model_artifact
 from fal.typing import *
 
 def model(dbt, fal):
-    dbt.config(materialized="fal_table")
+    dbt.config(materialized="table")
     df = dbt.ref("model_b")
 
     df["my_bool"] = True


### PR DESCRIPTION
## Description

With this change now Python models with encapsulating adapter can have 

```py
def model(dbt, fal):
  dbt.config(materialized='table')
```

and it will run on fal.

❗ ❗❗ This makes it impossible to run some Python models on fal and others on the db-adapter's Python runtime. All models will run with fal.

### Integration tests

- [x] We have to wait for https://github.com/fal-ai/fal/pull/602 to be merged first.

Adapter to test:
<!-- Add relevant ones -->
- postgres
- snowflake
- bigquery
- duckdb

Python version to test:
<!-- Add relevant ones -->
- 3.8
<!--
- 3.7
- 3.9
- 3.10
-->
