### PR TITLE
chore: differentiate cloud from non-cloud users

### DIFF
--- a/projects/adapter/src/dbt/adapters/fal/wrappers.py
+++ b/projects/adapter/src/dbt/adapters/fal/wrappers.py
@@ -53,7 +53,10 @@ class FalEncAdapterWrapper(FalAdapterMixin):
         telemetry.log_api(
             "encapsulate_init",
             config=config,
-            additional_props={"is_teleport": self.is_teleport()},
+            additional_props={
+                "is_teleport": self.is_teleport(),
+                "fal_host": self.credentials.host,
+            },
         )
 
     def submit_python_job(self, *args, **kwargs):


### PR DESCRIPTION
looks like

```
 { ..., 'fal_host': 'api.alpha.fal.ai'}
```