### PR TITLE
ci: don't clone github.com/fal-ai/fal

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          git clone --depth 1 https://github.com/fal-ai/fal
           pip install -e projects/fal
           pip install pytest pytest-asyncio pillow
 


### PR DESCRIPTION
We already checked out our current branch in a previos step, so there is no reason to clone this again, especially since the new cloned dir is not used anyway.

Also made that checkout(fetch) step use a shallow clone.