### PR TITLE
fix(cli): use conventional __main__.py

### DIFF
--- a/projects/fal/src/fal/__main__.py
+++ b/projects/fal/src/fal/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -583,7 +583,3 @@ def _get_user_id() -> str:
         return user_id
     except Exception as e:
         raise api.FalServerlessError(f"Could not parse the user data: {e}")
-
-
-if __name__ == "__main__":
-    cli()


### PR DESCRIPTION
This allows people to run fal like so `python -m fal`. I don't think anyone was using `python -m fal.cli`, but have to clarify that this patch makes it no longer work, which could be considered a breaking change.

Also it is common for people to expect a `__main__.py` to be present, so this should be useful for anyone lurking around.