### PR TITLE
feat(cli): add ability to use --debug on all levels

### DIFF
--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -123,7 +123,10 @@ class AliasCommand(click.Command):
         return self._wrapped.__getattribute__(__name)
 
 
-@click.group(cls=MainGroup)
+@click.group(
+    cls=MainGroup,
+    context_settings={"allow_interspersed_args": True},
+)
 @click.option(
     "--debug", is_flag=True, help="Enable detailed errors and verbose logging."
 )


### PR DESCRIPTION
Currently if you want to use `--debug`, you have to specify it right after `fal` and any other place will result in an error, e.g.

```
$ fal function serve ... --debug
No such option: --debug
```

This PR allows it to be used with any subcommand.