### PR TITLE
chore: try using pytest-xdist and XS machines to speedup tests

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -36,11 +36,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e projects/fal
-          pip install pytest pytest-asyncio pillow
+          pip install pytest pytest-asyncio pytest-xdist pillow
 
       - name: Run integration tests
         env:
           FAL_KEY: ${{ secrets.FAL_CLOUD_KEY_ID }}:${{ secrets.FAL_CLOUD_KEY_SECRET }}
           FAL_HOST: api.${{ vars.FAL_CLOUD_INTEGRATION_TEST_HOST }}
         run: |
-          pytest -v projects/fal/tests
+          pytest -n auto -v projects/fal/tests

--- a/projects/fal/src/fal/_serialization.py
+++ b/projects/fal/src/fal/_serialization.py
@@ -164,6 +164,24 @@ def patch_exceptions():
 
 
 @mainify
+def _patch_console_thread_locals() -> None:
+    from rich.console import ConsoleThreadLocals
+
+    @dill.register(ConsoleThreadLocals)
+    def save_console_thread_locals(pickler, obj):
+        args = {
+            "theme_stack": obj.theme_stack,
+            "buffer": obj.buffer,
+            "buffer_index": obj.buffer_index,
+        }
+
+        def unpickle(kwargs):
+            return ConsoleThreadLocals(**kwargs)
+
+        pickler.save_reduce(unpickle, (args,), obj=obj)
+
+
+@mainify
 def patch_dill():
     import dill
 
@@ -172,6 +190,7 @@ def patch_dill():
     patch_exceptions()
     patch_pydantic_class_attributes()
     patch_pydantic_field_serialization()
+    _patch_console_thread_locals()
 
 
 @mainify

--- a/projects/fal/src/fal/_serialization.py
+++ b/projects/fal/src/fal/_serialization.py
@@ -165,6 +165,7 @@ def patch_exceptions():
 
 @mainify
 def _patch_console_thread_locals() -> None:
+    # NOTE: we __sometimes__ might have to serialize these
     from rich.console import ConsoleThreadLocals
 
     @dill.register(ConsoleThreadLocals)

--- a/projects/fal/tests/conftest.py
+++ b/projects/fal/tests/conftest.py
@@ -9,4 +9,4 @@ from fal import function
 
 @pytest.fixture(scope="function")
 def isolated_client():
-    return partial(function, machine_type="M", keep_alive=0)
+    return partial(function, machine_type="XS", keep_alive=0)

--- a/projects/fal/tests/integration_test.py
+++ b/projects/fal/tests/integration_test.py
@@ -15,6 +15,7 @@ from fal.toolkit.file.file import CompressedFile
 from fal.toolkit.utils.download_utils import _get_git_revision_hash, _hash_url
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_isolated(isolated_client):
     @isolated_client("virtualenv", requirements=["pyjokes==0.5.0"])
     def get_pyjokes_version():


### PR DESCRIPTION
Our tests use network a lot, so it makes sense to run them in parallel. E.g. now down to 5 minutes from seeing stuff as much as 29 minutes.