### PR TITLE
chore(dbt-fal): change default script path to project dir

### DIFF
--- a/adapter/integration_tests/projects/env_project/dbt_project.yml
+++ b/adapter/integration_tests/projects/env_project/dbt_project.yml
@@ -10,5 +10,8 @@ snapshot-paths: ["snapshots"]
 
 target-path: "{{ env_var('temp_dir') }}/target"
 
+vars:
+  fal-scripts-path: "fal_scripts"
+
 models:
   +schema: custom

--- a/adapter/integration_tests/projects/simple_project/dbt_project.yml
+++ b/adapter/integration_tests/projects/simple_project/dbt_project.yml
@@ -12,6 +12,3 @@ target-path: "{{ env_var('temp_dir') }}/target"
 
 models:
   +schema: custom
-
-vars:
-  fal-scripts-path: "utils"

--- a/adapter/integration_tests/projects/simple_project/models/model_c.py
+++ b/adapter/integration_tests/projects/simple_project/models/model_c.py
@@ -1,5 +1,5 @@
 def model(dbt, fal):
-    from get_bool import get_bool
+    from utils.get_bool import get_bool
 
     dbt.config(materialized="table")
     df = dbt.ref("model_b")

--- a/adapter/src/dbt/adapters/fal_experimental/utils/__init__.py
+++ b/adapter/src/dbt/adapters/fal_experimental/utils/__init__.py
@@ -29,7 +29,7 @@ def get_fal_scripts_path(config: RuntimeConfig):
     project_path = pathlib.Path(config.project_root)
 
     # Default value
-    fal_scripts_path = 'fal_scripts'
+    fal_scripts_path = ''
 
     if hasattr(config, 'vars'):
         fal_scripts_path: str = config.vars.to_dict().get(FAL_SCRIPTS_PATH_VAR_NAME, fal_scripts_path)  # type: ignore


### PR DESCRIPTION
This is done for consistency with fal. There might be future use cases where scripts path cannot be the dbt project path, so we have to be mindful of that.
