### PR TITLE
Revert "feat(cli): add ability to use --debug on all levels (#118)"

### DIFF
--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -123,10 +123,7 @@ class AliasCommand(click.Command):
         return self._wrapped.__getattribute__(__name)
 
 
-@click.group(
-    cls=MainGroup,
-    context_settings={"allow_interspersed_args": True},
-)
+@click.group(cls=MainGroup)
 @click.option(
     "--debug", is_flag=True, help="Enable detailed errors and verbose logging."
 )


### PR DESCRIPTION
This reverts commit 72cd669dc0b10d744d8f0014506eb42cf874ea78.

```
fal fn serve file.py App --alias some-alias
Usage: fal [OPTIONS] COMMAND [ARGS]...
Try 'fal --help' for help.

Error: No such option: --alias
(fal) 
```