### PR TITLE
chore: Update dbt_project.yml format

### DIFF
--- a/projects/fal/integration_tests/projects/000_fal_run/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/000_fal_run/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_000"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "target"

--- a/projects/fal/integration_tests/projects/001_flow_run_with_selectors/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/001_flow_run_with_selectors/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_001"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models", "other_models"]
-data-paths: ["data"]
+model-paths: ["models", "other_models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/002_jaffle_shop/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/002_jaffle_shop/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_002"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/003_runtime_errors/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/003_runtime_errors/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_003"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/004_globals/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/004_globals/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_004"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/005_functions_and_variables/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/005_functions_and_variables/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_005"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/006_script_paths/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/006_script_paths/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_006"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/007_ipynb_scripts/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/007_ipynb_scripts/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_007"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models", "other_models"]
-data-paths: ["data"]
+model-paths: ["models", "other_models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/008_pure_python_models/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/008_pure_python_models/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_008"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/009_execute_sql_function/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/009_execute_sql_function/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_test"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros", "custom_macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/010_source_freshness/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/010_source_freshness/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_010"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "target"

--- a/projects/fal/integration_tests/projects/011_highly_parallelizable/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/011_highly_parallelizable/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_011"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/012_model_generation_error/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/012_model_generation_error/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_012"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/013_structured_hooks/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/013_structured_hooks/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_013"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"

--- a/projects/fal/integration_tests/projects/014_broken_dbt_models/dbt_project.yml
+++ b/projects/fal/integration_tests/projects/014_broken_dbt_models/dbt_project.yml
@@ -2,8 +2,8 @@ name: "fal_014"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
-data-paths: ["data"]
+model-paths: ["models"]
+seed-paths: ["data"]
 snapshot-paths: ["snapshots"]
 target-path: "{{ env_var('temp_dir') }}/target"
 vars:

--- a/projects/fal/tests/mock/dbt_project.yml
+++ b/projects/fal/tests/mock/dbt_project.yml
@@ -2,10 +2,10 @@ name: "fal_test"
 version: "1.0.0"
 config-version: 2
 profile: "fal_test"
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 target-path: "mockTarget"


### PR DESCRIPTION
This format was [introduced in 1.0](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.0#renamed-fields-in-dbt_projectyml) and since we no longer support <1.0, we can update for the new format.