### PR TITLE
fix(deps): install pyjwt[crypto] for auth to work out-of-box

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -42,7 +42,7 @@ importlib-metadata = { version = ">=4.4", python = "<3.10" }
 msgpack = "^1.0.7"
 websockets = "^12.0"
 pillow = "^10.2.0"
-pyjwt = "^2.8.0"
+pyjwt = { version = "^2.8.0", extras = ["crypto"] }
 
 [tool.poetry.group.dev.dependencies]
 openapi-python-client = "^0.14.1"


### PR DESCRIPTION
Currently if you install fal in a fresh environment, `fal auth login` will work, but you'll get a message from pyjwt:

```
$ fal auth login

Open browser automatically ('no' to show URL)? [Y/n]: y
✓ Authenticated successfully, welcome!
The JWK Set did not contain any usable keys. Perhaps 'cryptography' is not installed?
```

and any other fal commands after that will tell you that you are not authenticated. This is because of a missing `[crypto]` extra.