### PR TITLE
fix(dbt-fal): Include _parse_replacements_ from DB adapter into wrapper adpater

### DIFF
--- a/adapter/src/dbt/adapters/fal/wrappers.py
+++ b/adapter/src/dbt/adapters/fal/wrappers.py
@@ -37,10 +37,14 @@ class FalEncAdapterWrapper(FalAdapterMixin):
         db_adapter = get_adapter_by_type(db_adapter_type.type())
         super().__init__(config, db_adapter)
 
-        # HACK: A Python adapter does not have _available_ all the attributes a DB adapter does.
+        # HACK: A Python adapter does not have self._available_ all the attributes a DB adapter does.
         # Since we use the DB adapter as the storage for the Python adapter, we must proxy to it
         # all the unhandled calls.
+
+        # self._available_ is set by metaclass=AdapterMeta
         self._available_ = self._db_adapter._available_.union(self._available_)
+        # self._parse_replacements_ is set by metaclass=AdapterMeta
+        self._parse_replacements_.update(self._db_adapter._parse_replacements_)
 
         telemetry.log_api(
             "encapsulate_init",

--- a/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -52,6 +52,7 @@ def run_in_environment_with_adapter(
     The environment_name must be defined inside fal_project.yml file
     in your project's root directory."""
     if type(environment) == IsolateServer:
+        # TODO: make a specialized function for this case?
         deps = [i for i in get_default_pip_dependencies() if i.startswith('dbt-')]
 
         if environment.target_environment_kind == 'conda':


### PR DESCRIPTION
## Description
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Setting `self._parse_replacements_` which was not being set and is built in the `AdapterMeta` class.

I will try to explain what was going on:

1. compiling was loading the manifest
2. which was parsing the project and all it's dependencies
3. the fivetran package had some database-specific jinja
4. which failed static jinja parsing and triggered an [adapter-connected parse](https://github.com/dbt-labs/dbt-core/blob/930bd3541e19f160ed79f3cc6c26ea7085ced760/core/dbt/parser/models.py#L337-L338)
   ```py
            # jinja rendering
            super().render_update(node, config)
            fire_event(StaticParserFallbackJinjaRendering(path=node.path))
   ```
5. then in the fivetran package jinja we get [an `adapter.get_columns_in_relation(...)` call](https://github.com/fivetran/dbt_stripe_source/blob/3a51c3f2097597be7b838081a367bcf77d900912/models/stg_stripe__invoice_line_item.sql#L14)
What was happening whas that the fivetran dbt package has some jinja values that need to go to the database to be filled. 
6. this call is hanlded by [the `ParseDatabaseWrapper`](https://github.com/dbt-labs/dbt-core/blob/930bd3541e19f160ed79f3cc6c26ea7085ced760/core/dbt/context/providers.py#L430-L434)
7. and for the fal encapsulating adapter, `name in self._adapter._parse_replacements_` was `False` when it should be `True`

We should add a test around this.