### PR TITLE
Revert "test: mark test_missing_dependencies xfail for SerializationError"

### DIFF
--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -13,7 +13,6 @@ from fal.toolkit.file.file import File
 PACKAGE_NAME = "fal"
 
 
-@pytest.mark.xfail(reason="We need to fix the SerializationError")
 def test_missing_dependencies_nested_server_error(isolated_client):
     @isolated_client()
     def test1():


### PR DESCRIPTION
Reverts fal-ai/fal#193

With https://github.com/fal-ai/isolate-cloud/pull/1689 merged and deployed, we can remove xfail.