### PR TITLE
fix: flow run tag selection

### DIFF
--- a/projects/fal/integration_tests/features/flow_run.feature
+++ b/projects/fal/integration_tests/features/flow_run.feature
@@ -162,7 +162,7 @@ Feature: `flow run` command
       """
     Then it throws an exception RuntimeError with message 'Error running dbt run'
 
-  Scenario: fal flow run command with selectors with complex selectors
+  Scenario: fal flow run command with selectors with tag selectors
     Given the project 001_flow_run_with_selectors
     When the data is seeded
     When the following command is invoked:
@@ -170,9 +170,9 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select tag:daily
       """
     Then the following models are calculated:
-      | agent_wait_time |
+      | agent_wait_time | model_b | model_c |
 
-  Scenario: fal flow run command with complex selectors and children
+  Scenario: fal flow run command with tag selector and children
     Given the project 001_flow_run_with_selectors
     When the data is seeded
     When the following command is invoked:
@@ -180,7 +180,7 @@ Feature: `flow run` command
       fal flow run --profiles-dir $profilesDir --project-dir $baseDir --select tag:daily+
       """
     Then the following models are calculated:
-      | agent_wait_time | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 |
+      | agent_wait_time | model_b | model_c | intermediate_model_1 | intermediate_model_2 | intermediate_model_3 |
     And the following scripts are ran:
       | agent_wait_time.after.py |
 

--- a/projects/fal/integration_tests/projects/001_flow_run_with_selectors/models/schema.yml
+++ b/projects/fal/integration_tests/projects/001_flow_run_with_selectors/models/schema.yml
@@ -10,8 +10,12 @@ models:
   - name: model_a
 
   - name: model_b
+    config:
+      tags: daily
 
   - name: model_c
+    config:
+      tags: daily
     meta:
       fal:
         scripts:


### PR DESCRIPTION
Fixes `flow run --select tag:my_tag` selection to select all relevant models.

Closes: #807 