### PR TITLE
fix: handle new relation quoting for Python introduced in dbt-1.4.5

### DIFF
--- a/projects/adapter/integration_tests/projects/source_freshness/models/schema.yml
+++ b/projects/adapter/integration_tests/projects/source_freshness/models/schema.yml
@@ -8,7 +8,7 @@ sources:
       warn_after: { "count": 5, "period": minute }
       error_after: { "count": 30, "period": minute }
     tables:
-      - name: "freshness_table"
+      - name: freshness_table
         loaded_at_field: "current_timestamp"
         columns:
           - name: info

--- a/projects/adapter/src/dbt/adapters/fal/impl.py
+++ b/projects/adapter/src/dbt/adapters/fal/impl.py
@@ -134,10 +134,9 @@ class FalEncAdapter(BaseAdapter):
 
         # TODO: maybe we can do this better?
         with _release_plugin_lock():
-            original_plugin = FACTORY.get_plugin_by_name(fal_credentials.type)
             db_adapter_class = FACTORY.get_adapter_class_by_name(db_credentials.type)
-
-        original_plugin.dependencies = [db_credentials.type]
+            original_plugin = FACTORY.get_plugin_by_name(fal_credentials.type)
+            original_plugin.dependencies = [db_credentials.type]
 
         config.python_adapter_credentials = fal_credentials
         config.sql_adapter_credentials = db_credentials

--- a/projects/adapter/src/dbt/adapters/fal/wrappers.py
+++ b/projects/adapter/src/dbt/adapters/fal/wrappers.py
@@ -80,6 +80,8 @@ class FalEncAdapterWrapper(FalAdapterMixin):
         return ManifestLoader.get_full_manifest(self.config)
 
     def type(self):
+        # NOTE: This does not let `fal__` macros to be used
+        # Maybe for 1.5 we will get a more reliable way to detect if we are in a SQL or Python context
         if find_funcs_in_stack({"render", "db_materialization"}):
             return self._db_adapter.type()
 


### PR DESCRIPTION
## Description
We are seeing 

> Error: 00:24:01.472113 [error] [MainThread]: Table “freshness_table” not found

This was introduced in https://github.com/dbt-labs/dbt-core/issues/7114

```py
def source(*args, dbt_load_df_function):
    sources = {"freshness_test.freshness_table": "test.dbt_fal_custom.freshness_table"}
    key = ".".join(args)
    return dbt_load_df_function(sources[key])
```
vs

```py
def source(*args, dbt_load_df_function):
    sources = {"freshness_test.freshness_table": "\"test\".\"dbt_fal_custom\".\"freshness_table\""}
    key = '.'.join(args)
    return dbt_load_df_function(sources[key])
```

Notice the quotes in the `sources` dict.

<!-- If applicable: -->
<!--
GitHub: resolves #XXX
Linear: closes FEA-956
-->

### Integration tests

Adapter to test:
<!-- Add relevant ones -->
- postgres
<!--
- snowflake
- bigquery
- redshift
- duckdb
- athena
-->

Python version to test:
<!-- Add relevant ones -->
- 3.8
<!--
- 3.7
- 3.9
- 3.10
-->
