### PR TITLE
fix(toolkit): use hidden bytes/str Field instead of PrivateAttr with custom types

### DIFF
--- a/projects/fal/src/fal/toolkit/image/image.py
+++ b/projects/fal/src/fal/toolkit/image/image.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal, Union, Optional
 from pydantic import BaseModel, Field
 
 from fal.toolkit.file.file import DEFAULT_REPOSITORY, File
-from fal.toolkit.file.types import FileData, FileRepository, RepositoryId
+from fal.toolkit.file.types import FileRepository, RepositoryId
 from fal.toolkit.utils.download_utils import _download_file_python
 
 if TYPE_CHECKING:
@@ -78,15 +78,15 @@ class Image(File):
         file_name: str | None = None,
         repository: FileRepository | RepositoryId = DEFAULT_REPOSITORY,
     ) -> Image:
-        file_data = FileData(
-            data=data, content_type=f"image/{format}", file_name=file_name
-        )
-        return cls(
-            file_data=file_data,
+        obj = super().from_bytes(
+            data,
+            content_type=f"image/{format}",
+            file_name=file_name,
             repository=repository,
-            width=size.width if size else None,
-            height=size.height if size else None,
         )
+        obj.width=size.width if size else None
+        obj.height=size.height if size else None
+        return obj
 
     @classmethod
     def from_pil(


### PR DESCRIPTION
On pydantic v1 (v2 seems to work fine), `PrivateAttr`s initialization is pretty intricate and our pickling (not us but cloudpickle) in an unclear way seems to be messing with the order of attribute setting and results in private attrs finding their way into `__dict__` of the model and so into its `dict()` as well, even though they are also in `__private_attributes__`. I dug around, but I think in interest of time we are better off not using them for now. General feeling is that `PrivateAttr`s are not too common (we don't use it anywhere else in the whole org) and, esp in v1, are pretty fragile/buggy (https://github.com/pydantic/pydantic/issues/7142, https://github.com/pydantic/pydantic/discussions/3480).

We kinda made this work before https://github.com/fal-ai/fal/pull/155/files#diff-455e7b832e183d2693a3af34285fdc92b599e8836ff14c4acb47af78e56e2cacR85 by setting the `_file_data` before `super().__init__` but that was probably an accident.