### PR TITLE
tests: use latest 1.3 version for integration tests

### DIFF
--- a/.github/workflows/test_integration_cli.yml
+++ b/.github/workflows/test_integration_cli.yml
@@ -59,7 +59,7 @@ on:
           - "1.0.*"
           - "1.1.*"
           - "1.2.*"
-          - "1.3.0rc2" # TODO: update when released
+          - "1.3.*"
 
 jobs:
   matrix-adapter:
@@ -175,7 +175,7 @@ jobs:
             "1.0.*",
             "1.1.*",
             "1.2.*",
-            "1.3.0rc2", # TODO: update when released
+            "1.3.*",
           ]
           OUTPUT = OPTIONS
 

--- a/.github/workflows/test_integration_cli.yml
+++ b/.github/workflows/test_integration_cli.yml
@@ -202,15 +202,23 @@ jobs:
         dbt: ${{ fromJSON(needs.matrix-dbt.outputs.list) }}
         python: ${{ fromJSON(needs.matrix-python.outputs.list) }}
         exclude:
-          # Only DBT 1.1+ supports Python 3.10 (officially)
+          # Only dbt 1.1+ supports Python 3.10 (officially)
           - python: 3.10
             dbt: "1.0.*"
+          # dbt-fal is for dbt-core>=1.3
           - profile: "fal"
             dbt: "1.0.*"
           - profile: "fal"
             dbt: "1.1.*"
           - profile: "fal"
             dbt: "1.2.*"
+          # dbt-athena-adapter only supports dbt-core==1.0.* for now
+          - profile: "athena"
+            dbt: "1.1.*"
+          - profile: "athena"
+            dbt: "1.2.*"
+          - profile: "athena"
+            dbt: "1.3.*"
 
     # Run only the latest commit pushed to PR
     concurrency:


### PR DESCRIPTION

Adapter to test:
<!-- Add relevant ones -->
- postgres
- snowflake
- bigquery
- redshift
- duckdb
- athena

Python version to test:
<!-- Add relevant ones -->
- 3.8
- 3.7
- 3.9
- 3.10
