### PR TITLE
feat(App): introduce /health endpoint

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -832,6 +832,9 @@ class BaseServable:
         """
         pass
 
+    def _add_extra_routes(self, app: FastAPI):
+        pass
+
     @asynccontextmanager
     async def lifespan(self, app: FastAPI):
         yield
@@ -892,6 +895,8 @@ class BaseServable:
                     name=endpoint.__name__,
                     methods=["POST"],
                 )
+
+        self._add_extra_routes(_app)
 
         return _app
 

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -120,6 +120,9 @@ class App(fal.api.BaseServable):
         finally:
             await _call_any_fn(self.teardown)
 
+    def health(self):
+        return {}
+
     def setup(self):
         """Setup the application before serving."""
 
@@ -160,6 +163,11 @@ class App(fal.api.BaseServable):
                     self.__class__.__name__,
                 )
             return response
+
+    def _add_extra_routes(self, app: FastAPI):
+        @app.get("/health")
+        def health():
+            return self.health()
 
     def provide_hints(self) -> list[str]:
         """Provide hints for routing the application."""


### PR DESCRIPTION
Introducing default `/health` endpoint that will by default return `{}` and can be extended by user-provided info using `fal.App.health()` method. This endpoint could also be used as a default endpoint to try connecting to, to know if the app is running.