### PR TITLE
fix(dbt-fal): Find wrapped adapter Relation class on init 

### DIFF
--- a/adapter/integration_tests/projects/simple_project/dbt_project.yml
+++ b/adapter/integration_tests/projects/simple_project/dbt_project.yml
@@ -14,12 +14,5 @@ vars:
   fal-scripts-path: "scripts"
   fal-models-paths: ["fal_models"]
 
-# NOTE: necessary for snowflake projects
-# dbt uses adapter_class.Relation, and that is BaseRelation
-quoting:
-  database: false
-  schema: false
-  identifier: false
-
 models:
   +schema: custom

--- a/adapter/src/dbt/adapters/fal/impl.py
+++ b/adapter/src/dbt/adapters/fal/impl.py
@@ -1,10 +1,8 @@
+from typing import Dict, Any
+
 from contextlib import contextmanager
-from dbt import flags
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.factory import FACTORY
-from dbt.config.profile import Profile, read_profile
-from dbt.config.renderer import ProfileRenderer
-from dbt.config.utils import parse_cli_vars
 
 from .connections import FalEncCredentials
 from .wrappers import FalEncAdapterWrapper, FalCredentialsWrapper
@@ -18,24 +16,63 @@ def _release_plugin_lock():
     finally:
         FACTORY.lock.acquire()
 
+def load_db_profile():
+    import sys
+    import os
 
-def load_db_profile(config) -> Profile:
-    fal_credentials = config.credentials
+    from dbt.main import parse_args
+    from dbt.config.profile import Profile, read_profile
+    from dbt.config.project import Project
+    from dbt.config.renderer import ProfileRenderer
+    from dbt.config.utils import parse_cli_vars
+    from dbt import flags
 
-    raw_profile_data = read_profile(flags.PROFILES_DIR)
-    cli_vars = parse_cli_vars(getattr(config.args, "vars", "{}"))
-    with _release_plugin_lock():
+    args = parse_args(sys.argv[1:])
+
+    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/runtime.py#L193-L203
+    project_root = args.project_dir if args.project_dir else os.getcwd()
+    version_check = bool(flags.VERSION_CHECK)
+    partial = Project.partial_load(project_root, verify_version=version_check)
+
+    cli_vars: Dict[str, Any] = parse_cli_vars(getattr(args, "vars", "{}"))
+    profile_renderer = ProfileRenderer(cli_vars)
+    project_profile_name = partial.render_profile_name(profile_renderer)
+
+    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/profile.py#L423-L425
+    profile_name = Profile.pick_profile_name(getattr(args, "profile", None), project_profile_name)
+    raw_profiles = read_profile(flags.PROFILES_DIR)
+    raw_profile = raw_profiles[profile_name]
+
+    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/profile.py#L287-L293
+    target_override = getattr(args, "target", None)
+    if target_override is not None:
+        target_name = target_override
+    elif "target" in raw_profile:
+        target_name = profile_renderer.render_value(raw_profile["target"])
+    else:
+        target_name = "default"
+
+    fal_dict = Profile._get_profile_data(raw_profile, profile_name, target_name)
+    db_profile = fal_dict.get('db_profile')
+    assert db_profile, "fal credentials must have a `db_profile` property set"
+
+    try:
         return Profile.from_raw_profiles(
-            raw_profile_data,
-            config.profile_name,
+            raw_profiles,
+            profile_name,
             renderer=ProfileRenderer(cli_vars),
-            target_override=fal_credentials.db_profile,
+            target_override=db_profile,
         )
+    except AttributeError as error:
+        if "circular import" in str(error):
+            raise AttributeError("Do not wrap a type 'fal' profile with another type 'fal' profile") from error
 
+DB_PROFILE = load_db_profile()
+DB_RELATION = FACTORY.get_relation_class_by_name(DB_PROFILE.credentials.type)
 
-# NOTE: cls.Relation = BaseRelation, causes problems for Snowflake because BaseRelation has quoting = True for all
-# TODO: maybe assign FalEncAdapter.Relation in `__init__` Plugin and have this directly inherit from FalAdapterMixin
 class FalEncAdapter(BaseAdapter):
+    Relation = DB_RELATION  # type: ignore
+
     def __new__(cls, config):
         # There are two different credentials types which can be passed to FalEncAdapter
         # 1. FalEncCredentials
@@ -48,8 +85,7 @@ class FalEncAdapter(BaseAdapter):
 
         fal_credentials = config.credentials
         if isinstance(fal_credentials, FalEncCredentials):
-            db_profile = load_db_profile(config)
-            db_credentials = db_profile.credentials
+            db_credentials = DB_PROFILE.credentials
         else:
             # Since profile construction (in the case above) already registers the
             # adapter plugin for the db type, we need to also mimic that here.
@@ -61,9 +97,7 @@ class FalEncAdapter(BaseAdapter):
         # TODO: maybe we can do this better?
         with _release_plugin_lock():
             original_plugin = FACTORY.get_plugin_by_name(fal_credentials.type)
-            db_adapter_plugin = FACTORY.get_plugin_by_name(db_credentials.type)
-
-        db_type: BaseAdapter = db_adapter_plugin.adapter  # type: ignore
+            db_adapter_class = FACTORY.get_adapter_class_by_name(db_credentials.type)
 
         original_plugin.dependencies = [db_credentials.type]
 
@@ -74,10 +108,9 @@ class FalEncAdapter(BaseAdapter):
             # Temporary credentials for register
             config.credentials = config.sql_adapter_credentials
             FACTORY.register_adapter(config)
+            config.credentials = FalCredentialsWrapper(config.sql_adapter_credentials)
 
-        config.credentials = FalCredentialsWrapper(config.sql_adapter_credentials)
-
-        return FalEncAdapterWrapper(db_type, config)
+        return FalEncAdapterWrapper(db_adapter_class, config)
 
     @classmethod
     def type(cls):


### PR DESCRIPTION
We no longer have to specify the wrapped adapter's quoting behavior in dbt_project.yml
