### PR TITLE
ci: run tests with python 3.9

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We want to keep 3.9 compatibility, this is a good way to ensure this.

The recently merged #44 passed probably by chance, since the error was really in the testing environment itself.