### PR TITLE
feat(dbt-fal): enable fal cloud

### DIFF
--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -40,8 +40,6 @@ jobs:
           - profile: snowflake
             teleport: true
             cloud: true
-          - profile: bigquery
-            cloud: true
           - profile: redshift
             cloud: true
 
@@ -171,15 +169,21 @@ jobs:
           export DB_NAMESPACE="${{ github.run_id }}_${UUID}"
 
           BEHAVE_TAGS=""
-          if [[ '${{ matrix.teleport }}' != 'true' ]] && [[ '${{ matrix.cloud }}' != 'true' ]]
-          then
-            BEHAVE_TAGS="--tags=-teleport --tags=-cloud"
-          elif [[ '${{ matrix.teleport }}' != 'true' ]]
+          if [[ '${{ matrix.teleport }}' != 'true' ]]
           then
             BEHAVE_TAGS="--tags=-teleport"
-          elif [[ '${{ matrix.cloud }}' != 'true' ]]
+          fi
+
+          if [[ '${{ matrix.cloud }}' != 'true' ]]
           then
-            BEHAVE_TAGS="--tags=-cloud"
+            BEHAVE_TAGS="$BEHAVE_TAGS --tags=-cloud"
+          fi
+
+          if [[ -z "${GITHUB_HEAD_REF}" ]]
+          then
+            export FAL_GITHUB_BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
+          else
+            export FAL_GITHUB_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           fi
 
           behave $BEHAVE_TAGS -fplain -D profile=${{ matrix.profile }}

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -39,6 +39,12 @@ jobs:
             adapter_version: 1.2.2
           - profile: snowflake
             teleport: true
+            cloud: true
+          - profile: bigquery
+            cloud: true
+          - profile: redshift
+            cloud: true
+
 
     concurrency:
       group: "${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ matrix.profile }}-${{ matrix.python }}"
@@ -75,13 +81,20 @@ jobs:
           fi
 
           pushd ..
-          if [[ '${{ matrix.teleport }}' == 'true' ]]
+          if [[ '${{ matrix.teleport }}' == 'true' ]] && [[ '${{ matrix.cloud }}' == 'true' ]]
+          then
+            pip install -e ".[${{ matrix.profile }},teleport,cloud]"
+          elif [[ '${{ matrix.teleport }}' == 'true' ]]
           then
             pip install -e ".[${{ matrix.profile }},teleport]"
+          elif [[ '${{ matrix.cloud }}' == 'true' ]]
+          then
+            pip install -e ".[${{ matrix.profile }},cloud]"
           else
             pip install -e ".[${{ matrix.profile }}]"
           fi
           popd
+
 
       - name: Setup behave
         working-directory: fal/adapter/integration_tests
@@ -116,6 +129,10 @@ jobs:
           # Teleport
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Isolate Cloud
+          FAL_HOST: ${{ secrets.FAL_HOST }}
+          FAL_KEY_SECRET: ${{ secrets.FAL_KEY_SECRET }}
+          FAL_KEY_ID: ${{ secrets.FAL_KEY_ID }}
         run: |
           source .venv/bin/activate
 
@@ -154,9 +171,15 @@ jobs:
           export DB_NAMESPACE="${{ github.run_id }}_${UUID}"
 
           BEHAVE_TAGS=""
-          if [[ '${{ matrix.teleport }}' != 'true' ]]
+          if [[ '${{ matrix.teleport }}' != 'true' ]] && [[ '${{ matrix.cloud }}' != 'true' ]]
+          then
+            BEHAVE_TAGS="--tags=-teleport --tags=-cloud"
+          elif [[ '${{ matrix.teleport }}' != 'true' ]]
           then
             BEHAVE_TAGS="--tags=-teleport"
+          elif [[ '${{ matrix.cloud }}' != 'true' ]]
+          then
+            BEHAVE_TAGS="--tags=-cloud"
           fi
 
           behave $BEHAVE_TAGS -fplain -D profile=${{ matrix.profile }}

--- a/adapter/integration_tests/features/cloud.feature
+++ b/adapter/integration_tests/features/cloud.feature
@@ -1,0 +1,12 @@
+@cloud
+Feature: isolate cloud
+  Background: Project Setup
+    Given the project env_project
+
+  Scenario: Run a Python model with Isolate Cloud
+    When the following shell command is invoked:
+      """
+      dbt --debug run --profiles-dir $profilesDir --project-dir $baseDir -t prod --select +model_c+
+      """
+    Then the following models are calculated in order:
+      | model_a | model_c | model_d |

--- a/adapter/integration_tests/features/teleport.feature
+++ b/adapter/integration_tests/features/teleport.feature
@@ -10,11 +10,3 @@ Feature: Teleporting data
       """
     Then the following models are calculated in order:
       | model_a | model_c | model_d |
-
-  Scenario: Run a Python model with Isolate Cloud and teleport
-    When the following shell command is invoked:
-      """
-      dbt --debug run --profiles-dir $profilesDir --project-dir $baseDir -t prod_with_teleport --select +model_c+
-      """
-    Then the following models are calculated in order:
-      | model_a | model_c | model_d |

--- a/adapter/integration_tests/features/teleport.feature
+++ b/adapter/integration_tests/features/teleport.feature
@@ -6,7 +6,15 @@ Feature: Teleporting data
   Scenario: Run a Python model with Isolate and teleport
     When the following shell command is invoked:
       """
-      dbt --debug run --profiles-dir $profilesDir --project-dir $baseDir -t integration_tests_teleport --select +model_c+
+      dbt --debug run --profiles-dir $profilesDir --project-dir $baseDir -t staging_with_teleport --select +model_c+
+      """
+    Then the following models are calculated in order:
+      | model_a | model_c | model_d |
+
+  Scenario: Run a Python model with Isolate Cloud and teleport
+    When the following shell command is invoked:
+      """
+      dbt --debug run --profiles-dir $profilesDir --project-dir $baseDir -t prod_with_teleport --select +model_c+
       """
     Then the following models are calculated in order:
       | model_a | model_c | model_d |

--- a/adapter/integration_tests/profiles/bigquery/profiles.yml
+++ b/adapter/integration_tests/profiles/bigquery/profiles.yml
@@ -2,11 +2,17 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
+    prod:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
     db:
       type: bigquery
       method: service-account

--- a/adapter/integration_tests/profiles/duckdb/profiles.yml
+++ b/adapter/integration_tests/profiles/duckdb/profiles.yml
@@ -2,11 +2,17 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
+    prod:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
     db:
       type: duckdb
       path: "{{ env_var('DB_PATH') }}"

--- a/adapter/integration_tests/profiles/postgres/profiles.yml
+++ b/adapter/integration_tests/profiles/postgres/profiles.yml
@@ -2,11 +2,17 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
+    prod:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
     db:
       type: postgres
       host: localhost

--- a/adapter/integration_tests/profiles/redshift/profiles.yml
+++ b/adapter/integration_tests/profiles/redshift/profiles.yml
@@ -2,11 +2,17 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
+    prod:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
     db:
       type: redshift
       host: "{{ env_var('RS_HOST') }}"

--- a/adapter/integration_tests/profiles/snowflake/profiles.yml
+++ b/adapter/integration_tests/profiles/snowflake/profiles.yml
@@ -2,14 +2,32 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
-    integration_tests_teleport:
+    prod:
       type: fal
       db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
+    staging_with_teleport:
+      type: fal
+      db_profile: db
+      teleport:
+        type: s3
+        s3_bucket: fal-dbt-test
+        s3_region: us-east-1
+        s3_access_key_id: "{{ env_var('AWS_ACCESS_KEY_ID') }}"
+        s3_access_key: "{{ env_var('AWS_SECRET_ACCESS_KEY') }}"
+    prod_with_teleport:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
       teleport:
         type: s3
         s3_bucket: fal-dbt-test

--- a/adapter/integration_tests/profiles/trino/profiles.yml
+++ b/adapter/integration_tests/profiles/trino/profiles.yml
@@ -2,11 +2,17 @@ config:
   send_anonymous_usage_stats: False
 
 fal_test:
-  target: integration_tests
+  target: staging
   outputs:
-    integration_tests:
+    staging:
       type: fal
       db_profile: db
+    prod:
+      type: fal
+      db_profile: db
+      host: "{{ env_var('FAL_HOST') }}"
+      key_secret: "{{ env_var('FAL_KEY_SECRET') }}"
+      key_id: "{{ env_var('FAL_KEY_ID') }}"
     db:
       type: trino
       user: user

--- a/adapter/poetry.lock
+++ b/adapter/poetry.lock
@@ -131,6 +131,21 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "auth0-python"
+version = "3.24.0"
+description = "Auth0 Python SDK"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*"
+
+[package.dependencies]
+pyjwt = {version = ">=1.7.1", extras = ["crypto"]}
+requests = ">=2.14.0"
+
+[package.extras]
+test = ["coverage", "mock (>=1.3.0)", "pre-commit"]
+
+[[package]]
 name = "babel"
 version = "2.11.0"
 description = "Internationalization utilities"
@@ -305,6 +320,17 @@ description = "A tool to analyze and extract information from Jinja used in dbt 
 category = "main"
 optional = false
 python-versions = ">=3.6.1"
+
+[[package]]
+name = "dill"
+version = "0.3.5.1"
+description = "serialize all of python"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "distlib"
@@ -598,6 +624,37 @@ protobuf = "*"
 rich = ">=12.0"
 tblib = ">=1.7.0,<2.0.0"
 virtualenv = ">=20.4"
+
+[[package]]
+name = "isolate-cloud"
+version = "0.6.11"
+description = "SDK and cli for the fal isolate Cloud service"
+category = "main"
+optional = true
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+auth0-python = ">=3.24.0,<4.0.0"
+dill = "0.3.5.1"
+grpcio = ">=1.50.0,<2.0.0"
+isolate = ">=0.5.0"
+isolate-proto = ">=0.0.11,<0.0.12"
+requests = ">=2.28.1,<3.0.0"
+typer = ">=0.7.0,<0.8.0"
+typing-extensions = "4.4"
+
+[[package]]
+name = "isolate-proto"
+version = "0.0.11"
+description = "(internal) gRPC definitions for Isolate Cloud"
+category = "main"
+optional = true
+python-versions = ">=3.7,<4"
+
+[package.dependencies]
+grpcio = ">=1.49"
+isolate = {version = ">=0.7,<0.8", extras = ["grpc"]}
+protobuf = "*"
 
 [[package]]
 name = "jinja2"
@@ -987,6 +1044,9 @@ category = "main"
 optional = true
 python-versions = ">=3.7"
 
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
@@ -1305,6 +1365,23 @@ sqlalchemy = ["sqlalchemy (>=1.3,<2.0)"]
 tests = ["black", "click", "httpretty (<1.1)", "isort", "pre-commit", "pytest", "pytest-runner", "requests-kerberos", "sqlalchemy (>=1.3,<2.0)", "sqlalchemy-utils"]
 
 [[package]]
+name = "typer"
+version = "0.7.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)", "rich (>=10.11.0,<13.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "pillow (>=9.3.0,<10.0.0)", "cairosvg (>=2.5.2,<3.0.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "coverage (>=6.2,<7.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)", "rich (>=10.11.0,<13.0.0)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1401,6 +1478,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [extras]
 athena = []
 bigquery = ["google-cloud-bigquery"]
+cloud = ["isolate-cloud"]
 duckdb = []
 postgres = []
 redshift = ["sqlalchemy-redshift"]
@@ -1411,7 +1489,7 @@ trino = ["trino"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.2, <3.11"
-content-hash = "5c6d35c6656e2c6e37b92b095bc86450bc7c1ff70a79aae10da9574c866a77cf"
+content-hash = "f2a75649b31471988eb89a0a9697a501cb5778896d86e533474a6f0ecad02cb3"
 
 [metadata.files]
 agate = [
@@ -1537,6 +1615,10 @@ atomicwrites = [
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+auth0-python = [
+    {file = "auth0-python-3.24.0.tar.gz", hash = "sha256:88d7bce9472342e77f2f25fd8b060819b3557000e3a43e2618cd7a0fe5212c71"},
+    {file = "auth0_python-3.24.0-py2.py3-none-any.whl", hash = "sha256:a76e308df407fad9c6c29cd9de9a89bc5c1f7236f051c824923904046aea27a1"},
 ]
 babel = [
     {file = "Babel-2.11.0-py3-none-any.whl", hash = "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe"},
@@ -1687,6 +1769,10 @@ dbt-extractor = [
     {file = "dbt_extractor-0.4.1-cp36-abi3-win32.whl", hash = "sha256:3fe8d8e28a7bd3e0884896147269ca0202ca432d8733113386bdc84c824561bf"},
     {file = "dbt_extractor-0.4.1-cp36-abi3-win_amd64.whl", hash = "sha256:35265a0ae0a250623b0c2e3308b2738dc8212e40e0aa88407849e9ea090bb312"},
     {file = "dbt_extractor-0.4.1.tar.gz", hash = "sha256:75b1c665699ec0f1ffce1ba3d776f7dfce802156f22e70a7b9c8f0b4d7e80f42"},
+]
+dill = [
+    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
+    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 distlib = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
@@ -2005,6 +2091,14 @@ isodate = [
 isolate = [
     {file = "isolate-0.7.0-py3-none-any.whl", hash = "sha256:aebdd881c810367367d02b12dc23970be26a6df49a22fe06b7a0b1a90e4520a7"},
     {file = "isolate-0.7.0.tar.gz", hash = "sha256:109e87a76e83f897e15c625b5f3e4860bd778a76143daa246b740bf045f14428"},
+]
+isolate-cloud = [
+    {file = "isolate-cloud-0.6.11.tar.gz", hash = "sha256:36c4564e2f744bbfacd1712039ed05f6586b69c44e343a4a6be3bc711a5174a7"},
+    {file = "isolate_cloud-0.6.11-py3-none-any.whl", hash = "sha256:70cf2fb82c0833eb6f533c5070b8079d93a60436699f45237e6ffa8021cb50b0"},
+]
+isolate-proto = [
+    {file = "isolate_proto-0.0.11-py3-none-any.whl", hash = "sha256:780bdc3be70fcd3ba1a62612e674034c58401c540899013fcde98194b9e73983"},
+    {file = "isolate_proto-0.0.11.tar.gz", hash = "sha256:c7100e7601ad026e0d1a8677bd644acadfcaa4334d8c96fb2f915a3a176c8153"},
 ]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -2648,6 +2742,10 @@ text-unidecode = [
 trino = [
     {file = "trino-0.319.0-py3-none-any.whl", hash = "sha256:44e07da121a655da9f9eb92a0670bad8b4d769f7e42537281bd101ab7b7de3ee"},
     {file = "trino-0.319.0.tar.gz", hash = "sha256:d5a01258ff48b4e6dbed9cdbb070e2bf5afdbec90c933b19f1acad6db2947f32"},
+]
+typer = [
+    {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
+    {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/adapter/poetry.lock
+++ b/adapter/poetry.lock
@@ -1478,7 +1478,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [extras]
 athena = []
 bigquery = ["google-cloud-bigquery"]
-cloud = ["isolate-cloud"]
+cloud = ["isolate-cloud", "dill"]
 duckdb = []
 postgres = []
 redshift = ["sqlalchemy-redshift"]
@@ -1489,7 +1489,7 @@ trino = ["trino"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.2, <3.11"
-content-hash = "f2a75649b31471988eb89a0a9697a501cb5778896d86e533474a6f0ecad02cb3"
+content-hash = "f0d135d3cb19b5e98a15f42a833f513fd5aa37ea61b197805019f8d2345021a1"
 
 [metadata.files]
 agate = [

--- a/adapter/poetry.lock
+++ b/adapter/poetry.lock
@@ -1376,10 +1376,10 @@ python-versions = ">=3.6"
 click = ">=7.1.1,<9.0.0"
 
 [package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)", "rich (>=10.11.0,<13.0.0)"]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "pillow (>=9.3.0,<10.0.0)", "cairosvg (>=2.5.2,<3.0.0)"]
-test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "coverage (>=6.2,<7.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)", "rich (>=10.11.0,<13.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "typing-extensions"

--- a/adapter/pyproject.toml
+++ b/adapter/pyproject.toml
@@ -43,6 +43,7 @@ s3fs = { version = ">=2022.8.2", optional = true }
 
 # fal cloud
 isolate-cloud = { version = ">=0.6.11", optional = true }
+dill = { version = ">=0.3.5.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
@@ -56,7 +57,7 @@ duckdb = []
 athena = []
 trino = ["trino"]
 teleport = ["s3fs"]
-cloud = ["isolate-cloud"]
+cloud = ["isolate-cloud", "dill"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/adapter/pyproject.toml
+++ b/adapter/pyproject.toml
@@ -42,7 +42,7 @@ trino = { version = "^0.319.0", extras = ["sqlalchemy"], optional = true }
 s3fs = { version = ">=2022.8.2", optional = true }
 
 # fal cloud
-isolate-cloud = { version = ">=0.6.4", optional = true }
+isolate-cloud = { version = ">=0.6.11", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/adapter/pyproject.toml
+++ b/adapter/pyproject.toml
@@ -41,6 +41,9 @@ trino = { version = "^0.319.0", extras = ["sqlalchemy"], optional = true }
 # teleport
 s3fs = { version = ">=2022.8.2", optional = true }
 
+# fal cloud
+isolate-cloud = { version = ">=0.7.0", optional = true }
+
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 
@@ -53,6 +56,7 @@ duckdb = []
 athena = []
 trino = ["trino"]
 teleport = ["s3fs"]
+cloud = ["isolate-cloud"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/adapter/pyproject.toml
+++ b/adapter/pyproject.toml
@@ -42,7 +42,7 @@ trino = { version = "^0.319.0", extras = ["sqlalchemy"], optional = true }
 s3fs = { version = ">=2022.8.2", optional = true }
 
 # fal cloud
-isolate-cloud = { version = ">=0.7.0", optional = true }
+isolate-cloud = { version = ">=0.6.4", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/adapter/src/dbt/adapters/fal/connections.py
+++ b/adapter/src/dbt/adapters/fal/connections.py
@@ -5,6 +5,9 @@ from dbt.adapters.fal_experimental.connections import FalCredentials
 class FalEncCredentials(FalCredentials):
 
     db_profile: str = ''
+    host: str = ''
+    secret: str = ''
+    secret_id: str = ''
 
     def _connection_keys(self):
         return () + super()._connection_keys()

--- a/adapter/src/dbt/adapters/fal/connections.py
+++ b/adapter/src/dbt/adapters/fal/connections.py
@@ -3,11 +3,7 @@ from dbt.adapters.fal_experimental.connections import FalCredentials
 
 @dataclass
 class FalEncCredentials(FalCredentials):
-
     db_profile: str = ''
-    host: str = ''
-    secret: str = ''
-    secret_id: str = ''
 
     def _connection_keys(self):
         return () + super()._connection_keys()

--- a/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import zipfile
+import io
 from functools import partial
-from typing import Any
+from tempfile import NamedTemporaryFile
+from typing import Any, Optional
 
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.connection import AdapterResponse
 
 from isolate.backends.virtualenv import PythonIPC, VirtualPythonEnvironment
-from dbt.adapters.fal_experimental.utils.environments import get_default_pip_dependencies
+from dbt.adapters.fal_experimental.utils.environments import (
+    get_default_pip_dependencies,
+)
 from dbt.parser.manifest import MacroManifest, Manifest
 
 from isolate.backends import BaseEnvironment
@@ -22,6 +27,7 @@ from .adapter_support import (
 
 from .utils import extra_path, get_fal_scripts_path, retrieve_symbol
 
+
 def run_with_adapter(code: str, adapter: BaseAdapter, config: RuntimeConfig) -> Any:
     # main symbol is defined during dbt-fal's compilation
     # and acts as an entrypoint for us to run the model.
@@ -33,21 +39,37 @@ def run_with_adapter(code: str, adapter: BaseAdapter, config: RuntimeConfig) -> 
             write_df=prepare_for_adapter(adapter, write_df_to_relation),
         )
 
-def _isolated_runner(code: str, config: RuntimeConfig, manifest: Manifest, macro_manifest: MacroManifest) -> Any:
+
+def _isolated_runner(
+    code: str,
+    config: RuntimeConfig,
+    manifest: Manifest,
+    macro_manifest: MacroManifest,
+    local_packages: Optional[bytes] = None,
+) -> Any:
     # This function can be run in an entirely separate
     # process or an environment, so we need to reconstruct
     # the DB adapter solely from the config.
     adapter = reconstruct_adapter(config, manifest, macro_manifest)
+    fal_scripts_path = get_fal_scripts_path(config)
+    if local_packages is not None:
+        assert not fal_scripts_path.exists()
+        fal_scripts_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_file = zipfile.ZipFile(io.BytesIO(local_packages))
+        zip_file.extractall(fal_scripts_path)
+
     return run_with_adapter(code, adapter, config)
+
 
 def run_in_environment_with_adapter(
     environment: BaseEnvironment,
     code: str,
     config: RuntimeConfig,
     manifest: Manifest,
-    macro_manifest: MacroManifest
+    macro_manifest: MacroManifest,
 ) -> AdapterResponse:
     from isolate.backends.remote import IsolateServer
+
     """Run the 'main' function inside the given code on the
     specified environment.
 
@@ -55,29 +77,52 @@ def run_in_environment_with_adapter(
     in your project's root directory."""
     if type(environment) == IsolateServer:
         # TODO: make a specialized function for this case?
-        deps = [i for i in get_default_pip_dependencies() if i.startswith('dbt-')]
+        deps = [i for i in get_default_pip_dependencies() if i.startswith("dbt-")]
 
-        extra_config = {
-            'kind': 'virtualenv',
-            'configuration': { 'requirements': deps }
-        }
+        extra_config = {"kind": "virtualenv", "configuration": {"requirements": deps}}
 
         environment.target_environments.append(extra_config)
 
         key = environment.create()
 
+        fal_scripts_path = get_fal_scripts_path(config)
+
+        if fal_scripts_path.exists():
+            with NamedTemporaryFile() as temp_file:
+                with zipfile.ZipFile(
+                    temp_file.name, "w", zipfile.ZIP_DEFLATED
+                ) as zip_file:
+                    for entry in fal_scripts_path.rglob("*"):
+                        zip_file.write(entry, entry.relative_to(fal_scripts_path))
+
+                compressed_local_packages = temp_file.read()
+        else:
+            compressed_local_packages = None
+
         with environment.open_connection(key) as connection:
-            execute_model = partial(_isolated_runner, code, config, manifest, macro_manifest)
+            execute_model = partial(
+                _isolated_runner,
+                code,
+                config,
+                manifest,
+                macro_manifest,
+                local_packages=compressed_local_packages,
+            )
             result = connection.run(execute_model)
             return result
-
 
     else:
         deps = get_default_pip_dependencies()
         stage = VirtualPythonEnvironment(deps)
         fal_scripts_path = get_fal_scripts_path(config)
 
-        with PythonIPC(environment, environment.create(), extra_inheritance_paths=[fal_scripts_path, stage.create()]) as connection:
-            execute_model = partial(_isolated_runner, code, config, manifest, macro_manifest)
+        with PythonIPC(
+            environment,
+            environment.create(),
+            extra_inheritance_paths=[fal_scripts_path, stage.create()],
+        ) as connection:
+            execute_model = partial(
+                _isolated_runner, code, config, manifest, macro_manifest
+            )
             result = connection.run(execute_model)
             return result

--- a/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -54,7 +54,8 @@ def _isolated_runner(
     adapter = reconstruct_adapter(config, manifest, macro_manifest)
     fal_scripts_path = get_fal_scripts_path(config)
     if local_packages is not None:
-        assert not fal_scripts_path.exists()
+        # Shoule we overwrite this?
+        assert not fal_scripts_path.exists(), f"Path: {fal_scripts_path} already exists in isolate cloud."
         fal_scripts_path.parent.mkdir(parents=True, exist_ok=True)
         zip_file = zipfile.ZipFile(io.BytesIO(local_packages))
         zip_file.extractall(fal_scripts_path)

--- a/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -69,8 +69,6 @@ def run_in_environment_with_adapter(
     manifest: Manifest,
     macro_manifest: MacroManifest,
 ) -> AdapterResponse:
-    from isolate.backends.remote import IsolateServer
-
     """Run the 'main' function inside the given code on the
     specified environment.
 
@@ -78,17 +76,7 @@ def run_in_environment_with_adapter(
     in your project's root directory."""
 
     if type(environment).__name__ in ['IsolateServer', 'FalHostedServer']:
-        deps = [i for i in get_default_pip_dependencies() if i.startswith('dbt-')]
-
-        if not any('dbt-fal' in i for i in deps):
-            # HACK: hard-coding dbt-fal version to install in remote environment since local version could not be found
-            # TODO: improve dbt-fal version resolution
-            dbt_fal_dep = "dbt-fal"
-            dbt_fal_extras = _find_adapter_extras("dbt-fal")
-            if dbt_fal_extras:
-                dbt_fal_dep += f"[{' ,'.join(dbt_fal_extras)}]"
-
-            deps.append(f"{dbt_fal_dep}==1.3.7")
+        deps = [i for i in get_default_pip_dependencies(is_remote=True) if i.startswith('dbt-')]
 
         extra_config = {
             'kind': 'virtualenv',

--- a/adapter/src/dbt/adapters/fal_experimental/connections.py
+++ b/adapter/src/dbt/adapters/fal_experimental/connections.py
@@ -43,8 +43,11 @@ class FalConnectionManager(PythonConnectionManager):
 @dataclass
 class FalCredentials(Credentials):
     default_environment: str = "local"
-
     teleport: Optional[TeleportCredentials] = None
+    host: str = ''
+    key_secret: str = ''
+    key_id: str = ''
+
 
     # NOTE: So we are allowed to not set them in profiles.yml
     # they are ignored for now

--- a/adapter/src/dbt/adapters/fal_experimental/impl.py
+++ b/adapter/src/dbt/adapters/fal_experimental/impl.py
@@ -72,8 +72,16 @@ class FalAdapterMixin(TeleportAdapter, metaclass=AdapterMeta):
             self.credentials.default_environment,
         )
 
+        machine_type = parsed_model["config"].get(
+            "fal_machine",
+            "S",
+        )
+
         environment, is_local = fetch_environment(
-            self.config.project_root, environment_name, self.credentials
+            self.config.project_root,
+            environment_name,
+            machine_type,
+            self.credentials
         )
 
         telemetry.log_api(

--- a/adapter/src/dbt/adapters/fal_experimental/impl.py
+++ b/adapter/src/dbt/adapters/fal_experimental/impl.py
@@ -73,7 +73,7 @@ class FalAdapterMixin(TeleportAdapter, metaclass=AdapterMeta):
         )
 
         environment, is_local = fetch_environment(
-            self.config.project_root, environment_name
+            self.config.project_root, environment_name, self.credentials
         )
 
         telemetry.log_api(

--- a/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
+++ b/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
+from dbt.events.adapter_endpoint import AdapterLogger
 
 import dbt.exceptions
 import importlib_metadata
@@ -23,6 +24,7 @@ REMOTE_TYPES_DICT = {
     "conda": "conda"
 }
 
+logger = AdapterLogger('fal')
 
 class FalParseError(Exception):
     pass
@@ -47,6 +49,10 @@ def fetch_environment(
     if environment_name == "local":
         if credentials.key_secret and credentials.key_id:
             # "local" environment in this case is fal cloud
+            # TODO: add docs link
+            logger.warning("`local` environments will be executed on fal cloud." + \
+                           "If you don't want to use fal cloud, you can change your " + \
+                           "profile target to one where fal doesn't have credentials")
             return _build_hosted_env(
                 config={'name': '', 'type': 'venv'},
                 parsed_config={},

--- a/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
+++ b/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
@@ -161,8 +161,8 @@ def _build_hosted_env(
         credentials: Any,
         machine_type: str
 ) -> BaseEnvironment:
-    from isolate_cloud.sdk import FalHostedServer
-    from isolate_cloud.sdk import CloudKeyCredentials
+    from isolate_cloud.api import FalHostedServer
+    from isolate_cloud.api import CloudKeyCredentials
     if not config.get("type"):
         kind = "virtualenv"
     else:
@@ -184,7 +184,7 @@ def _build_hosted_env(
     return FalHostedServer.from_config(
         {
             "host": credentials.host,
-            "creds": CloudKeyCredentials(credentials.key_secret, credentials.key_id),
+            "creds": CloudKeyCredentials(credentials.key_id, credentials.key_secret),
             "machine_type": machine_type,
             "target_environments": [env_definition]
         }

--- a/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
+++ b/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
@@ -177,7 +177,7 @@ def _build_hosted_env(
     return FalHostedServer.from_config(
         {
             "host": credentials.host,
-            "creds": CloudKeyCredentials(credentials.key_secret, credentials.key_id),
+            "creds": CloudKeyCredentials(credentials.key_id, credentials.key_secret),
             "machine_type": machine_type,
             "target_environments": [env_definition]
         }


### PR DESCRIPTION
in `profiles.yml` you can now pass some credentials:
```
my_profile:
  target: fal_cloud
  outputs:
    fal_cloud:
      type: fal
      db_profile: db
      host: my_host
      secret: my_secret
      secret_id: my_secret_id
    db:
      type: postgres
      ...
```
And now, all Python models will run on isolate cloud by default. 

You can specify environments in `fal_project.yml`:
```
environments:
  - name: funny-cloud
    type: venv
    requirements:
      - pyjokes==0.6.0
```

You can specify machine sizes in model configs:
```
def model(dbt, fal):
    dbt.config(materialized="table")
    dbt.config(fal_machine="GPU") # "S" by default
    ...
```

If you want to run fal locally, you should omit credentials from `profiles.yml`:
```
my_profile:
  target: fal_local
  outputs:
    fal_local:
      type: fal
      db_profile: db
    db:
      type: postgres
      ...
```