### PR TITLE
fix(fal): show cause in cli

### DIFF
--- a/projects/fal/src/fal/exceptions/handlers.py
+++ b/projects/fal/src/fal/exceptions/handlers.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 from ._base import FalServerlessException
 
-ExceptionType = TypeVar("ExceptionType")
+ExceptionType = TypeVar("ExceptionType", bound=BaseException)
 
 
 class BaseExceptionHandler(Generic[ExceptionType]):
@@ -23,7 +23,11 @@ class BaseExceptionHandler(Generic[ExceptionType]):
         return True
 
     def handle(self, exception: ExceptionType):
-        console.print(str(exception))
+        cause = exception.__cause__
+        if cause is None:
+            console.print(str(exception))
+        else:
+            console.print(f"{str(exception)}: {str(cause)}")
 
 
 class FalServerlessExceptionHandler(BaseExceptionHandler[FalServerlessException]):


### PR DESCRIPTION
E.g. previously one would get

```
Error while serializing the given object
```

and now

```
Error while serializing the given object: Can't pickle <cyfunction ConstrainedList.list_length_validator at 0x110f544b0>: it's not the
same object as pydantic.types.ConstrainedList.list_length_validator
```

which is much more useful (obviously pickle errors are still obscure as hell, but that's a different topic).