### PR TITLE
fix: use non-protected url

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -58,9 +58,9 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest",
-    "pytest-xdist",
+    "pytest<8",
     "pytest-asyncio",
+    "pytest-xdist",
     "flaky",
 ]
 dev = [

--- a/projects/fal/tests/toolkit/image_test.py
+++ b/projects/fal/tests/toolkit/image_test.py
@@ -98,7 +98,7 @@ def test_fal_image_from_bytes(isolated_client):
 @pytest.mark.parametrize(
     "image_url",
     [
-        "https://storage.googleapis.com/falserverless/model_tests/remove_background/elephant.jpg",
+        "https://commons.wikimedia.org/static/images/project-logos/commonswiki-1.5x.png",
         image_to_data_uri(get_image()),
     ],
 )


### PR DESCRIPTION
From tests it seems the storage.googleapis.com link was slow to respond some times. (I am guessing we abused it)