### PR TITLE
feat: get datawarehouse type in SQL context

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: fal pytest
 
 on:
   pull_request:

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -1,4 +1,4 @@
-name: Test dbt-fal encapsulate adapter
+name: dbt-fal integration tests
 
 on:
   pull_request:

--- a/.github/workflows/test_integration_cli.yml
+++ b/.github/workflows/test_integration_cli.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: fal integration tests
 
 on:
   pull_request:

--- a/adapter/integration_tests/features/sql_model.feature
+++ b/adapter/integration_tests/features/sql_model.feature
@@ -1,0 +1,20 @@
+Feature: Python models
+  Background: Project Setup
+    Given the project simple_project
+
+  Scenario: Run a project with a SQL model
+    When the following shell command is invoked:
+      """
+      dbt run --profiles-dir $profilesDir --project-dir $baseDir
+      """
+    Then the following models are calculated in order:
+      | model_a | model_b | model_c | model_d |
+
+  Scenario: Get datawarehouse for target.type and env.type but fal for adapter.type()
+    When the following shell command is invoked:
+      """
+      dbt run --profiles-dir $profilesDir --project-dir $baseDir --select model_a
+      """
+    Then the compiled SQL model model_a has the string "-- adapter.type() = $profile"
+    Then the compiled SQL model model_a has the string "-- target.type = $profile"
+    Then the compiled SQL model model_a has the string "-- env.type = $profile"

--- a/adapter/integration_tests/features/sql_model.feature
+++ b/adapter/integration_tests/features/sql_model.feature
@@ -10,7 +10,7 @@ Feature: Python models
     Then the following models are calculated in order:
       | model_a | model_b | model_c | model_d |
 
-  Scenario: Get datawarehouse for target.type and env.type but fal for adapter.type()
+  Scenario: Get datawarehouse for target.type, env.type and adapter.type()
     When the following shell command is invoked:
       """
       dbt run --profiles-dir $profilesDir --project-dir $baseDir --select model_a

--- a/adapter/integration_tests/features/steps/fal_adapter_steps.py
+++ b/adapter/integration_tests/features/steps/fal_adapter_steps.py
@@ -4,6 +4,7 @@ from behave import *
 
 import tempfile
 import json
+import yaml
 from pathlib import Path
 from datetime import datetime
 import re
@@ -12,16 +13,15 @@ import re
 @when("the following shell command is invoked")
 def run_command_step(context):
     context.exc = None
-    profiles_dir = _set_profiles_dir(context)
-    command = (
-        context.text.replace("$baseDir", context.base_dir)
-        .replace("$profilesDir", str(profiles_dir))
-        .replace("$tempDir", str(context.temp_dir.name))
-    )
+
+    profiles_dir = _get_profiles_dir(context)
+
+    command = _replace_vars(context, context.text)
     try:
         os.system(command)
     except:
         import sys
+
         context.exc = sys.exc_info()
 
 
@@ -45,8 +45,8 @@ def set_project_folder(context, project: str):
 
     context.base_dir = str(project_path)
     context.temp_dir = tempfile.TemporaryDirectory()
+    context.project_name = _load_dbt_project_file(context)["name"]
     os.environ["temp_dir"] = context.temp_dir.name
-    os.environ["project_dir"] = context.base_dir
 
 
 @then("the following models are calculated in order")
@@ -55,15 +55,29 @@ def check_model_results(context):
     sorted_models = sorted(models, key=lambda x: x[1])
     sorted_model_names = [model[0] for model in sorted_models]
     expected_model_names = context.table.headings
-    assert sorted_model_names == expected_model_names, f"Expected {expected_model_names}, got {sorted_model_names}"
+    assert (
+        sorted_model_names == expected_model_names
+    ), f"Expected {expected_model_names}, got {sorted_model_names}"
 
 
 @then('model {model_name} fails with message "{msg}"')
 def invoke_command_error(context, model_name: str, msg: str):
     results = _load_dbt_result_file(context)
-    model_result = [i for i in results if model_name in i['unique_id']][0]
-    assert model_result['status'] == 'error'
-    assert model_result['message'] == msg
+    model_result = [i for i in results if model_name in i["unique_id"]][0]
+    print(model_result)
+    assert model_result["status"] == "error"
+    assert model_result["message"] == msg
+
+
+@then('the compiled {model_type} model {model_name} has the string "{msg}"')
+def check_compiled_model(context, model_type: str, model_name: str, msg: str):
+    model_type = model_type.lower()
+    msg = _replace_vars(context, msg)
+    assert model_type in ["sql", "python", "py"], "model type should be SQL or Python"
+    if model_type == "python":
+        model_type = "py"
+    compiled = _load_target_run_model(context, f"{model_name}.{model_type}")
+    assert msg in compiled, f'Expected "{msg}" not present in compiled model {compiled}'
 
 
 def _get_dated_dbt_models(context):
@@ -85,7 +99,38 @@ def _load_dbt_result_file(context):
         return json.load(stream)["results"]
 
 
-def _set_profiles_dir(context) -> Path:
+def _load_dbt_project_file(context):
+    with open(os.path.join(context.base_dir, "dbt_project.yml")) as stream:
+        return yaml.full_load(stream)
+
+
+def _load_target_run_model(context, model_with_ext: str):
+    with open(
+        os.path.join(
+            context.temp_dir.name,
+            "target",
+            "run",
+            context.project_name,
+            "models",
+            model_with_ext,
+        )
+    ) as stream:
+        return stream.read()
+
+
+def _replace_vars(context, msg):
+    return (
+        msg.replace("$baseDir", context.base_dir)
+        .replace("$tempDir", str(context.temp_dir.name))
+        .replace("$profilesDir", _get_profiles_dir(context))
+        .replace("$profile", _get_profile(context))
+    )
+
+
+def _get_profile(context) -> str:
+    if "profile" in context:
+        return context.profile
+
     # TODO: Ideally this needs to change in just one place
     available_profiles = [
         "postgres",
@@ -94,19 +139,23 @@ def _set_profiles_dir(context) -> Path:
         "snowflake",
         "duckdb",
         "athena",
-        "trino"
+        "trino",
     ]
-    if "profile" in context.config.userdata:
-        profile = context.config.userdata["profile"]
-        if profile not in available_profiles:
-            raise Exception(f"Profile {profile} is not supported")
-        raw_path = reduce(os.path.join, [os.getcwd(), "profiles", profile])
-        path = Path(raw_path).absolute()
-    elif "profiles_dir" in context:
-        path = Path(context.profiles_dir).absolute()
-    else:
-        # Use postgres profile
-        path = Path(context.base_dir).parent.absolute()
+    profile = context.config.userdata.get("profile", "postgres")
+    if profile not in available_profiles:
+        raise Exception(f"Profile {profile} is not supported")
 
-    os.environ["profiles_dir"] = str(path)
-    return path
+    context.profile = profile
+    return context.profile
+
+
+def _get_profiles_dir(context):
+    if "profiles_dir" in context:
+        return context.profiles_dir
+
+    profile = _get_profile(context)
+    raw_path = reduce(os.path.join, [os.getcwd(), "profiles", profile])
+    path = Path(raw_path).absolute()
+
+    context.profiles_dir = str(path)
+    return context.profiles_dir

--- a/adapter/integration_tests/projects/simple_project/models/model_a.sql
+++ b/adapter/integration_tests/projects/simple_project/models/model_a.sql
@@ -2,6 +2,9 @@
 WITH data AS (
 
     SELECT
+        -- adapter.type() = {{ adapter.type() }}
+        -- env.type = {{ env.type }}
+        -- target.type = {{ target.type }}
         'some text' AS my_text
 )
 

--- a/adapter/src/dbt/adapters/fal/wrappers.py
+++ b/adapter/src/dbt/adapters/fal/wrappers.py
@@ -22,9 +22,8 @@ class FalCredentialsWrapper:
     def type(self):
         import inspect
 
-        target = filter(lambda s: s.function == "to_target_dict", inspect.stack())
-        db_mat = filter(lambda s: s.function == "db_materialization", inspect.stack())
-        if any(target) or any(db_mat):
+        materializer_funcs = {"to_target_dict", "db_materialization"}
+        if any(frame.function in materializer_funcs for frame in inspect.stack()):
             # This makes sense for both SQL and Python because the target is always the db
             return self._db_creds.type
 
@@ -86,9 +85,8 @@ class FalEncAdapterWrapper(FalAdapterMixin):
     def type(self):
         import inspect
 
-        render = filter(lambda s: s.function == "render", inspect.stack())
-        db_mat = filter(lambda s: s.function == "db_materialization", inspect.stack())
-        if any(render) or any(db_mat):
+        materializer_funcs = {"render", "db_materialization"}
+        if any(frame.function in materializer_funcs for frame in inspect.stack()):
             return self._db_adapter.type()
 
         return "fal"

--- a/adapter/src/dbt/adapters/fal/wrappers.py
+++ b/adapter/src/dbt/adapters/fal/wrappers.py
@@ -20,6 +20,14 @@ class FalCredentialsWrapper:
 
     @property
     def type(self):
+        import inspect
+
+        target = filter(lambda s: s.function == "to_target_dict", inspect.stack())
+        db_mat = filter(lambda s: s.function == "db_materialization", inspect.stack())
+        if any(target) or any(db_mat):
+            # This makes sense for both SQL and Python because the target is always the db
+            return self._db_creds.type
+
         return "fal"
 
     def __getattr__(self, name: str) -> Any:
@@ -59,12 +67,13 @@ class FalEncAdapterWrapper(FalAdapterMixin):
     @telemetry.log_call(
         "encapsulate_db_materialization", log_args=["materialization"], config=True
     )
-    def db_materialization(self, context, materialization):
+    def db_materialization(self, context: dict, materialization: str):
         # NOTE: inspired by https://github.com/dbt-labs/dbt-core/blob/be4a91a0fe35a619587b7a0145e190690e3771c6/core/dbt/task/run.py#L254-L290
         materialization_macro = self.manifest.find_materialization_macro_by_name(
             self.config.project_name, materialization, self._db_adapter.type()
         )
 
+        # HACK: run the entire SQL materialization and return the resulting dict with relations created
         return MacroGenerator(
             materialization_macro, context, stack=context["context_macro_stack"]
         )()
@@ -74,8 +83,14 @@ class FalEncAdapterWrapper(FalAdapterMixin):
     def manifest(self):
         return ManifestLoader.get_full_manifest(self.config)
 
-    @classmethod
-    def type(cls):
+    def type(self):
+        import inspect
+
+        render = filter(lambda s: s.function == "render", inspect.stack())
+        db_mat = filter(lambda s: s.function == "db_materialization", inspect.stack())
+        if any(render) or any(db_mat):
+            return self._db_adapter.type()
+
         return "fal"
 
     def __getattr__(self, name):


### PR DESCRIPTION
## Description
In SQL context we should get the `adapter.type()` to be the encapsulated adpter type, since they process the SQL.
And in all contexts, the target (and env) are the encapsulated adapter type, because they always offer the storage (for Python too).

### Integration tests

Adapter to test:
<!-- Add relevant ones -->
- postgres
- snowflake
- bigquery
- redshift
- duckdb
- athena

Python version to test:
<!-- Add relevant ones -->
- 3.8
