### PR TITLE
fix(cli): don't try to print typical cli/click exceptions

### DIFF
--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -54,6 +54,8 @@ class MainGroup(click.Group):
     _tracer = get_tracer(__name__)
 
     def invoke(self, ctx):
+        from click.exceptions import Abort, ClickException, Exit
+
         execution_info = ExecutionInfo(debug=ctx.params["debug"])
         qualified_name = " ".join([ctx.info_name] + argv[1:])
         invocation_id = execution_info.invocation_id
@@ -68,6 +70,9 @@ class MainGroup(click.Group):
                     command=qualified_name,
                 )
                 return super().invoke(ctx)
+            except (EOFError, KeyboardInterrupt, ClickException, Exit, Abort):
+                # let click's main handle these
+                raise
             except Exception as exception:
                 logger.error(exception)
                 if execution_info.debug:


### PR DESCRIPTION
For example, when you don't specify a subcommand you get a `0` printed, which is coming from a click's `Exit` exception:

```
$ fal auth
Usage: fal auth [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  login
  logout
0
```