### PR TITLE
chore: Remove automatic release and check branch of release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -3,8 +3,6 @@
 name: PyPI Release
 
 on:
-  push:
-    branches: [release]
   workflow_dispatch:
     inputs:
       version:
@@ -15,9 +13,17 @@ on:
         options:
           - patch
           - minor
+      publish_from_any_branch:
+        description: Publish from any branch
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   deploy:
+    # Run only for `release` branch or if marked as acceptable
+    if: github.ref == 'refs/heads/release' || inputs.publish_from_any_branch
+
     runs-on: ubuntu-latest
 
     steps:
@@ -25,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
@@ -38,11 +44,7 @@ jobs:
           PYPI_USERNAME: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          VERSION_TYPE="patch"
-          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]
-          then
-            VERSION_TYPE="${{ github.event.inputs.version }}"
-          fi
+          VERSION_TYPE="${{ inputs.version }}"
 
           poetry version $VERSION_TYPE
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2745502/199334253-b32e1b3a-9762-42ea-a6a1-44840522a511.png)

Example skipped because it did not run from the `release` branch: https://github.com/fal-ai/fal/actions/runs/3372641323
Example running becase the checkbox was checked (cancelled manually): https://github.com/fal-ai/fal/actions/runs/3372658764/jobs/5596344586