### PR TITLE
feat: add leeway to id_token check to account for clock skew

### DIFF
--- a/projects/fal/src/fal/auth/auth0.py
+++ b/projects/fal/src/fal/auth/auth0.py
@@ -169,6 +169,7 @@ def validate_id_token(token: str):
         algorithms=AUTH0_ALGORITHMS,
         issuer=AUTH0_ISSUER,
         audience=AUTH0_CLIENT_ID,
+        leeway=60,  # 1 minute, to account for clock skew
         options={
             "verify_signature": True,
             "verify_exp": True,
@@ -180,12 +181,11 @@ def validate_id_token(token: str):
 
 
 def verify_access_token_expiration(token: str):
-    from datetime import timedelta
-
     from jwt import decode
 
+    leeway = 60 * 30 * 60  # 30 minutes
     decode(
         token,
-        leeway=timedelta(minutes=-30),  # Mark as expired some time before it expires
+        leeway=-leeway,  # negative to consider expired before actual expiration
         options={"verify_exp": True, "verify_signature": False},
     )


### PR DESCRIPTION
It seems sometimes `iat` (issued at) value from auth0 id token has a slightly-later value than it should, so we are adding some leeway to let those pass. 