### PR TITLE
fix(auth): always try to open browser but also show url and code

### DIFF
--- a/projects/fal/src/fal/auth/auth0.py
+++ b/projects/fal/src/fal/auth/auth0.py
@@ -9,7 +9,7 @@ import httpx
 
 from fal.console import console
 from fal.console.icons import CHECK_ICON
-from fal.console.ux import get_browser
+from fal.console.ux import maybe_open_browser_tab
 
 WEBSITE_URL = "https://fal.ai"
 
@@ -27,19 +27,17 @@ def logout_url(return_url: str):
 
 
 def _open_browser(url: str, code: str | None) -> None:
-    browser = get_browser()
-    console.print()
+    maybe_open_browser_tab(url)
 
-    if browser is not None and click.confirm(
-        "Open browser automatically ('no' to show URL)?", default=True, err=True
-    ):
-        browser.open_new_tab(url)
-    else:
-        console.print(f"On your computer or mobile device navigate to: {url}")
-        if code:
-            console.print(
-                f"Confirm it shows the following code: [markdown.code]{code}[/]"
-            )
+    console.print(
+        "If browser didn't open automatically, on your computer or mobile device navigate to"
+    )
+    console.print(url)
+
+    if code:
+        console.print(
+            f"\nConfirm it shows the following code: [markdown.code]{code}[/]\n"
+        )
 
 
 def login() -> dict:

--- a/projects/fal/src/fal/console/ux.py
+++ b/projects/fal/src/fal/console/ux.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import webbrowser
 
 
-def get_browser() -> webbrowser.BaseBrowser | None:
-    """Gets a reference to the default browser, if available.
-
-    This allows us to decide on a flow before showing the actual browser window.
-    It also avoids unwanted output in the console from the standard `webbrowser.open()`.
-
-    See https://stackoverflow.com/a/19199794
-    """
+def maybe_open_browser_tab(url) -> None:
     try:
-        return webbrowser.get()
+        # Avoids unwanted output in the console from the standard `webbrowser.open()`.
+        # See https://stackoverflow.com/a/19199794
+        browser = webbrowser.get()
+
+        browser.open_new_tab(url)
     except webbrowser.Error:
-        return None
+        pass


### PR DESCRIPTION
The prompt is unnecessary, we should just try opening a browser automatically.

Currently the URL tells me to check the code in CLI, which is not shown to me if `webbrowser.get()` was able to find a browser. Also then `open_new_tab` is not really guaranteed to work, so we are better off just always showing the URL as well.

<img width="925" alt="Screenshot 2024-03-21 at 01 25 41" src="https://github.com/fal-ai/fal/assets/5367102/cfee5506-6e00-464c-8e85-2af79d9e57fa">


Also it is obvious that the url is a bit too long to comfortably transfer to another device by hand, but I do understand that it is a temporary technical limitation. Just trying to make things clearer from cli side as much as possible.