### PR TITLE
feat: build container for each version of the CLI

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,62 @@
+name: Container
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - "*"
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: Version
+        required: false
+        type: string
+
+jobs:
+
+  container:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build container
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+
+  push:
+    if: github.event_name != 'pull_request'
+    needs:
+    - container
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Determine Version
+      id: version
+      run: echo "::set-output name=version::$(git describe --always --tags --dirty)"
+    - name: Build and push
+      id: push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64, linux/arm64
+        tags: ghcr.io/fal-ai/fal:latest, ghcr.io/fal-ai/fal:${{ inputs.version || steps.version.outputs.version }}
+    - name: Determine digest
+      run: echo ${{ steps.push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,6 +73,7 @@ jobs:
           done
 
       - name: Bump publishing version and build
+        id: bump
         working-directory: projects/fal
         env:
           VERSION_TYPE: ${{ github.event.inputs.version }}
@@ -83,6 +85,7 @@ jobs:
 
           poetry version $VERSION_TYPE
           poetry build
+          echo "version=$(poetry version --short)" >> "$GITHUB_OUTPUT"
 
       - name: Publish PyPI
         env:
@@ -104,3 +107,9 @@ jobs:
           title: Bump the pyproject.toml version for fal
           base: main
           token: ${{ secrets.RELEASER_GITHUB_PAT }}
+
+  release-container:
+    uses: ./.github/workflows/container.yml
+    needs: release
+    with:
+      version: ${{ needs.release.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim as build
+RUN ln -s /usr/bin/python3 /tmp/python3
+RUN python3 -m venv /opt/fal
+COPY projects /src
+RUN /opt/fal/bin/pip install /src/fal
+
+FROM gcr.io/distroless/python3-debian12
+COPY --from=build /tmp /usr/local/bin
+COPY --from=build /opt/fal /opt/fal
+ENTRYPOINT ["/opt/fal/bin/fal"]


### PR DESCRIPTION
This commit adds a new feature to the project that builds a container
for every version. This is helpful for easily running the CLI without
having a local installation of Python, e.g. running the CLI in CI or on
Kubernetes.

With the current GitHub actions setup, a container is built on every
merge to main with the Git SHA as the tag as well as on every trigger of
the `release.yml` workflow, in which case the tag will be the version of
the release.

Images will be pushed to ghcr.io/fal-ai/fal.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
