### PR TITLE
fix(auth): fix typo in token expiration leeway

### DIFF
--- a/projects/fal/src/fal/auth/auth0.py
+++ b/projects/fal/src/fal/auth/auth0.py
@@ -183,7 +183,7 @@ def validate_id_token(token: str):
 def verify_access_token_expiration(token: str):
     from jwt import decode
 
-    leeway = 60 * 30 * 60  # 30 minutes
+    leeway = 30 * 60  # 30 minutes
     decode(
         token,
         leeway=-leeway,  # negative to consider expired before actual expiration


### PR DESCRIPTION
I noticed that all my commands were super slow (like `fal auth` that should just error-out was taking 6 seconds to run) and upon investigation saw that my `access_token` was always considered expired. It turned out that it was just a typo that made a leeway be 1800 minutes instead of 30 minutes like comment suggests.