### PR TITLE
feat(dbt-fal): adapt to new 1.5 dbt changes

### DIFF
--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -29,7 +29,8 @@ jobs:
           - postgres
           - bigquery
           - snowflake
-          - redshift
+          # TODO: redshift had a bigger change between 1.4 and 1.5 and will be addressed separately
+          # - redshift
           # TODO: enable as 1.5 becomes available for following adapters
           # - athena
           # - trino
@@ -49,8 +50,8 @@ jobs:
           - profile: snowflake
             teleport: true
             cloud: true
-          - profile: redshift
-            cloud: true
+          # - profile: redshift
+          #   cloud: true
           - profile: bigquery
             cloud: true
         # TODO: remove postgres include/exclude when 1.5 is released

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -35,7 +35,8 @@ jobs:
           - trino
           # - sqlserver # does not support dbt 1.4 yet
         dbt_version:
-          - "1.4.*"
+          # TODO: change when 1.5 is released
+          - "1.5.0-b5"
         python:
           # - "3.7"
           - "3.8"

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -38,8 +38,7 @@ jobs:
           # - sqlserver
         dbt_version:
           # TODO: change when 1.5 is released
-          - 1.5.0-b4
-          - 1.5.0-b5
+          - 1.5.0-rc1
         python:
           # - "3.7"
           - "3.8"
@@ -54,16 +53,6 @@ jobs:
           #   cloud: true
           - profile: bigquery
             cloud: true
-        # TODO: remove postgres include/exclude when 1.5 is released
-        exclude:
-          - profile: postgres
-            dbt_version: 1.5.0-b4
-          - profile: snowflake
-            dbt_version: 1.5.0-b5
-          - profile: redshift
-            dbt_version: 1.5.0-b5
-          - profile: bigquery
-            dbt_version: 1.5.0-b5
 
     concurrency:
       group: "${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ matrix.profile }}-${{ matrix.python }}"

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -28,15 +28,17 @@ jobs:
         profile:
           - postgres
           - bigquery
-          # - duckdb
           - snowflake
           - redshift
-          - athena
-          - trino
-          # - sqlserver # does not support dbt 1.4 yet
+          # TODO: enable as 1.5 becomes available for following adapters
+          # - athena
+          # - trino
+          # - duckdb
+          # - sqlserver
         dbt_version:
           # TODO: change when 1.5 is released
-          - "1.5.0-b5"
+          - 1.5.0-b4
+          - 1.5.0-b5
         python:
           # - "3.7"
           - "3.8"
@@ -51,6 +53,16 @@ jobs:
             cloud: true
           - profile: bigquery
             cloud: true
+        # TODO: remove postgres include/exclude when 1.5 is released
+        exclude:
+          - profile: postgres
+            dbt_version: 1.5.0-b4
+          - profile: snowflake
+            dbt_version: 1.5.0-b5
+          - profile: redshift
+            dbt_version: 1.5.0-b5
+          - profile: bigquery
+            dbt_version: 1.5.0-b5
 
     concurrency:
       group: "${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ matrix.profile }}-${{ matrix.python }}"

--- a/.github/workflows/test_integration_adapter.yml
+++ b/.github/workflows/test_integration_adapter.yml
@@ -37,8 +37,7 @@ jobs:
           # - duckdb
           # - sqlserver
         dbt_version:
-          # TODO: change when 1.5 is released
-          - 1.5.0-rc1
+          - "1.5.0"
         python:
           # - "3.7"
           - "3.8"

--- a/projects/adapter/integration_tests/projects/env_project/dbt_project.yml
+++ b/projects/adapter/integration_tests/projects/env_project/dbt_project.yml
@@ -8,8 +8,6 @@ seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "{{ env_var('temp_dir') }}/target"
-
 vars:
   fal-scripts-path: "fal_scripts"
 

--- a/projects/adapter/integration_tests/projects/simple_project/dbt_project.yml
+++ b/projects/adapter/integration_tests/projects/simple_project/dbt_project.yml
@@ -8,10 +8,10 @@ seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "{{ env_var('temp_dir') }}/target"
-
 models:
   +schema: custom
+  # All serverless should run on M machines by default
+  +fal_machine: "M"
   simple_test:
     python:
       +materialized: table

--- a/projects/adapter/integration_tests/projects/source_freshness/dbt_project.yml
+++ b/projects/adapter/integration_tests/projects/source_freshness/dbt_project.yml
@@ -8,8 +8,6 @@ seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "{{ env_var('temp_dir') }}/target"
-
 vars:
   fal-scripts-path: "fal_scripts"
 

--- a/projects/adapter/poetry.lock
+++ b/projects/adapter/poetry.lock
@@ -188,21 +188,6 @@ python-versions = ">=3.6"
 tzdata = ["tzdata"]
 
 [[package]]
-name = "betterproto"
-version = "1.2.5"
-description = "A better Protobuf / gRPC generator & library"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-grpclib = "*"
-stringcase = "*"
-
-[package.extras]
-compiler = ["black", "jinja2", "protobuf"]
-
-[[package]]
 name = "botocore"
 version = "1.27.59"
 description = "Low-level, data-driven core of boto 3."
@@ -331,7 +316,7 @@ pyarrow = ">=3.0.0"
 
 [[package]]
 name = "dbt-core"
-version = "1.4.1"
+version = "1.5.0"
 description = "With dbt, data analysts and engineers can build analytics the way engineers build applications."
 category = "main"
 optional = false
@@ -339,27 +324,28 @@ python-versions = ">=3.7.2"
 
 [package.dependencies]
 agate = ">=1.6,<1.7.1"
-betterproto = "1.2.5"
 cffi = ">=1.9,<2.0.0"
 click = ">=7.0,<9"
 colorama = ">=0.3.9,<0.4.7"
 dbt-extractor = ">=0.4.1,<0.5.0"
-hologram = ">=0.0.14,<=0.0.15"
+hologram = ">=0.0.14,<=0.0.16"
 idna = ">=2.5,<4"
 isodate = ">=0.6,<0.7"
 Jinja2 = "3.1.2"
 logbook = ">=1.5,<1.6"
-mashumaro = {version = "3.3.1", extras = ["msgpack"]}
+mashumaro = {version = "3.6", extras = ["msgpack"]}
 minimal-snowplow-tracker = "0.0.2"
 networkx = [
     {version = ">=2.3,<2.8.1", markers = "python_version < \"3.8\""},
     {version = ">=2.3,<3", markers = "python_version >= \"3.8\""},
 ]
-packaging = ">=20.9,<22.0"
-pathspec = ">=0.9,<0.11"
+packaging = ">20.9"
+pathspec = ">=0.9,<0.12"
+protobuf = ">=3.18.3"
+pytz = ">=2015.7"
 pyyaml = ">=6.0"
 requests = "<3.0.0"
-sqlparse = ">=0.2.3,<0.5"
+sqlparse = ">=0.2.3,<0.4.4"
 typing-extensions = ">=3.7.4"
 werkzeug = ">=1,<3"
 
@@ -679,33 +665,6 @@ grpcio = ">=1.51.1"
 protobuf = ">=4.21.6"
 
 [[package]]
-name = "grpclib"
-version = "0.4.3"
-description = "Pure-Python gRPC implementation for asyncio"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-h2 = ">=3.1.0,<5"
-multidict = "*"
-
-[package.extras]
-protobuf = ["protobuf (>=3.15.0)"]
-
-[[package]]
-name = "h2"
-version = "4.1.0"
-description = "HTTP/2 State-Machine based protocol implementation"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-hpack = ">=4.0,<5"
-hyperframe = ">=6.0,<7"
-
-[[package]]
 name = "hologram"
 version = "0.0.15"
 description = "JSON schema generation from dataclasses"
@@ -716,22 +675,6 @@ python-versions = "*"
 [package.dependencies]
 jsonschema = ">=3.0,<4.0"
 python-dateutil = ">=2.8,<2.9"
-
-[[package]]
-name = "hpack"
-version = "4.0.0"
-description = "Pure-Python HPACK header compression"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
-
-[[package]]
-name = "hyperframe"
-version = "6.0.1"
-description = "HTTP/2 framing layer for Python"
-category = "main"
-optional = false
-python-versions = ">=3.6.1"
 
 [[package]]
 name = "idna"
@@ -905,8 +848,8 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "mashumaro"
-version = "3.3.1"
-description = "Fast serialization framework on top of dataclasses"
+version = "3.6"
+description = "Fast serialization library on top of dataclasses"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -970,7 +913,7 @@ name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
@@ -1067,14 +1010,11 @@ asn1crypto = ">=1.5.1"
 
 [[package]]
 name = "packaging"
-version = "21.3"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pandas"
@@ -1299,17 +1239,6 @@ cryptography = ">=38.0.0,<39"
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
-
-[[package]]
-name = "pyparsing"
-version = "3.0.9"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "main"
-optional = false
-python-versions = ">=3.6.8"
-
-[package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
@@ -1582,14 +1511,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "stringcase"
-version = "1.2.0"
-description = "String case converter."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "structlog"
 version = "22.3.0"
 description = "Structured Logging for Python"
@@ -1776,7 +1697,7 @@ trino = ["trino"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.2, <3.12"
-content-hash = "501535cc6c40ccab932f918b97677e4ee9c5a8b3be4ece840a220ce5119eb754"
+content-hash = "0aba704d4c818c076e8530ffa7f720fbea3548cbd96e4b88ca0e72f1cfedb991"
 
 [metadata.files]
 agate = [
@@ -1937,9 +1858,6 @@ backports-zoneinfo = [
     {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
     {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
 ]
-betterproto = [
-    {file = "betterproto-1.2.5.tar.gz", hash = "sha256:74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d"},
-]
 botocore = [
     {file = "botocore-1.27.59-py3-none-any.whl", hash = "sha256:69d756791fc024bda54f6c53f71ae34e695ee41bbbc1743d9179c4837a4929da"},
     {file = "botocore-1.27.59.tar.gz", hash = "sha256:eda4aed6ee719a745d1288eaf1beb12f6f6448ad1fa12f159405db14ba9c92cf"},
@@ -2067,8 +1985,8 @@ db-dtypes = [
     {file = "db_dtypes-1.0.5-py2.py3-none-any.whl", hash = "sha256:ab6782bf7a414dd7289ce4ba8ddea5ec44c1339d189c7738d7098efdfd148266"},
 ]
 dbt-core = [
-    {file = "dbt-core-1.4.1.tar.gz", hash = "sha256:ef67fd94260cb6a9d293ef8923fb39965687844d0b6937e5eabd9378d7611cf3"},
-    {file = "dbt_core-1.4.1-py3-none-any.whl", hash = "sha256:40fbc42484accb75bb59dd8cabb018da4f3a022f08cfa4f490a0c8759b25a9d9"},
+    {file = "dbt-core-1.5.0.tar.gz", hash = "sha256:d6d43b7ff0f12765e7e85559c1a109eaa23a7536b26b3f963d0c19263f69b3c4"},
+    {file = "dbt_core-1.5.0-py3-none-any.whl", hash = "sha256:0761fb8287830d7c8990517340238c62c0085e8b8351952440fe03fdd30ee817"},
 ]
 dbt-extractor = [
     {file = "dbt_extractor-0.4.1-cp36-abi3-macosx_10_7_x86_64.whl", hash = "sha256:4dc715bd740e418d8dc1dd418fea508e79208a24cf5ab110b0092a3cbe96bf71"},
@@ -2402,24 +2320,9 @@ grpcio-status = [
     {file = "grpcio-status-1.51.1.tar.gz", hash = "sha256:ac2617a3095935ebd785e2228958f24b10a0d527a0c9eb5a0863c784f648a816"},
     {file = "grpcio_status-1.51.1-py3-none-any.whl", hash = "sha256:a52cbdc4b18f325bfc13d319ae7c7ae7a0fee07f3d9a005504d6097896d7a495"},
 ]
-grpclib = [
-    {file = "grpclib-0.4.3.tar.gz", hash = "sha256:eadf2002fc5a25158b707c0338a6c0b96dd7fbdc6df66f7e515e7f041d56a940"},
-]
-h2 = [
-    {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
-    {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},
-]
 hologram = [
     {file = "hologram-0.0.15-py3-none-any.whl", hash = "sha256:48ca81ed47da1c604b2d3b951424b600eb8a5785b00513e3b8e3ae8101f90145"},
     {file = "hologram-0.0.15.tar.gz", hash = "sha256:79b3d04df84d5a9d09c2e669ec5bcc50b1713ec79f4683cfdea85583b41e46f0"},
-]
-hpack = [
-    {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
-    {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
-]
-hyperframe = [
-    {file = "hyperframe-6.0.1-py3-none-any.whl", hash = "sha256:0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15"},
-    {file = "hyperframe-6.0.1.tar.gz", hash = "sha256:ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -2525,8 +2428,8 @@ markupsafe = [
     {file = "MarkupSafe-2.1.2.tar.gz", hash = "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"},
 ]
 mashumaro = [
-    {file = "mashumaro-3.3.1-py3-none-any.whl", hash = "sha256:74ae7704e4ac8813ff701909aa8d96a405156dc2e1e3fd34ac07db7f0823a54a"},
-    {file = "mashumaro-3.3.1.tar.gz", hash = "sha256:997ed0a4ce64967b96ff65f5ca76b8e5e459a4ec7a6a0f73625a067004a801c9"},
+    {file = "mashumaro-3.6-py3-none-any.whl", hash = "sha256:77403e3e2ecd0a7d0e22d472c08e33282460e48726eabe356c5163efbdf9c7ee"},
+    {file = "mashumaro-3.6.tar.gz", hash = "sha256:ceb3de53029219bbbb0385ca600b59348dcd14e0c68523986c6d51889ad338f5"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -2757,8 +2660,8 @@ oscrypto = [
     {file = "oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4"},
 ]
 packaging = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 pandas = [
     {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
@@ -2920,10 +2823,6 @@ pyjwt = [
 pyopenssl = [
     {file = "pyOpenSSL-22.1.0-py3-none-any.whl", hash = "sha256:b28437c9773bb6c6958628cf9c3bebe585de661dba6f63df17111966363dd15e"},
     {file = "pyOpenSSL-22.1.0.tar.gz", hash = "sha256:7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968"},
-]
-pyparsing = [
-    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
@@ -3136,9 +3035,6 @@ sqlalchemy-redshift = [
 sqlparse = [
     {file = "sqlparse-0.4.3-py3-none-any.whl", hash = "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34"},
     {file = "sqlparse-0.4.3.tar.gz", hash = "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"},
-]
-stringcase = [
-    {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]
 structlog = [
     {file = "structlog-22.3.0-py3-none-any.whl", hash = "sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad"},

--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.2, <3.12"
-dbt-core = ">=1.5.0-rc1, <1.6"
+dbt-core = ">=1.5.0, <1.6"
 posthog = "^1.4.5"
 pandas = "^1.3.4"
 "backports.functools_lru_cache" = "^1.6.4"

--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.2, <3.12"
-dbt-core = ">=1.4.0, <1.5"
+dbt-core = ">=1.5.0-b5, <1.6"
 posthog = "^1.4.5"
 pandas = "^1.3.4"
 "backports.functools_lru_cache" = "^1.6.4"
@@ -43,7 +43,7 @@ s3fs = { version = ">=2022.8.2", optional = true }
 
 # fal cloud
 dill = ">=0.3.5.1"
-packaging = "<22"
+packaging = ">=23"
 fal-serverless = "^0.6.28"
 importlib-metadata = "^6.0.0"
 

--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.2, <3.12"
-dbt-core = ">=1.5.0-b5, <1.6"
+dbt-core = ">=1.5.0-rc1, <1.6"
 posthog = "^1.4.5"
 pandas = "^1.3.4"
 "backports.functools_lru_cache" = "^1.6.4"

--- a/projects/adapter/src/dbt/adapters/fal/impl.py
+++ b/projects/adapter/src/dbt/adapters/fal/impl.py
@@ -32,11 +32,11 @@ def _release_plugin_lock():
 
 DB_PROFILE = None
 DB_RELATION = BaseRelation
-OVERRIDEN_PROPERTIES = {}
+OVERRIDE_PROPERTIES = {}
 
 # NOTE: Should this file run on isolate agents? Could we skip it entirely and build a FalEncAdapterWrapper directly?
 if not is_agent():
-    DB_PROFILE, OVERRIDEN_PROPERTIES = load_profiles_info_1_5()
+    DB_PROFILE, OVERRIDE_PROPERTIES = load_profiles_info_1_5()
     DB_RELATION = FACTORY.get_relation_class_by_name(DB_PROFILE.credentials.type)
 
 
@@ -76,9 +76,9 @@ class FalEncAdapter(BaseAdapter):
         config.python_adapter_credentials = fal_credentials
         config.sql_adapter_credentials = db_credentials
 
-        for key in OVERRIDEN_PROPERTIES:
-            if OVERRIDEN_PROPERTIES[key] is None:
-                setattr(config, key, getattr(DB_PROFILE, key))
+        for key in OVERRIDE_PROPERTIES:
+            if OVERRIDE_PROPERTIES[key] is not None:
+                setattr(config, key, OVERRIDE_PROPERTIES[key])
 
         with _release_plugin_lock():
             # Temporary credentials for register

--- a/projects/adapter/src/dbt/adapters/fal/impl.py
+++ b/projects/adapter/src/dbt/adapters/fal/impl.py
@@ -1,9 +1,10 @@
-from typing import Dict, Any, Tuple
+from typing import Optional
 
 from collections import defaultdict
 from contextlib import contextmanager
-from dbt.config.profile import Profile
-from dbt.adapters.base.impl import BaseAdapter, BaseRelation
+from dbt.adapters.base.impl import BaseAdapter
+from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.protocol import AdapterConfig
 from dbt.adapters.factory import FACTORY
 
 # TODO: offer in `from isolate import is_agent`
@@ -11,6 +12,13 @@ from isolate.connections.common import is_agent
 
 from .connections import FalEncCredentials
 from .wrappers import FalEncAdapterWrapper, FalCredentialsWrapper
+
+from .load_db_profile import load_profiles_info_1_5
+
+
+class FalConfigs(AdapterConfig):
+    fal_environment: Optional[str]
+    fal_machine: Optional[str]
 
 
 @contextmanager
@@ -22,101 +30,28 @@ def _release_plugin_lock():
         FACTORY.lock.acquire()
 
 
-def load_profiles_info() -> Tuple[Profile, Dict[str, bool], Dict[str, bool]]:
-    import os
-
-    from dbt.config.profile import read_profile
-    from dbt.config.project import Project
-    from dbt.config.renderer import ProfileRenderer
-    from dbt.config.utils import parse_cli_vars
-    from dbt.main import _build_base_subparser, _add_common_arguments
-    from dbt import flags
-
-    # includes vars, profile, target
-    parser = _build_base_subparser()
-    _add_common_arguments(parser)
-    args, _unknown = parser.parse_known_args()
-
-    # dbt-core does os.chdir(project_dir) before reaching this location
-    # from https://github.com/dbt-labs/dbt-core/blob/73116fb816498c4c45a01a2498199465202ec01b/core/dbt/task/base.py#L186
-    project_root = os.getcwd()
-
-    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/runtime.py#L193-L203
-    version_check = bool(flags.VERSION_CHECK)
-    partial = Project.partial_load(project_root, verify_version=version_check)
-
-    cli_vars: Dict[str, Any] = parse_cli_vars(getattr(args, "vars", "{}"))
-    profile_renderer = ProfileRenderer(cli_vars)
-    project_profile_name = partial.render_profile_name(profile_renderer)
-
-    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/profile.py#L423-L425
-    profile_name = Profile.pick_profile_name(
-        getattr(args, "profile", None), project_profile_name
-    )
-    raw_profiles = read_profile(flags.PROFILES_DIR)
-    raw_profile = raw_profiles[profile_name]
-
-    # from https://github.com/dbt-labs/dbt-core/blob/19c48e285ec381b7f7fa2dbaaa8d8361374136ba/core/dbt/config/profile.py#L287-L293
-    target_override = getattr(args, "target", None)
-    if target_override is not None:
-        target_name = target_override
-    elif "target" in raw_profile:
-        target_name = profile_renderer.render_value(raw_profile["target"])
-    else:
-        target_name = "default"
-
-    fal_dict = Profile._get_profile_data(raw_profile, profile_name, target_name)
-    db_profile = fal_dict.get("db_profile")
-    assert db_profile, "fal credentials must have a `db_profile` property set"
-
-    try:
-        db_profile = Profile.from_raw_profiles(
-            raw_profiles,
-            profile_name,
-            renderer=profile_renderer,
-            target_override=db_profile,
-        )
-
-        return (
-            db_profile,
-            {"threads": "threads" in fal_dict},
-            {"threads": args.threads is not None},
-        )
-    except AttributeError as error:
-        if "circular import" in str(error):
-            raise AttributeError(
-                "Do not wrap a type 'fal' profile with another type 'fal' profile"
-            ) from error
-        else:
-            raise
-
-
 DB_PROFILE = None
 DB_RELATION = BaseRelation
-INHERIT_PROPERTIES = defaultdict(lambda: True)
+OVERRIDEN_PROPERTIES = {}
 
 # NOTE: Should this file run on isolate agents? Could we skip it entirely and build a FalEncAdapterWrapper directly?
 if not is_agent():
-    DB_PROFILE, PROFILE_PROPERTIES, ARGS_PROPERTIES = load_profiles_info()
+    DB_PROFILE, OVERRIDEN_PROPERTIES = load_profiles_info_1_5()
     DB_RELATION = FACTORY.get_relation_class_by_name(DB_PROFILE.credentials.type)
-
-    for key, val in PROFILE_PROPERTIES.items():
-        if val:
-            INHERIT_PROPERTIES[key] = False
-    for key, val in ARGS_PROPERTIES.items():
-        if val:
-            INHERIT_PROPERTIES[key] = False
 
 
 class FalEncAdapter(BaseAdapter):
     Relation = DB_RELATION  # type: ignore
+
+    # TODO: how do we actually use this?
+    AdapterSpecificConfigs = FalConfigs
 
     def __new__(cls, config):
         # There are two different credentials types which can be passed to FalEncAdapter
         # 1. FalEncCredentials
         # 2. FalCredentialsWrapper
         #
-        # For the first one, we have to go through parsing the profiles.yml (so that we
+        # For `FalEncCredentials`, we have to go through parsing the profiles.yml (so that we
         # can obtain the real 'db' credentials). But for the other one, we can just use
         # the bound credentials directly (e.g. in isolated mode where we don't actually
         # have access to the profiles.yml file).
@@ -140,8 +75,10 @@ class FalEncAdapter(BaseAdapter):
 
         config.python_adapter_credentials = fal_credentials
         config.sql_adapter_credentials = db_credentials
-        if INHERIT_PROPERTIES["threads"]:
-            config.threads = DB_PROFILE.threads
+
+        for key in OVERRIDEN_PROPERTIES:
+            if OVERRIDEN_PROPERTIES[key] is None:
+                setattr(config, key, getattr(DB_PROFILE, key))
 
         with _release_plugin_lock():
             # Temporary credentials for register

--- a/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
+++ b/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
@@ -1,7 +1,6 @@
 from typing import Dict, Any, Tuple, Optional
 
-from dbt.cli.flags import Flags
-from dbt.flags import get_flags
+from dbt.flags import get_flags, Namespace
 from dbt.config.project import load_raw_project
 from dbt.config.profile import read_profile, Profile
 from dbt.config.renderer import ProfileRenderer
@@ -39,7 +38,7 @@ def find_target_name(
 
 
 def load_profiles_info_1_5() -> Tuple[Profile, Dict[str, Any]]:
-    flags: Flags = get_flags()  # type: ignore
+    flags: Namespace = get_flags()
 
     profile_renderer = ProfileRenderer(flags.VARS)
 

--- a/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
+++ b/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
@@ -1,0 +1,81 @@
+from typing import Dict, Any, Tuple, Optional
+
+from dbt.cli.flags import Flags
+from dbt.flags import get_flags
+from dbt.config.project import load_raw_project
+from dbt.config.profile import read_profile, Profile
+from dbt.config.renderer import ProfileRenderer
+
+
+# NOTE: inspired in https://github.com/dbt-labs/dbt-core/blob/828d723512fced809c63e369a82c7eb570a74986/core/dbt/config/runtime.py#L58-L74
+def find_profile_name(
+    profile_override: Optional[str],
+    project_root: str,
+    profile_renderer: ProfileRenderer,
+):
+    if profile_override is not None:
+        profile_name = profile_override
+    else:
+        raw_project = load_raw_project(project_root)
+        raw_profile_name = raw_project.get("profile")
+        profile_name = profile_renderer.render_value(raw_profile_name)
+
+    return profile_name
+
+
+# NOTE: inspired in https://github.com/dbt-labs/dbt-core/blob/828d723512fced809c63e369a82c7eb570a74986/core/dbt/config/profile.py#L279-L311
+def find_target_name(
+    target_override: Optional[str], raw_profile: dict, profile_renderer: ProfileRenderer
+):
+    if target_override is not None:
+        target_name = target_override
+    elif "target" in raw_profile:
+        # render the target if it was parsed from yaml
+        target_name = profile_renderer.render_value(raw_profile["target"])
+    else:
+        target_name = "default"
+
+    return target_name
+
+
+def load_profiles_info_1_5() -> Tuple[Profile, Dict[str, Any]]:
+    flags: Flags = get_flags()  # type: ignore
+
+    profile_renderer = ProfileRenderer(flags.VARS)
+
+    profile_name = find_profile_name(flags.PROFILE, flags.PROJECT_DIR, profile_renderer)
+
+    raw_profiles = read_profile(flags.PROFILES_DIR)
+    raw_profile = raw_profiles[profile_name]
+
+    target_name = find_target_name(flags.TARGET, raw_profile, profile_renderer)
+
+    fal_dict = Profile._get_profile_data(
+        profile=raw_profile,
+        profile_name=profile_name,
+        target_name=target_name,
+    )
+    db_profile_target_name = fal_dict.get("db_profile")
+    assert (
+        db_profile_target_name
+    ), "fal credentials must have a `db_profile` property set"
+
+    try:
+        db_profile = Profile.from_raw_profile_info(
+            raw_profile=raw_profile,
+            profile_name=profile_name,
+            renderer=profile_renderer,
+            # TODO: should we load the user_config?
+            user_config={},
+            target_override=db_profile_target_name,
+        )
+    except RecursionError as error:
+        raise AttributeError(
+            "Did you wrap a type 'fal' profile with another type 'fal' profile?"
+        ) from error
+
+    override_properties = {
+        "threads": flags.THREADS or fal_dict.get("threads"),
+    }
+
+    return db_profile, override_properties

--- a/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
+++ b/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
@@ -75,7 +75,7 @@ def load_profiles_info_1_5() -> Tuple[Profile, Dict[str, Any]]:
         ) from error
 
     override_properties = {
-        "threads": flags.THREADS or fal_dict.get("threads"),
+        "threads": flags.THREADS or fal_dict.get("threads") or db_profile.threads,
     }
 
     return db_profile, override_properties

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -4,11 +4,12 @@ import zipfile
 import io
 from functools import partial
 from tempfile import NamedTemporaryFile
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.connection import AdapterResponse
+from dbt.flags import get_flags, Namespace
 
 from fal_serverless import FalServerlessHost, isolated
 from dbt.adapters.fal_experimental.utils.environments import (
@@ -42,6 +43,7 @@ def run_with_adapter(code: str, adapter: BaseAdapter, config: RuntimeConfig) -> 
 
 def _isolated_runner(
     code: str,
+    flags: Namespace,
     config: RuntimeConfig,
     manifest: Manifest,
     macro_manifest: MacroManifest,
@@ -50,7 +52,7 @@ def _isolated_runner(
     # This function can be run in an entirely separate
     # process or an environment, so we need to reconstruct
     # the DB adapter solely from the config.
-    adapter = reconstruct_adapter(config, manifest, macro_manifest)
+    adapter = reconstruct_adapter(flags, config, manifest, macro_manifest)
     fal_scripts_path = get_fal_scripts_path(config)
     if local_packages is not None:
         if fal_scripts_path.exists():
@@ -99,6 +101,7 @@ def run_in_environment_with_adapter(
     execute_model = partial(
         _isolated_runner,
         code,
+        get_flags(),
         config,
         manifest,
         macro_manifest,

--- a/projects/adapter/src/dbt/adapters/fal_experimental/adapter.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/adapter.py
@@ -100,11 +100,11 @@ def run_in_environment_with_adapter(
 
     execute_model = partial(
         _isolated_runner,
-        code,
-        get_flags(),
-        config,
-        manifest,
-        macro_manifest,
+        code=code,
+        flags=get_flags(),
+        config=config,
+        manifest=manifest,
+        macro_manifest=macro_manifest,
         local_packages=compressed_local_packages
     )
 

--- a/projects/adapter/src/dbt/adapters/fal_experimental/impl.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/impl.py
@@ -100,7 +100,7 @@ class FalAdapterMixin(TeleportAdapter, metaclass=AdapterMeta):
             teleport_info = self._build_teleport_info()
             if is_local:
                 result_table_path = run_with_teleport(
-                    compiled_code,
+                    code=compiled_code,
                     teleport_info=teleport_info,
                     locations=self._relation_data_location_cache,
                     config=db_adapter_config(self.config)

--- a/projects/adapter/src/dbt/adapters/fal_experimental/impl.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/impl.py
@@ -66,12 +66,14 @@ class FalAdapterMixin(TeleportAdapter, metaclass=AdapterMeta):
         self, parsed_model: dict, compiled_code: str
     ) -> AdapterResponse:
         """Execute the given `compiled_code` in the target environment."""
-        environment_name = parsed_model["config"].get(
+        config_dict = parsed_model["config"]
+
+        environment_name = config_dict.get(
             "fal_environment",
             self.credentials.default_environment,
         )
 
-        machine_type = parsed_model["config"].get(
+        machine_type = config_dict.get(
             "fal_machine",
             "S",
         )

--- a/projects/adapter/src/dbt/adapters/fal_experimental/teleport.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/teleport.py
@@ -1,23 +1,37 @@
+from __future__ import annotations
+
+import zipfile
+import io
+import functools
+import pandas as pd
+from functools import partial
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict, NewType, Optional
-from functools import partial
-import functools
-import zipfile
-from dbt.adapters.fal_experimental.connections import TeleportTypeEnum
-from dbt.adapters.fal_experimental.utils.environments import EnvironmentDefinition, get_default_pip_dependencies
-from dbt.adapters.fal_experimental.utils import extra_path, get_fal_scripts_path, retrieve_symbol
+
 from dbt.config.runtime import RuntimeConfig
-from fal_serverless import FalServerlessHost, isolated
-import pandas as pd
-
 from dbt.contracts.connection import AdapterResponse
+from dbt.flags import get_flags, Namespace
 
+from fal_serverless import FalServerlessHost, isolated
+from dbt.adapters.fal_experimental.connections import TeleportTypeEnum
+from dbt.adapters.fal_experimental.utils.environments import (
+    EnvironmentDefinition,
+    get_default_pip_dependencies,
+)
+from dbt.adapters.fal_experimental.utils import (
+    extra_path,
+    get_fal_scripts_path,
+    retrieve_symbol,
+)
 from dbt.fal.adapters.teleport.info import TeleportInfo
 
 
-DataLocation = NewType('DataLocation', Dict[str, str])
+DataLocation = NewType("DataLocation", Dict[str, str])
 
-def _prepare_for_teleport(function: Callable, teleport: TeleportInfo, locations: DataLocation) -> Callable:
+
+def _prepare_for_teleport(
+    function: Callable, teleport: TeleportInfo, locations: DataLocation
+) -> Callable:
     @functools.wraps(function)
     def wrapped(relation: str, *args, **kwargs) -> Any:
         relation = relation.lower()
@@ -25,11 +39,14 @@ def _prepare_for_teleport(function: Callable, teleport: TeleportInfo, locations:
 
     return wrapped
 
-def _teleport_df_from_external_storage(teleport_info: TeleportInfo, locations: DataLocation, relation: str) -> pd.DataFrame:
+
+def _teleport_df_from_external_storage(
+    teleport_info: TeleportInfo, locations: DataLocation, relation: str
+) -> pd.DataFrame:
     if relation not in locations:
         raise RuntimeError(f"Could not find url for '{relation}' in {locations}")
 
-    if teleport_info.format == 'parquet':
+    if teleport_info.format == "parquet":
         relation_path = locations[relation]
         url = teleport_info.build_url(relation_path)
         storage_options = _build_teleport_storage_options(teleport_info)
@@ -38,8 +55,14 @@ def _teleport_df_from_external_storage(teleport_info: TeleportInfo, locations: D
         # TODO: support more
         raise RuntimeError(f"Format {teleport_info.format} not supported")
 
-def _teleport_df_to_external_storage(teleport_info: TeleportInfo, locations: DataLocation, relation: str, data: pd.DataFrame):
-    if teleport_info.format == 'parquet':
+
+def _teleport_df_to_external_storage(
+    teleport_info: TeleportInfo,
+    locations: DataLocation,
+    relation: str,
+    data: pd.DataFrame,
+):
+    if teleport_info.format == "parquet":
         relation_path = teleport_info.build_relation_path(relation)
         url = teleport_info.build_url(relation_path)
         storage_options = _build_teleport_storage_options(teleport_info)
@@ -50,32 +73,37 @@ def _teleport_df_to_external_storage(teleport_info: TeleportInfo, locations: Dat
     else:
         raise RuntimeError(f"Format {teleport_info.format} not supported")
 
+
 def _build_teleport_storage_options(teleport_info: TeleportInfo) -> Dict[str, str]:
     storage_options = {}
     if teleport_info.credentials.type == TeleportTypeEnum.REMOTE_S3:
         storage_options = {
             "key": teleport_info.credentials.s3_access_key_id,
-            "secret": teleport_info.credentials.s3_access_key
+            "secret": teleport_info.credentials.s3_access_key,
         }
     elif teleport_info.credentials.type == TeleportTypeEnum.LOCAL:
         pass
     else:
-        raise RuntimeError(f"Teleport storage type {teleport_info.credentials.type} not supported")
+        raise RuntimeError(
+            f"Teleport storage type {teleport_info.credentials.type} not supported"
+        )
     return storage_options
 
+
 def run_with_teleport(
-        code: str,
-        teleport_info: TeleportInfo,
-        locations: DataLocation,
-        config: RuntimeConfig,
-        local_packages: Optional[bytes]) -> str:
+    code: str,
+    teleport_info: TeleportInfo,
+    locations: DataLocation,
+    config: RuntimeConfig,
+    local_packages: Optional[bytes] = None,
+) -> str:
     # main symbol is defined during dbt-fal's compilation
     # and acts as an entrypoint for us to run the model.
-    import io
     fal_scripts_path = str(get_fal_scripts_path(config))
     if local_packages is not None:
         if fal_scripts_path.exists():
             import shutil
+
             shutil.rmtree(fal_scripts_path)
         fal_scripts_path.parent.mkdir(parents=True, exist_ok=True)
         zip_file = zipfile.ZipFile(io.BytesIO(local_packages))
@@ -84,9 +112,14 @@ def run_with_teleport(
     with extra_path(fal_scripts_path):
         main = retrieve_symbol(code, "main")
         return main(
-            read_df=_prepare_for_teleport(_teleport_df_from_external_storage, teleport_info, locations),
-            write_df=_prepare_for_teleport(_teleport_df_to_external_storage, teleport_info, locations)
+            read_df=_prepare_for_teleport(
+                _teleport_df_from_external_storage, teleport_info, locations
+            ),
+            write_df=_prepare_for_teleport(
+                _teleport_df_to_external_storage, teleport_info, locations
+            ),
         )
+
 
 def run_in_environment_with_teleport(
     environment: EnvironmentDefinition,
@@ -114,9 +147,7 @@ def run_in_environment_with_teleport(
 
     if is_remote and fal_scripts_path.exists():
         with NamedTemporaryFile() as temp_file:
-            with zipfile.ZipFile(
-                temp_file.name, "w", zipfile.ZIP_DEFLATED
-            ) as zip_file:
+            with zipfile.ZipFile(temp_file.name, "w", zipfile.ZIP_DEFLATED) as zip_file:
                 for entry in fal_scripts_path.rglob("*"):
                     zip_file.write(entry, entry.relative_to(fal_scripts_path))
 
@@ -124,19 +155,18 @@ def run_in_environment_with_teleport(
 
     execute_model = partial(
         run_with_teleport,
-        code,
-        teleport_info,
-        locations,
-        config,
-        compressed_local_packages)
+        code=code,
+        teleport_info=teleport_info,
+        locations=locations,
+        config=config,
+        local_packages=compressed_local_packages,
+    )
 
     if environment.kind == "virtualenv":
         requirements = environment.config.get("requirements", [])
         requirements += deps
         isolated_function = isolated(
-            kind="virtualenv",
-            host=environment.host,
-            requirements=requirements
+            kind="virtualenv", host=environment.host, requirements=requirements
         )(execute_model)
     elif environment.kind == "conda":
         dependencies = environment.config.pop("packages", [])
@@ -144,12 +174,11 @@ def run_in_environment_with_teleport(
         env_dict = {
             "name": "dbt_fal_env",
             "channels": ["conda-forge", "defaults"],
-            "dependencies": dependencies
+            "dependencies": dependencies,
         }
         isolated_function = isolated(
-            kind="conda",
-            host=environment.host,
-            env_dict=env_dict)(execute_model)
+            kind="conda", host=environment.host, env_dict=env_dict
+        )(execute_model)
     else:
         # We should not reach this point, because environment types are validated when the
         # environment objects are created (in utils/environments.py).

--- a/projects/adapter/src/dbt/adapters/fal_experimental/teleport_support/snowflake.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/teleport_support/snowflake.py
@@ -1,8 +1,6 @@
-from typing import List
 from dbt.adapters.fal_experimental.connections import TeleportCredentials
 from dbt.fal.adapters.teleport.impl import TeleportAdapter
 from dbt.fal.adapters.teleport.info import TeleportInfo
-from dbt.adapters.fal_experimental.adapter_support import new_connection
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.base.impl import BaseAdapter
 

--- a/projects/adapter/src/dbt/include/fal/macros/materializations/table.sql
+++ b/projects/adapter/src/dbt/include/fal/macros/materializations/table.sql
@@ -6,8 +6,9 @@
 
   {%- if adapter.is_teleport() -%}
     {%- for _ref in model.refs -%}
-        {%- set resolved = ref(*_ref) -%}
-        {%- do adapter.sync_teleport_relation(ref(*_ref)) -%}
+      {% set _ref_args = [_ref.get('package'), _ref['name']] if _ref.get('package') else [_ref['name'],] %}
+      {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}
+      {%- do adapter.sync_teleport_relation(resolved) -%}
     {%- endfor -%}
   {%- endif -%}
 

--- a/projects/adapter/src/dbt/include/fal_experimental/macros/materializations/table.sql
+++ b/projects/adapter/src/dbt/include/fal_experimental/macros/materializations/table.sql
@@ -1,3 +1,4 @@
+-- This file may be outdated because we actually use the `fal` materialization
 {% materialization table, adapter='fal_experimental', supported_languages=['python'] -%}
 
   -- TODO: change to sync_teleport() when available in dbt-core


### PR DESCRIPTION
## Description
Refactor and adapt DB profile loading for dbt-fal.
It mostly follows the same ideas adapted to some changes on how flags are loaded and avoiding a new parser for some checks.
In general this is a better implementation than before but does not really take advantage of any new API introduced in 1.5

<!-- If applicable: -->
<!--
GitHub: resolves #XXX
Linear: closes FEA-932
-->

Other good thing with this change is that now running `dbt run` on the integration test projects does not need a `temp_dir` env var being set, becuase it handles it exclusively for behave.

## Postgres
Got it to just fail for `features/source.feature:9  Run a Python model that queries a source in local environment`.
That failure would be related to fal-cli tool, because we fill the source with a `FalDbt` instance.

```
❯ python load_freshness_table.py . ~/.dbt/
Traceback (most recent call last):
  File "load_freshness_table.py", line 3, in <module>
    from fal import FalDbt
  File "/Users/matteo/.pyenv/versions/fal15/lib/python3.8/site-packages/fal/__init__.py", line 3, in <module>
    from faldbt.project import (
  File "/Users/matteo/.pyenv/versions/fal15/lib/python3.8/site-packages/faldbt/project.py", line 20, in <module>
    from dbt.contracts.graph.parsed import (
ModuleNotFoundError: No module named 'dbt.contracts.graph.parsed'
```

## Snowflake


## BigQuery


## Redshift
Changed connection solution, will be addressed in PR #835