### PR TITLE
fix(auth): show device code in the CLI

### DIFF
--- a/projects/fal/src/fal/auth/auth0.py
+++ b/projects/fal/src/fal/auth/auth0.py
@@ -76,6 +76,8 @@ def login() -> dict:
         "client_id": AUTH0_CLIENT_ID,
     }
 
+    console.print(f"\nYour device code is {device_user_code}\n", style="bold")
+
     with console.status("Waiting for confirmation...") as status:
         while True:
             token_response = httpx.post(


### PR DESCRIPTION
The web page shows me the code and tells me to check it with what I see in CLI, while we don't actually show it in CLI.

<img width="397" alt="Screenshot 2024-03-21 at 00 00 26" src="https://github.com/fal-ai/fal/assets/5367102/65151fa2-c726-4efb-8dba-c1533b3a56d6">
