### PR TITLE
fix: FalDbt init with dbt-fal

### DIFF
--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -62,6 +62,7 @@ def get_dbt_config(
     profile: Optional[str] = None,
 ) -> RuntimeConfig:
     # Construct a phony config
+    import os
     args = RuntimeArgs(
         project_dir=project_dir,
         profiles_dir=profiles_dir,
@@ -70,7 +71,16 @@ def get_dbt_config(
         profile=profile,
         target=profile_target,
     )
-    return RuntimeConfig.from_args(args)
+
+    if project_dir and not os.getenv("GITHUB_ACTIONS"):
+        # HACK: initializing dbt-fal requires cwd to be project_dir
+        owd = os.getcwd()
+        os.chdir(project_dir)
+        config = RuntimeConfig.from_args(args)
+        os.chdir(owd)
+    else:
+        config = RuntimeConfig.from_args(args)
+    return config
 
 
 def get_el_configs(


### PR DESCRIPTION
Initializing FalDbt in a directory other than project_dir was causing this error:

```
dbt.exceptions.DbtProjectError: Runtime Error
  no dbt_project.yml found at expected path [redacted]/dbt_project.yml
```
