### PR TITLE
chore(fal): bump grpcio/isolate/isolate_proto

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -22,9 +22,9 @@ authors = [{ name = "Features & Labels <support@fal.ai>"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "isolate[build]>=0.12.3,<1.0",
-    "isolate-proto==0.4.0",
-    "grpcio>=1.50.0,<2",
+    "isolate[build]>=0.13.0,<1.14.0",
+    "isolate-proto==0.5.1",
+    "grpcio==1.64.0",
     "dill==0.3.7",
     "cloudpickle==3.0.0",
     "typing-extensions>=4.7.1,<5",


### PR DESCRIPTION
Strictly speaking we should always generate python code with the same version of grpc that we will be using it with. Mixing and matching can cause unpredictable behaviour.

Related https://github.com/fal-ai/fal/pull/231
Related https://github.com/fal-ai/isolate/pull/139