### PR TITLE
Improve speed of inserts on PostgreSQL

### DIFF
--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -1,5 +1,4 @@
 import functools
-from io import StringIO
 from time import sleep
 from typing import Any
 
@@ -98,45 +97,21 @@ def write_df_to_relation(
 
             alchemy_engine = _get_alchemy_engine(adapter, connection)
 
-            to_sql_args = {
-                "con": alchemy_engine,
-                "name": temp_relation.identifier,
-                "schema": temp_relation.schema,
-                "if_exists": if_exists,
-                "index": False,
-            }
-
-            if adapter.type() == "postgres":
-                to_sql_args["method"] = _psql_insert_copy
-
             # TODO: probably worth handling errors here an returning
             # a proper adapter response.
-            rows_affected = dataframe.to_sql(**to_sql_args)
+            rows_affected = dataframe.to_sql(
+                con=alchemy_engine,
+                name=temp_relation.identifier,
+                schema=temp_relation.schema,
+                if_exists=if_exists,
+                index=False,
+            )
             adapter.cache.add(temp_relation)
             drop_relation_if_it_exists(adapter, relation)
             adapter.rename_relation(temp_relation, relation)
             adapter.commit_if_has_connection()
 
             return AdapterResponse("OK", rows_affected=rows_affected)
-
-
-def _psql_insert_copy(table, conn, keys, data_iter):
-    """Alternative to_sql method for PostgreSQL.
-
-    Adapted from https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method
-    """
-    dbapi_conn = conn.connection
-    with dbapi_conn.cursor() as cur:
-        s_buf = StringIO()
-        writer = csv.writer(s_buf)
-        writer.writerows(data_iter)
-        s_buf.seek(0)
-
-        columns = ", ".join((f'"{k}"' for k in keys))
-        table_name = f"{table.schema}.{table.name}" if table.schema else table.name
-
-        sql = f"COPY {table_name} ({columns}) FROM STDIN WITH CSV"
-        cur.copy_expert(sql=sql, file=s_buf)
 
 
 def read_relation_as_df(adapter: BaseAdapter, relation: BaseRelation) -> pd.DataFrame:

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -66,22 +66,24 @@ def write_df_to_relation(
     """Generic version of the write_df_to_relation. Materialize the given
     dataframe to the targeted relation on the adapter."""
 
-    if adapter.type() == "snowflake":
+    adapter_type = adapter.type()
+
+    if adapter_type == "snowflake":
         import dbt.adapters.fal_experimental.support.snowflake as support_snowflake
 
         return support_snowflake.write_df_to_relation(adapter, dataframe, relation)
 
-    elif adapter.type() == "bigquery":
+    elif adapter_type == "bigquery":
         import dbt.adapters.fal_experimental.support.bigquery as support_bq
 
         return support_bq.write_df_to_relation(adapter, dataframe, relation)
 
-    elif adapter.type() == "duckdb":
+    elif adapter_type == "duckdb":
         import dbt.adapters.fal_experimental.support.duckdb as support_duckdb
 
         return support_duckdb.write_df_to_relation(adapter, dataframe, relation)
 
-    elif adapter.type() == "postgres":
+    elif adapter_type == "postgres":
         import dbt.adapters.fal_experimental.support.postgres as support_postgres
 
         return support_postgres.write_db_to_relation(adapter, dataframe, relation)
@@ -116,22 +118,24 @@ def write_df_to_relation(
 def read_relation_as_df(adapter: BaseAdapter, relation: BaseRelation) -> pd.DataFrame:
     """Generic version of the read_df_from_relation."""
 
-    if adapter.type() == "snowflake":
+    adapter_type = adapter.type()
+
+    if adapter_type == "snowflake":
         import dbt.adapters.fal_experimental.support.snowflake as support_snowflake
 
         return support_snowflake.read_relation_as_df(adapter, relation)
 
-    elif adapter.type() == "bigquery":
+    elif adapter_type == "bigquery":
         import dbt.adapters.fal_experimental.support.bigquery as support_bq
 
         return support_bq.read_relation_as_df(adapter, relation)
 
-    elif adapter.type() == "duckdb":
+    elif adapter_type == "duckdb":
         import dbt.adapters.fal_experimental.support.duckdb as support_duckdb
 
         return support_duckdb.read_relation_as_df(adapter, relation)
 
-    elif adapter.type() == "postgres":
+    elif adapter_type == "postgres":
         import dbt.adapters.fal_experimental.support.postgres as support_postgres
 
         return support_postgres.read_relation_as_df(adapter, relation)

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -13,7 +13,6 @@ from dbt.parser.manifest import MacroManifest, Manifest, ManifestLoader
 from dbt.adapters import factory
 
 _SQLALCHEMY_DIALECTS = {
-    "postgres": "postgresql+psycopg2",
     "redshift": "redshift+psycopg2",
 }
 
@@ -30,7 +29,7 @@ def _get_alchemy_engine(adapter: BaseAdapter, connection: Connection) -> Any:
         import dbt.adapters.fal_experimental.support.trino as support_trino
         return support_trino.create_engine(adapter)
 
-    if adapter_type in ("postgres", "redshift"):
+    if adapter_type == "redshift":
         # If the given adapter supports the DBAPI (PEP 249), we can
         # use its connection directly for the engine.
         sqlalchemy_kwargs["creator"] = lambda *args, **kwargs: connection.handle

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -83,6 +83,11 @@ def write_df_to_relation(
 
         return support_duckdb.write_df_to_relation(adapter, dataframe, relation)
 
+    elif adapter.type() == "postgres":
+        import dbt.adapters.fal_experimental.support.postgres as support_postgres
+
+        return support_postgres.write_db_to_relation(adapter, dataframe, relation)
+
     else:
         with new_connection(adapter, "fal:write_df_to_relation") as connection:
             # TODO: this should probably live in the materialization macro.
@@ -151,6 +156,11 @@ def read_relation_as_df(adapter: BaseAdapter, relation: BaseRelation) -> pd.Data
         import dbt.adapters.fal_experimental.support.duckdb as support_duckdb
 
         return support_duckdb.read_relation_as_df(adapter, relation)
+
+    elif adapter.type() == "postgres":
+        import dbt.adapters.fal_experimental.support.postgres as support_postgres
+
+        return support_postgres.read_relation_as_df(adapter, relation)
 
     else:
         with new_connection(adapter, "fal:read_relation_as_df") as connection:

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -92,15 +92,20 @@ def write_df_to_relation(
 
             alchemy_engine = _get_alchemy_engine(adapter, connection)
 
+            to_sql_args = {
+                "con": alchemy_engine,
+                "name": temp_relation.identifier,
+                "schema": temp_relation.schema,
+                "if_exists": if_exists,
+                "index": False,
+            }
+
+            if adapter.type() == "postgres":
+                to_sql_args["method"] = _psql_insert_copy
+
             # TODO: probably worth handling errors here an returning
             # a proper adapter response.
-            rows_affected = dataframe.to_sql(
-                con=alchemy_engine,
-                name=temp_relation.identifier,
-                schema=temp_relation.schema,
-                if_exists=if_exists,
-                index=False,
-            )
+            rows_affected = dataframe.to_sql(**to_sql_args)
             adapter.cache.add(temp_relation)
             drop_relation_if_it_exists(adapter, relation)
             adapter.rename_relation(temp_relation, relation)

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -117,7 +117,7 @@ def write_df_to_relation(
 def _psql_insert_copy(table, conn, keys, data_iter):
     """Alternative to_sql method for PostgreSQL.
 
-    From https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method
+    Adapted from https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method
     """
     dbapi_conn = conn.connection
     with dbapi_conn.cursor() as cur:
@@ -126,14 +126,10 @@ def _psql_insert_copy(table, conn, keys, data_iter):
         writer.writerows(data_iter)
         s_buf.seek(0)
 
-        columns = ', '.join(['"{}"'.format(k) for k in keys])
-        if table.schema:
-            table_name = '{}.{}'.format(table.schema, table.name)
-        else:
-            table_name = table.name
+        columns = ", ".join((f'"{k}"' for k in keys))
+        table_name = f"{table.schema}.{table.name}" if table.schema else table.name
 
-        sql = 'COPY {} ({}) FROM STDIN WITH CSV'.format(
-            table_name, columns)
+        sql = f"COPY {table_name} ({columns}) FROM STDIN WITH CSV"
         cur.copy_expert(sql=sql, file=s_buf)
 
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -1,4 +1,5 @@
 import functools
+from io import StringIO
 from time import sleep
 from typing import Any
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py
@@ -86,7 +86,7 @@ def write_df_to_relation(
     elif adapter_type == "postgres":
         import dbt.adapters.fal_experimental.support.postgres as support_postgres
 
-        return support_postgres.write_db_to_relation(adapter, dataframe, relation)
+        return support_postgres.write_df_to_relation(adapter, dataframe, relation)
 
     else:
         with new_connection(adapter, "fal:write_df_to_relation") as connection:

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -33,6 +33,8 @@ def write_df_to_relation(
     adapter: PostgresAdapter,
     data: pd.DataFrame,
     relation: BaseRelation,
+    *,
+    if_exists: str = "replace",
 ) -> AdapterResponse:
     assert adapter.type() == "postgres"
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -12,7 +12,7 @@ def read_relation_as_df(
 ) -> pd.DataFrame:
     assert adapter.type() == "postgres"
 
-    with new_connection(adapter, "fal:read_relation_as_df") as connection:
+    with new_connection(adapter, "fal-postgres:read_relation_as_df") as connection:
         alchemy_engine = _get_alchemy_engine(adapter, connection)
         return pd.read_sql_table(
             con=alchemy_engine,
@@ -28,7 +28,7 @@ def write_df_to_relation(
 ) -> AdapterResponse:
     assert adapter.type() == "postgres"
 
-    with new_connection(adapter, "fal:write_df_to_relation") as connection:
+    with new_connection(adapter, "fal-postgres:write_df_to_relation") as connection:
         # TODO: this should probably live in the materialization macro.
         temp_relation = relation.replace_path(
             identifier=f"__dbt_fal_temp_{relation.identifier}"

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -37,20 +37,16 @@ def write_df_to_relation(
 
         alchemy_engine = _get_alchemy_engine(adapter, connection)
 
-        to_sql_args = {
-            "con": alchemy_engine,
-            "name": temp_relation.identifier,
-            "schema": temp_relation.schema,
-            "if_exists": if_exists,
-            "index": False,
-        }
-
-        if adapter.type() == "postgres":
-            to_sql_args["method"] = _psql_insert_copy
-
         # TODO: probably worth handling errors here an returning
         # a proper adapter response.
-        rows_affected = dataframe.to_sql(**to_sql_args)
+        rows_affected = dataframe.to_sql(
+            con=alchemy_engine,
+            name=temp_relation.identifier,
+            schema=temp_relation.schema,
+            if_exists=if_exists,
+            index=False,
+            method=_psql_insert_copy,
+        )
         adapter.cache.add(temp_relation)
         drop_relation_if_it_exists(adapter, relation)
         adapter.rename_relation(temp_relation, relation)

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -5,7 +5,7 @@ import sqlalchemy
 
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.connections import AdapterResponse
-from dbt.adapters.fal_experimental.adapter_support import new_connection
+from dbt.adapters.fal_experimental.adapter_support import drop_relation_if_it_exists, new_connection
 from dbt.adapters.postgres import PostgresAdapter
 
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -1,0 +1,78 @@
+from io import StringIO
+
+import pandas as pd
+
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.base.connections import AdapterResponse
+from dbt.adapters.postgres import PostgresAdapter
+
+
+def read_relation_as_df(
+    adapter: PostgresAdapter, relation: BaseRelation
+) -> pd.DataFrame:
+    assert adapter.type() == "postgres"
+
+    with new_connection(adapter, "fal:read_relation_as_df") as connection:
+        alchemy_engine = _get_alchemy_engine(adapter, connection)
+        return pd.read_sql_table(
+            con=alchemy_engine,
+            table_name=relation.identifier,
+            schema=relation.schema,
+        )
+
+
+def write_df_to_relation(
+    adapter: PostgresAdapter,
+    data: pd.DataFrame,
+    relation: BaseRelation,
+) -> AdapterResponse:
+    assert adapter.type() == "postgres"
+
+    with new_connection(adapter, "fal:write_df_to_relation") as connection:
+        # TODO: this should probably live in the materialization macro.
+        temp_relation = relation.replace_path(
+            identifier=f"__dbt_fal_temp_{relation.identifier}"
+        )
+        drop_relation_if_it_exists(adapter, temp_relation)
+
+        alchemy_engine = _get_alchemy_engine(adapter, connection)
+
+        to_sql_args = {
+            "con": alchemy_engine,
+            "name": temp_relation.identifier,
+            "schema": temp_relation.schema,
+            "if_exists": if_exists,
+            "index": False,
+        }
+
+        if adapter.type() == "postgres":
+            to_sql_args["method"] = _psql_insert_copy
+
+        # TODO: probably worth handling errors here an returning
+        # a proper adapter response.
+        rows_affected = dataframe.to_sql(**to_sql_args)
+        adapter.cache.add(temp_relation)
+        drop_relation_if_it_exists(adapter, relation)
+        adapter.rename_relation(temp_relation, relation)
+        adapter.commit_if_has_connection()
+
+        return AdapterResponse("OK", rows_affected=rows_affected)
+
+
+def _psql_insert_copy(table, conn, keys, data_iter):
+    """Alternative to_sql method for PostgreSQL.
+
+    Adapted from https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method
+    """
+    dbapi_conn = conn.connection
+    with dbapi_conn.cursor() as cur:
+        s_buf = StringIO()
+        writer = csv.writer(s_buf)
+        writer.writerows(data_iter)
+        s_buf.seek(0)
+
+        columns = ", ".join((f'"{k}"' for k in keys))
+        table_name = f"{table.schema}.{table.name}" if table.schema else table.name
+
+        sql = f"COPY {table_name} ({columns}) FROM STDIN WITH CSV"
+        cur.copy_expert(sql=sql, file=s_buf)

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -50,7 +50,7 @@ def write_df_to_relation(
 
         # TODO: probably worth handling errors here an returning
         # a proper adapter response.
-        rows_affected = dataframe.to_sql(
+        rows_affected = data.to_sql(
             con=alchemy_engine,
             name=temp_relation.identifier,
             schema=temp_relation.schema,

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -43,7 +43,10 @@ def write_df_to_relation(
         )
         drop_relation_if_it_exists(adapter, temp_relation)
 
-        alchemy_engine = _get_alchemy_engine(adapter, connection)
+        alchemy_engine = sqlalchemy.create_engine(
+            "postgresql+psycopg2://",
+            creator=lambda *args, **kwargs: connection.handle,
+        )
 
         # TODO: probably worth handling errors here an returning
         # a proper adapter response.

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/postgres.py
@@ -1,3 +1,4 @@
+import csv
 from io import StringIO
 
 import pandas as pd


### PR DESCRIPTION
## Description

dbt-fal currently [uses a generic pandas.DataFrame.to_sql call](https://github.com/fal-ai/fal/blob/070592fc0d24d6093c97fe70a9f7cfb8a1da71ec/projects/adapter/src/dbt/adapters/fal_experimental/adapter_support.py#L97-L103) when using adapters others than `snowflake`, `bigquery`, and `duckdb`. This results in an `INSERT` statement per row when writing dataframes to PostgreSQL, which is excruciatingly slow.

The `pandas.DataFrame.to_sql` can take an optional `method` argument that controls the SQL insertion clause. In particular, the Pandas user guide [provides an example for PostgreSQL that uses `COPY FROM`](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method) to efficiently insert rows.

Here are some numbers from a Python model that I'm working on. The model reads and writes 4.1 million rows with two text columns. With dbt-fal as is, the model takes 1038 seconds total, of which about **660.9 seconds** are spent writing data to PostgreSQL.

```
03:27:18  Running with dbt=1.4.1
03:27:18  Found 49 models, 0 tests, 0 snapshots, 0 analyses, 300 macros, 0 operations, 0 seed files, 30 sources, 2 exposures, 0 metrics
03:27:18  
03:27:23  Concurrency: 4 threads (target='dev-fal')
03:27:23  
03:27:23  1 of 1 START python table model dbt_king_stg_dibi_env.foundations_wells_names_cleaned  [RUN]
dur=660.9213428497314
03:44:41  1 of 1 OK created python table model dbt_king_stg_dibi_env.foundations_wells_names_cleaned  [OK in 1038.03s]
03:44:42  
03:44:42  Finished running 1 table model in 0 hours 17 minutes and 23.50 seconds (1043.50s).
03:44:42  
03:44:42  Completed successfully
03:44:42  
03:44:42  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

With the custom method, insertion time drops to just **35.2 seconds**, over **18× faster**.

```
03:19:52  Running with dbt=1.4.1
03:19:52  Found 49 models, 0 tests, 0 snapshots, 0 analyses, 300 macros, 0 operations, 0 seed files, 30 sources, 2 exposures, 0 metrics
03:19:52  
03:19:56  Concurrency: 4 threads (target='dev-fal')
03:19:56  
03:19:56  1 of 1 START python table model dbt_king_stg_dibi_env.foundations_wells_names_cleaned  [RUN]
dur=35.29836106300354
03:26:54  1 of 1 OK created python table model dbt_king_stg_dibi_env.foundations_wells_names_cleaned  [OK in 417.89s]
03:26:55  
03:26:55  Finished running 1 table model in 0 hours 7 minutes and 3.08 seconds (423.08s).
03:26:55  
03:26:55  Completed successfully
03:26:55  
03:26:55  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

The `dur` numbers come from temporary wall time calculations in the code.

```python
start = time()
rows_affected = dataframe.to_sql(**to_sql_args)
end = time()
dur = (end - start)
print(f"{dur=}")
```

### Integration tests

Adapter to test:
- postgres


Python version to test:
- 3.x