### PR TITLE
feat(api): improve handling of user exceptions

### DIFF
--- a/projects/fal/src/fal/cli.py
+++ b/projects/fal/src/fal/cli.py
@@ -348,6 +348,8 @@ def register_application(
 @click.pass_obj
 def run(host: api.FalServerlessHost, file_path: str, function_name: str):
     isolated_function = load_function_from(host, file_path, function_name)
+    # let our exc handlers handle UserFunctionException
+    isolated_function.reraise = False
     isolated_function()
 
 

--- a/projects/fal/src/fal/exceptions/__init__.py
+++ b/projects/fal/src/fal/exceptions/__init__.py
@@ -4,6 +4,7 @@ from .handlers import (
     BaseExceptionHandler,
     FalServerlessExceptionHandler,
     GrpcExceptionHandler,
+    UserFunctionExceptionHandler,
 )
 
 
@@ -20,6 +21,7 @@ class ApplicationExceptionHandler:
     _handlers: list[BaseExceptionHandler] = [
         GrpcExceptionHandler(),
         FalServerlessExceptionHandler(),
+        UserFunctionExceptionHandler(),
     ]
 
     def handle(self, exception):


### PR DESCRIPTION
This patch adds support for chained exceptions and utilizes those to provide a more seamless experience for both cli and api users by providing them with original exceptions and their tracebacks.

This likely makes isolate's `stringized_traceback` obsolete.

For example:
```python
import fal


class FooException(Exception):
    pass

class BarException(Exception):
    pass

def bar():
    raise BarException("bar")

def foo():
    try:
        bar()
    except Exception as exc:
        raise FooException("foo") from exc

@fal.function()
def mytest():
    foo()
    print(str(2*2))

if __name__ == "__main__":
    mytest()
```

running it through API we now we'll get (note that not only traceback is present but also `__cause__` is correctly set):

```
Traceback (most recent call last):
  File "/Users/efiop/git/efiop/ui-comp/fal/exc_chain.py", line 15, in foo
    bar()
  ^^^^^^^^
  File "/Users/efiop/git/efiop/ui-comp/fal/exc_chain.py", line 11, in bar
    raise BarException("bar")
      ^^^^^^^^^^^^^^^^^
BarException: bar

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/efiop/git/efiop/ui-comp/fal/exc_chain.py", line 25, in <module>
    mytest()
  File "/Users/efiop/git/efiop/fal/projects/fal/src/fal/api.py", line 978, in __call__
    raise cause
  File "/Users/efiop/git/efiop/ui-comp/fal/exc_chain.py", line 21, in mytest
    foo()
      ^^^^
  File "/Users/efiop/git/efiop/ui-comp/fal/exc_chain.py", line 17, in foo
    raise FooException("foo") from exc
  ^^^^^^^^^^^^^^^^^
FooException: foo
```

and with `fal fn run` (no `--debug`) we'll get

<img width="410" alt="Screenshot 2024-03-27 at 17 25 11" src="https://github.com/fal-ai/fal/assets/5367102/86d98250-99b9-450e-a509-9812745b627e">

NOTE: we now support chained exceptions, but their classes are recreated because we `dill` everything by value and not by reference. This is better than before, but not perfect yet. See #142


