### PR TITLE
fix(api): use same logger for LocalHost

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -246,6 +246,7 @@ class LocalHost(Host):
         "virtualenv",
         requirements=[f"dill=={dill.__version__}", f"tblib=={tblib.__version__}"],
     )
+    _log_printer = IsolateLogPrinter(debug=flags.DEBUG)
 
     def run(
         self,
@@ -254,7 +255,7 @@ class LocalHost(Host):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> ReturnT:
-        settings = replace(DEFAULT_SETTINGS, serialization_method="dill")
+        settings = replace(DEFAULT_SETTINGS, serialization_method="dill", log_hook=self._log_printer.print)
         environment = isolate.prepare_environment(
             **options.environment,
             context=settings,

--- a/projects/fal/src/fal/logging/isolate.py
+++ b/projects/fal/src/fal/logging/isolate.py
@@ -44,21 +44,3 @@ class IsolateLogPrinter:
         # Use structlog processors to get consistent output with local logs
         message = _renderer.__call__(logger={}, name=level, event_dict=event)
         print(message)
-
-    def print_dict(self, log: dict):
-        level = LogLevel[log["level"]]
-        if level < LogLevel.INFO and not self.debug:
-            return
-        if "timestamp" in log.keys():
-            timestamp = log["timestamp"]
-        else:
-            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
-
-        event: EventDict = {
-            "event": log["message"],
-            "level": log["level"],
-            "timestamp": timestamp[:-3],
-        }
-
-        message = _renderer.__call__(logger={}, name=log["level"], event_dict=event)
-        print(message)


### PR DESCRIPTION
Provides consistent output between remote and local hosts.

Before:

<img width="1092" alt="Screenshot 2024-04-03 at 02 16 22" src="https://github.com/fal-ai/fal/assets/5367102/8a28d4a1-81c7-4218-b927-d9434d1221b2">

After:
<img width="744" alt="Screenshot 2024-04-03 at 02 17 09" src="https://github.com/fal-ai/fal/assets/5367102/386413e5-3945-4d24-9989-30a53ff19ae5">

which is consistent with remote.

Pre-requisite for next steps in cli's ux.
