### PR TITLE
Add support for .yaml files in fal dbt parser

### DIFF
--- a/src/faldbt/parse.py
+++ b/src/faldbt/parse.py
@@ -194,7 +194,10 @@ def get_scripts_list(scripts_dir: str) -> List[str]:
 def get_global_script_configs(source_dirs: List[Path]) -> Dict[str, List[str]]:
     global_scripts = {"before": [], "after": []}
     for source_dir in source_dirs:
+        # Scan directories for .yml files
         schema_files = glob.glob(os.path.join(source_dir, "**.yml"), recursive=True)
+        # Scan directories for .yaml files
+        schema_files += glob.glob(os.path.join(source_dir, "**.yaml"), recursive=True)
         for file in schema_files:
             schema_yml = load_yaml(file)
             if schema_yml is not None:


### PR DESCRIPTION
## Description
Since in dbt project people can use a variety of .yaml, and .yml files, I added the support for scanning .yaml files


GitHub: resolves #684