### PR TITLE
feat: add CLI/proto bindings for rolling out deployments

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -349,6 +349,7 @@ class FalServerlessHost(Host):
         application_name: str | None = None,
         application_auth_mode: Literal["public", "shared", "private"] | None = None,
         metadata: dict[str, Any] | None = None,
+        do_rollout: bool = False,
     ) -> str | None:
         environment_options = options.environment.copy()
         environment_options.setdefault("python_version", active_python())
@@ -401,6 +402,7 @@ class FalServerlessHost(Host):
             application_auth_mode=application_auth_mode,
             machine_requirements=machine_requirements,
             metadata=metadata,
+            do_rollout=do_rollout,
         ):
             for log in partial_result.logs:
                 self._log_printer.print(log)

--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -265,6 +265,7 @@ def load_function_from(
     type=click.Choice(ALIAS_AUTH_OPTIONS),
     default="private",
 )
+@click.option("-R", "--rollout", is_flag=True)
 @click.argument("file_path", required=True)
 @click.argument("function_name", required=True)
 @click.pass_obj
@@ -274,6 +275,7 @@ def register_application(
     function_name: str,
     alias: str | None,
     auth_mode: ALIAS_AUTH_TYPE,
+    rollout: bool,
 ):
     user_id = _get_user_id()
 
@@ -297,6 +299,7 @@ def register_application(
         application_name=alias,
         application_auth_mode=auth_mode,
         metadata=isolated_function.options.host.get("metadata", {}),
+        do_rollout=rollout,
     )
 
     if id:

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -429,6 +429,7 @@ class FalServerlessConnection:
         serialization_method: str = _DEFAULT_SERIALIZATION_METHOD,
         machine_requirements: MachineRequirements | None = None,
         metadata: dict[str, Any] | None = None,
+        do_rollout: bool = False,
     ) -> Iterator[isolate_proto.RegisterApplicationResult]:
         wrapped_function = to_serialized_object(function, serialization_method)
         if machine_requirements:
@@ -467,6 +468,7 @@ class FalServerlessConnection:
             application_name=application_name,
             auth_mode=auth_mode,
             metadata=struct_metadata,
+            do_rollout=do_rollout,
         )
         for partial_result in self.stub.RegisterApplication(request):
             yield from_grpc(partial_result)

--- a/projects/isolate_proto/src/isolate_proto/controller.proto
+++ b/projects/isolate_proto/src/isolate_proto/controller.proto
@@ -174,6 +174,9 @@ message RegisterApplicationRequest {
     optional int32 max_concurrency = 7 [deprecated = true];
     // metadata to store with the application
     optional google.protobuf.Struct metadata = 8;
+    // Whether to deploy immediately or do a rolling update with waiting at
+    // min_concurrency replicas from the new revision to be ready.
+    optional bool do_rollout = 9;
 }
 
 message RegisterApplicationResultType {


### PR DESCRIPTION
```
$ fal fn serve registry/image/fast_sdxl/exports.py FastSDXL --alias fast-sdxl --auth shared --rollout
[deploys a revision]
[blocks till at least min_concurrency replicas are available]
[changes alias to point the new revision]
```
