### PR TITLE
fix(fal): inherit all exceptions from FalServerlessException

### DIFF
--- a/projects/fal/src/fal/exceptions/__init__.py
+++ b/projects/fal/src/fal/exceptions/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from ._base import FalServerlessException  # noqa: F401
 from .handlers import (
     BaseExceptionHandler,
-    FalServerlessExceptionHandler,
     GrpcExceptionHandler,
     UserFunctionExceptionHandler,
 )
@@ -20,7 +20,6 @@ class ApplicationExceptionHandler:
 
     _handlers: list[BaseExceptionHandler] = [
         GrpcExceptionHandler(),
-        FalServerlessExceptionHandler(),
         UserFunctionExceptionHandler(),
     ]
 

--- a/projects/fal/src/fal/exceptions/_base.py
+++ b/projects/fal/src/fal/exceptions/_base.py
@@ -3,15 +3,4 @@ from __future__ import annotations
 
 class FalServerlessException(Exception):
     """Base exception type for fal Serverless related flows and APIs."""
-
-    message: str
-
-    hint: str | None
-
-    def __init__(self, message: str, hint: str | None = None) -> None:
-        self.message = message
-        self.hint = hint
-        super().__init__(message)
-
-    def __str__(self) -> str:
-        return self.message + (f"\nHint: {self.hint}" if self.hint else "")
+    pass

--- a/projects/fal/src/fal/exceptions/auth.py
+++ b/projects/fal/src/fal/exceptions/auth.py
@@ -4,10 +4,8 @@ from ._base import FalServerlessException
 
 
 class UnauthenticatedException(FalServerlessException):
-    """Exception that indicates that"""
-
     def __init__(self) -> None:
         super().__init__(
-            message="You must be authenticated.",
-            hint="Login via `fal auth login` or make sure to setup fal keys correctly.",
+            "You must be authenticated. "
+            "Login via `fal auth login` or make sure to setup fal keys correctly."
         )

--- a/projects/fal/src/fal/exceptions/handlers.py
+++ b/projects/fal/src/fal/exceptions/handlers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from grpc import Call as RpcCall
-from rich.markdown import Markdown
 
 from fal.console import console
 from fal.console.icons import CROSS_ICON
@@ -11,7 +10,6 @@ from fal.console.icons import CROSS_ICON
 if TYPE_CHECKING:
     from fal.api import UserFunctionException
 
-from ._base import FalServerlessException
 
 ExceptionType = TypeVar("ExceptionType", bound=BaseException)
 
@@ -23,24 +21,11 @@ class BaseExceptionHandler(Generic[ExceptionType]):
         return True
 
     def handle(self, exception: ExceptionType):
+        msg = f"{CROSS_ICON} {str(exception)}"
         cause = exception.__cause__
-        if cause is None:
-            console.print(str(exception))
-        else:
-            console.print(f"{str(exception)}: {str(cause)}")
-
-
-class FalServerlessExceptionHandler(BaseExceptionHandler[FalServerlessException]):
-    """Handle fal Serverless exceptions"""
-
-    def should_handle(self, exception: Exception) -> bool:
-        return isinstance(exception, FalServerlessException)
-
-    def handle(self, exception: FalServerlessException):
-        console.print(f"{CROSS_ICON} {exception.message}")
-        if exception.hint is not None:
-            console.print(Markdown(f"**Hint:** {exception.hint}"))
-            console.print()
+        if cause is not None:
+            msg += f": {str(cause)}"
+        console.print(msg)
 
 
 class GrpcExceptionHandler(BaseExceptionHandler[RpcCall]):

--- a/projects/fal/src/fal/workflows.py
+++ b/projects/fal/src/fal/workflows.py
@@ -18,6 +18,7 @@ from rich.syntax import Syntax
 
 import fal
 from fal import flags
+from fal.exceptions import FalServerlessException
 from fal.rest_client import REST_CLIENT
 
 JSONType = Union[dict[str, Any], list[Any], str, int, float, bool, None, "Leaf"]
@@ -31,7 +32,7 @@ INPUT_VARIABLE_NAME = "input"
 WORKFLOW_EXPORT_VERSION = "0.1"
 
 
-class WorkflowSyntaxError(Exception):
+class WorkflowSyntaxError(FalServerlessException):
     pass
 
 


### PR DESCRIPTION
This was a little bit more involved before cloudpickle migration, as you had to put `@mainify` everywhere. Now we can comfortably do that and leverage this in error handling (e.g. see us passing through our own exceptions).