### PR TITLE
fix(api): specify pydantic version in SERVE_REQUIREMENTS

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -38,6 +38,7 @@ from isolate.backends.settings import DEFAULT_SETTINGS
 from isolate.connections import PythonIPC
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
+from pydantic import __version__ as pydantic_version
 from typing_extensions import Concatenate, ParamSpec
 
 import fal.flags as flags
@@ -62,7 +63,12 @@ ReturnT = TypeVar("ReturnT", covariant=True)
 BasicConfig = Dict[str, Any]
 _UNSET = object()
 
-SERVE_REQUIREMENTS = [f"fastapi=={fastapi_version}", "uvicorn", "starlette_exporter"]
+SERVE_REQUIREMENTS = [
+    f"fastapi=={fastapi_version}",
+    f"pydantic=={pydantic_version}",
+    "uvicorn",
+    "starlette_exporter",
+]
 
 
 @dataclass

--- a/projects/fal/tests/test_apps.py
+++ b/projects/fal/tests/test_apps.py
@@ -91,7 +91,6 @@ def calculator_app():
 
 class StatefulAdditionApp(fal.App, keep_alive=300, max_concurrency=1):
     machine_type = "S"
-    requirements = [f"pydantic=={pydantic_version}"]
 
     async def setup(self):
         self.counter = 0
@@ -133,7 +132,6 @@ class RTOutputs(BaseModel):
 
 class RealtimeApp(fal.App, keep_alive=300, max_concurrency=1):
     machine_type = "S"
-    requirements = [f"pydantic=={pydantic_version}"]
 
     @fal.endpoint("/")
     def generate(self, input: RTInput) -> RTOutput:


### PR DESCRIPTION
Since fastapi could work with any pydantic version, we are better off being more specific.

Followup for https://github.com/fal-ai/fal/pull/167