### PR TITLE
fix(dbt-fal): support latest dbt-trino

### DIFF
--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -31,7 +31,7 @@ jobs:
           # - duckdb
           - snowflake
           - redshift
-          # - trino
+          - trino
         dbt_version:
           - "1.4.*"
         python:

--- a/projects/adapter/integration_tests/features/source.feature
+++ b/projects/adapter/integration_tests/features/source.feature
@@ -1,5 +1,6 @@
 @TODO-duckdb
 @TODO-bigquery
+@TODO-trino
 Feature: dbt-fal can query sources
   Background: Project Setup
     Given the project source_freshness

--- a/projects/adapter/integration_tests/features/sql_model.feature
+++ b/projects/adapter/integration_tests/features/sql_model.feature
@@ -1,3 +1,4 @@
+@TODO-trino
 Feature: Python models
   Background: Project Setup
     Given the project simple_project

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/trino.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/trino.py
@@ -5,7 +5,7 @@ from dbt.adapters.trino.connections import TrinoCredentials
 import sqlalchemy
 
 def create_engine(adapter: BaseAdapter) -> Any:
-    creds = adapter.config.credentials._db_creds
+    creds = adapter.config.credentials
 
     connect_args = _build_connect_args(creds)
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/utils/environments.py
@@ -318,8 +318,8 @@ def _version_is_prerelease(raw_version: str) -> bool:
     return package_version.is_prerelease
 
 
-def _get_project_root_path(pacakge: str) -> Path:
-    import fal
+def _get_project_root_path(package: str) -> Path:
+    from dbt.adapters import fal
 
     # If this is a development version, we'll install
     # the current fal itself.
@@ -328,7 +328,7 @@ def _get_project_root_path(pacakge: str) -> Path:
         if (path.parent / ".git").exists():
             break
         path = path.parent
-    return path / pacakge
+    return path / package
 
 
 def get_default_requirements(


### PR DESCRIPTION
### Integration tests

Adapter to test:
- trino

Python version to test:
- 3.8
- 3.9
- 3.10
