### PR TITLE
feat: add adapter_type to telemetry

### DIFF
--- a/adapter/src/dbt/adapters/fal_experimental/telemetry/telemetry.py
+++ b/adapter/src/dbt/adapters/fal_experimental/telemetry/telemetry.py
@@ -15,6 +15,7 @@ import uuid
 from functools import wraps
 from typing import Any, List, Optional
 import inspect
+from dbt.config.runtime import RuntimeConfig
 
 import platform
 
@@ -108,6 +109,12 @@ def dbt_installed_version():
         return pkg_resources.get_distribution("dbt-core").version
     except ImportError:
         return
+
+
+def get_dbt_adapter_type(config: RuntimeConfig) -> str:
+    """Returns: the configured actual DBT adapter"""
+    target = config.to_target_dict()
+    return target["type"]
 
 
 def fal_installed_version():
@@ -270,6 +277,7 @@ def log_api(
         "total_runtime": str(total_runtime),
         "python_version": python_version(),
         "dbt_version": dbt_installed_version(),
+        "dbt_adapter": get_dbt_adapter_type(config),
         "docker_container": is_docker(),
         "airflow": is_airflow(),
         "github_action": is_github(),

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -22,6 +22,7 @@ from functools import wraps
 from typing import Any, List, Optional
 import inspect
 from contextlib import contextmanager
+from dbt.config.runtime import RuntimeConfig
 
 from fal.utils import cache_static
 
@@ -114,9 +115,8 @@ def dbt_installed_version():
     except ImportError:
         return
 
-def get_dbt_adapter_type() -> str | None:
+def get_dbt_adapter_type(config: RuntimeConfig | None) -> str | None:
     """Returns: the configured DBT adapter or None if it's not in a runner context"""
-    config = get_dbt_config()
     if config is not None:
         target = config.to_target_dict()
         return target["type"]
@@ -310,7 +310,7 @@ def log_api(
         "python_version": python_version(),
         "fal_version": fal_installed_version(),
         "dbt_version": dbt_installed_version(),
-        "dbt_adapter": get_dbt_adapter_type(),
+        "dbt_adapter": get_dbt_adapter_type(dbt_config),
         "docker_container": is_docker(),
         "airflow": is_airflow(),
         "github_action": is_github(),

--- a/src/fal/telemetry/telemetry.py
+++ b/src/fal/telemetry/telemetry.py
@@ -6,6 +6,8 @@ https://github.com/ploomber/ploomber
 Modifications are made to ensure that the code works with fal.
 """
 
+from __future__ import annotations
+
 import datetime
 import http.client as httplib
 import warnings
@@ -112,6 +114,13 @@ def dbt_installed_version():
     except ImportError:
         return
 
+def get_dbt_adapter_type() -> str | None:
+    """Returns: the configured DBT adapter or None if it's not in a runner context"""
+    config = get_dbt_config()
+    if config is not None:
+        target = config.to_target_dict()
+        return target["type"]
+    return None
 
 def fal_installed_version():
     """Returns: fal version"""
@@ -301,6 +310,7 @@ def log_api(
         "python_version": python_version(),
         "fal_version": fal_installed_version(),
         "dbt_version": dbt_installed_version(),
+        "dbt_adapter": get_dbt_adapter_type(),
         "docker_container": is_docker(),
         "airflow": is_airflow(),
         "github_action": is_github(),

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -350,6 +350,7 @@ def test_redaction():
                 "total_runtime": ANY,
                 "python_version": ANY,
                 "fal_version": ANY,
+                "dbt_adapter": ANY,
                 "dbt_version": ANY,
                 "docker_container": ANY,
                 "airflow": ANY,


### PR DESCRIPTION
### Description

Adds a new property to telemetry, the `adapter_type`.

After a bit of trial and error, it seems like the correct (i.e. runtime resolved) field comes from `config.to_target_dict()["type"]`. The more obvious `config.get_metadata().adapter_type` returns the static value from the configuration.
