### PR TITLE
fix(dbt-fal): only inherit threads from db profile when is not set in flag or profile config

### DIFF
--- a/adapter/src/dbt/adapters/fal/connections.py
+++ b/adapter/src/dbt/adapters/fal/connections.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from dbt.adapters.fal_experimental.connections import FalCredentials
 
+
 @dataclass
 class FalEncCredentials(FalCredentials):
-    db_profile: str = ''
+    db_profile: str = ""
 
     def _connection_keys(self):
         return () + super()._connection_keys()

--- a/adapter/src/dbt/adapters/fal_experimental/connections.py
+++ b/adapter/src/dbt/adapters/fal_experimental/connections.py
@@ -12,6 +12,7 @@ class TeleportTypeEnum(StrEnum):
     LOCAL = "local"
     REMOTE_S3 = "s3"
 
+
 @dataclass
 class TeleportCredentials(ExtensibleDbtClassMixin):
     type: TeleportTypeEnum
@@ -44,15 +45,14 @@ class FalConnectionManager(PythonConnectionManager):
 class FalCredentials(Credentials):
     default_environment: str = "local"
     teleport: Optional[TeleportCredentials] = None
-    host: str = ''
-    key_secret: str = ''
-    key_id: str = ''
-
+    host: str = ""
+    key_secret: str = ""
+    key_id: str = ""
 
     # NOTE: So we are allowed to not set them in profiles.yml
     # they are ignored for now
-    database: str = ''
-    schema: str = ''
+    database: str = ""
+    schema: str = ""
 
     @property
     def type(self):


### PR DESCRIPTION
## Description

- When passing `--threads 1` flag, it was being ignored and using the wrapped db adapter.
- When setting `threads: 1` in the profile config, it was being ignored and using the wrapped db adapter.

<!-- If applicable: -->
<!--
GitHub: resolves #XXX
Linear: closes FEA-772
-->
