### PR TITLE
chore(gha): use OICD for pypi releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     - published
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.parse.outputs.version }}
@@ -31,22 +31,40 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install deps
-        run: python -m pip install --upgrade pip setuptools_scm build twine
+        run: python -m pip install --upgrade pip setuptools_scm build
 
       - name: Build
-        working_directory: projects/${{ steps.parse.outputs.name }}
+        working-directory: projects/${{ steps.parse.outputs.name }}
         run: python -m build
 
-      - name: Publish PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        working-directory: projects/${{ steps.parse.outputs.name }}
-        run: twine upload dist/*
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ needs.build.outputs.name }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   release-container:
-    if: ${{ needs.release.outputs.name == "fal" }}
+    if: ${{ needs.build.outputs.name == "fal" }}
     uses: ./.github/workflows/container.yml
-    needs: release
+    needs: build
     with:
-      version: ${{ needs.release.outputs.version }}
+      version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
Allows us to not use tokens/secrets at all.

See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi