### PR TITLE
feat: add dynamic batching to realtime SDK

### DIFF
--- a/projects/fal/src/fal/apps.py
+++ b/projects/fal/src/fal/apps.py
@@ -160,13 +160,21 @@ class _RealtimeConnection:
     _ws: Any
 
     def run(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Run an inference task on the app and return the result."""
+        self.send(arguments)
+        return self.recv()
+
+    def send(self, arguments: dict[str, Any]) -> None:
         import msgpack
 
-        """Run an inference task on the app and return the result."""
-
+        """Send an inference task to the app."""
         payload = msgpack.packb(arguments)
-
         self._ws.send(payload)
+
+    def recv(self) -> dict[str, Any]:
+        import msgpack
+
+        """Receive the result of an inference task."""
         while True:
             response = self._ws.recv()
             if isinstance(response, str):
@@ -175,7 +183,6 @@ class _RealtimeConnection:
                 if json_payload.get("type") == "x-fal-error":
                     raise ValueError(json_payload["reason"])
                 continue
-
             return msgpack.unpackb(response)
 
 


### PR DESCRIPTION
Dynamic batching allows us to utilize the GPU in its full capacity when we already have the inputs lined up and we know it can be combined, which boosts the total throughput by up to 1.5x-2x depending on the models (e.g. for sd-turbo at 1 step, `dynamic_batching=4` enables per image latency to go from 40ms to 25ms).

## Example 

Programatic hinting of batch sizes:

```py
class ImageToImageInput(BaseModel):
    prompt: ...
    negative_prompt: ...

    def can_batch(self, other: ImageToImageInput) -> bool:
        # If the inputs are the same in all properties except for the image_url/image_bytes
        # then we can batch them together to optimize the inference.
        return (
            self.prompt == other.prompt
            and self.negative_prompt == other.negative_prompt
            and self.image_size == other.image_size
            [...]
            and self.loras == other.loras
            and self.model_name == other.model_name
        )
 ```
 
 Handling in the inference functions
 
 ```py
 class ImageToImage(fal.App): 
    @fal.realtime("/realtime/image-to-image", buffering=4, session_timeout=2, max_batch_size=4)
    def realtime_image_to_image(
        self,
        input: ImageToImageInput,
        *inputs: ImageToImageInput,
    ) -> RealtimeOutput:
        from PIL import Image

        input_images = []
        for target in (input, *inputs):
            if target.image_bytes:
                input_img = Image.open(io.BytesIO(input.image_bytes))
            else:
                input_img = read_image_from_url(input.image_url)

            input_images.append(input_img)

        with timed() as timings:
            output = self.runtime.image_to_image(input, input_images=input_images)

        return RealtimeOutput(
            images=[RawImage.from_pil(image) for image in output.images],
            timings={
                "inference": timings.took,
            },
            seed=output.seed,
        )
```


 