### PR TITLE
fix(dbt-fal): Inherit is_cancelable from the wrapped adapter

### DIFF
--- a/adapter/src/dbt/adapters/fal_experimental/impl.py
+++ b/adapter/src/dbt/adapters/fal_experimental/impl.py
@@ -48,11 +48,6 @@ class FalAdapterMixin(TeleportAdapter, metaclass=AdapterMeta):
     def storage_formats(cls):
         return ["csv", "parquet"]
 
-    @classmethod
-    def is_cancelable(cls) -> bool:
-        # TODO: maybe it is?
-        return False
-
     @available
     def is_teleport(self) -> bool:
         return getattr(self.credentials, "teleport", None) is not None
@@ -211,3 +206,8 @@ class FalAdapter(FalAdapterMixin, PythonAdapter):
             config=config,
             additional_props={"is_teleport": self.is_teleport()},
         )
+
+    @classmethod
+    def is_cancelable(cls) -> bool:
+        # TODO: maybe it is?
+        return False


### PR DESCRIPTION
## Description

Now when a `ctrl-c` happens, it cancels or not depending on the wrapped db adapter config.

We may need to work on handling cancels better in the future. But it's OK for now.