### PR TITLE
ci: run integration tests on main and schedule

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,12 +1,22 @@
 name: Run Integration Tests
 
 on:
+  push:
+    branches: [main]
+
   pull_request:
     types: [assigned, opened, synchronize, reopened]
     paths-ignore:
       - "README.md"
-  
+
+  schedule:
+    - cron: '30 5 * * *' # every day at 5:30 UTC
+
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   run:


### PR DESCRIPTION
Right now we only run tests on PRs, but it is useful to also run them on main and on schedule, so internal and external contributors could have a frame of reference for their changes and general health of the project (e.g. some 3rd party dependency updated and broke something or our service broke over the weekend/night etc).

Note that at any given moment there will only be 1 worker running integration tests for commits from main, so we shouldn't waste much resources even during fast merge pace.