### PR TITLE
fix(test): chore: use v2.fal.media instead of fal-cdn.fly.dev

### DIFF
--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -560,7 +560,7 @@ def test_worker_env_vars(isolated_client):
         "repo_type, url_prefix",
         [
             ("fal", "https://storage.googleapis.com/isolate-dev-smiling-shark_toolkit_bucket/"),
-            ("fal_v2", "https://fal-cdn.fly.dev/files"),
+            ("fal_v2", "https://v2.fal.media/files"),
         ]
 )
 def test_fal_storage(isolated_client, repo_type, url_prefix):


### PR DESCRIPTION
Depends on https://github.com/fal-ai/isolate-cloud/pull/1976