### PR TITLE
fix(ux): print user messages as is

### DIFF
--- a/projects/fal/src/fal/logging/isolate.py
+++ b/projects/fal/src/fal/logging/isolate.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
 
-from isolate.logs import Log, LogLevel
+from isolate.logs import Log, LogLevel, LogSource
 from structlog.dev import ConsoleRenderer
 from structlog.typing import EventDict
 
@@ -21,6 +22,12 @@ class IsolateLogPrinter:
     def print(self, log: Log):
         if log.level < LogLevel.INFO and not self.debug:
             return
+
+        if log.source == LogSource.USER:
+            stream = sys.stderr if log.level == LogLevel.STDERR else sys.stdout
+            print(log.message, file=stream)
+            return
+
         level = str(log.level)
 
         if hasattr(log, "timestamp"):


### PR DESCRIPTION
It is unexpected that we print all of them to stdout and also prepend a bunch of logging information. This should be seamless for the user most of the time.

Before:
<img width="758" alt="Screenshot 2024-04-03 at 18 58 49" src="https://github.com/fal-ai/fal/assets/5367102/ddc4377a-fa59-408f-b5de-0a82298ebdc4">

After:
<img width="501" alt="Screenshot 2024-04-03 at 18 59 14" src="https://github.com/fal-ai/fal/assets/5367102/43521cd7-90f2-4c29-8b62-7b53726066b6">

Same for `fal fn run`.
