### PR TITLE
fix(toolkit): use random string when uploading to gcp/r2

### DIFF
--- a/projects/fal/src/fal/toolkit/file/providers/gcp.py
+++ b/projects/fal/src/fal/toolkit/file/providers/gcp.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import datetime
 import json
 import os
+import posixpath
+import uuid
 from dataclasses import dataclass
 
 from fal.toolkit.file.types import FileData, FileRepository
@@ -49,7 +51,10 @@ class GoogleStorageRepository(FileRepository):
         return self._bucket
 
     def save(self, data: FileData) -> str:
-        destination_path = os.path.join(self.folder, data.file_name)
+        destination_path = posixpath.join(
+            self.folder,
+            f"{uuid.uuid4().hex}_{data.file_name}",
+        )
 
         gcp_blob = self.bucket.blob(destination_path)
         gcp_blob.upload_from_string(data.data, content_type=data.content_type)

--- a/projects/fal/src/fal/toolkit/file/providers/r2.py
+++ b/projects/fal/src/fal/toolkit/file/providers/r2.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
+import uuid
 from dataclasses import dataclass
 from io import BytesIO
 
@@ -66,7 +68,10 @@ class R2Repository(FileRepository):
         return self._bucket
 
     def save(self, data: FileData) -> str:
-        destination_path = os.path.join(self.key, data.file_name)
+        destination_path = posixpath.join(
+            self.key,
+            f"{uuid.uuid4().hex}_{data.file_name}",
+        )
 
         s3_object = self.bucket.Object(destination_path)
         s3_object.upload_fileobj(

--- a/projects/fal/tests/toolkit/file_test.py
+++ b/projects/fal/tests/toolkit/file_test.py
@@ -4,8 +4,7 @@ import os
 from base64 import b64encode
 
 import pytest
-from fal.toolkit.file.file import BUILT_IN_REPOSITORIES, File, GoogleStorageRepository
-from fal.toolkit.file.types import FileRepository, RepositoryId
+from fal.toolkit.file.file import File, GoogleStorageRepository
 
 
 def test_binary_content_matches():
@@ -65,40 +64,3 @@ def test_gcp_storage_if_available():
     assert file.url.startswith(
         "https://storage.googleapis.com/fal_registry_image_results/"
     )
-
-
-@pytest.mark.xfail(reason="fal cdn is temporarily broken")
-@pytest.mark.parametrize(
-    "repo",
-    BUILT_IN_REPOSITORIES.keys(),
-)
-def test_uniqueness_of_file_name(repo: RepositoryId | FileRepository):
-    if repo == "in_memory":
-        return
-
-    if repo == "gcp_storage":
-        gcp_sa_json = os.environ.get("GCLOUD_SA_JSON")
-        if gcp_sa_json is None:
-            pytest.skip(reason="GCLOUD_SA_JSON environment variable is not set")
-        repo = GoogleStorageRepository(bucket_name="fal_registry_image_results")
-
-    if repo == "r2":
-        r2_account_json = os.environ.get("R2_CREDS_JSON")
-        if r2_account_json is None:
-            pytest.skip(reason="R2_CREDS_JSON environment variable is not set")
-
-    if repo == "fal":
-        fal_key = os.environ.get("FAL_KEY")
-        if fal_key is None:
-            pytest.skip(reason="FAL_KEY environment variable is not set")
-
-    file = File.from_bytes(b"print('Hello!')", repository=repo, file_name="hello.py")
-
-    host_and_path = file.url.split("?")[0]
-    last_path = host_and_path.split("/")[-1]
-    assert last_path.endswith(
-        ".py"
-    ), f"The file name {last_path} should end with the same extension"
-    assert (
-        len(last_path) > 10
-    ), f"There should be a long enough random string in the file name {last_path}"


### PR DESCRIPTION
This fixes the overlap issues in cases where you try to upload 2 files with the same name.

Note that I removed the tests introduced in #115 , because the approach here is super obvious/declarative and it is just not worth the overhead of using real storage providers and maintaining that, every test like that is making our test suit more flaky and slow, forcing us to be more sloppy.

We could add unit tests for something like `self._get_key`, but again, considering how straightforward this is - probably not worth it.

Regarding the old fal-cdn using file extension - that will come as a revival of https://github.com/fal-ai/fal-cdn/pull/4 in a separate PR (https://github.com/fal-ai/fal-cdn/pull/23)