### PR TITLE
fix: include serialization listeners when serving/running from CLI

### DIFF
--- a/projects/fal/src/fal/_serialization.py
+++ b/projects/fal/src/fal/_serialization.py
@@ -50,6 +50,16 @@ def by_value_locator(obj, pickler=None, og_locator=_dill._locate_function):
 _dill._locate_function = by_value_locator
 
 
+def include_packages_from_path(raw_path: str):
+    path = Path(raw_path)
+    parent = path
+    while (parent.parent / "__init__.py").exists():
+        parent = parent.parent
+
+    if parent != path:
+        _PACKAGES.add(parent.name)
+
+
 def add_serialization_listeners_for(obj):
     module_name = getattr(obj, "__module__", None)
     if not module_name:
@@ -61,13 +71,7 @@ def add_serialization_listeners_for(obj):
         # tree to locate the actual package name.
         import __main__
 
-        path = Path(__main__.__file__)
-        parent = path
-        while (parent.parent / "__init__.py").exists():
-            parent = parent.parent
-
-        if parent != path:
-            _PACKAGES.add(parent.name)
+        include_packages_from_path(__main__.__file__)
 
     if "." in module_name:
         package_name, *_ = module_name.partition(".")

--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import click
 import fal.auth as auth
 import fal
-from fal import api, sdk
+from fal import api, sdk, _serialization
 from fal.console import console
 from fal.exceptions import ApplicationExceptionHandler
 from fal.logging import get_logger, set_debug_logging
@@ -245,6 +245,10 @@ def load_function_from(
     module = runpy.run_path(file_path)
     if function_name not in module:
         raise api.FalServerlessError(f"Function '{function_name}' not found in module")
+
+    # The module for the function is set to <run_path> when runpy is used, in which
+    # case we want to manually include the packages it is defined in.
+    _serialization.include_packages_from_path(file_path)
 
     target = module[function_name]
     if isinstance(target, type) and issubclass(target, fal.App):


### PR DESCRIPTION
stuff that works with `python t.py` doesn't work when we do `fal fn run` / `fal fn serve` because the path handlers need to be manually updated.