### PR TITLE
fix(toolkit): fix race conditions in download_utils

### DIFF
--- a/projects/fal/src/fal/toolkit/utils/download_utils.py
+++ b/projects/fal/src/fal/toolkit/utils/download_utils.py
@@ -216,11 +216,13 @@ def _download_file_python(
     Returns:
         The path where the downloaded file has been saved.
     """
+    basename = os.path.basename(target_path)
     # NOTE: using the same directory to avoid potential copies across temp fs and target
     # fs, and also to be able to atomically rename a downloaded file into place.
     with NamedTemporaryFile(
         delete=False,
         dir=os.path.dirname(target_path),
+        prefix=f"{basename}.tmp",
     ) as temp_file:
         try:
             file_path = temp_file.name
@@ -411,7 +413,10 @@ def clone_repository(
     # and target fs, and also to be able to atomically rename repo_name dir into place
     # when we are done setting it up.
     os.makedirs(target_dir, exist_ok=True)  # type: ignore[arg-type]
-    with TemporaryDirectory(dir=target_dir) as temp_dir:
+    with TemporaryDirectory(
+        dir=target_dir,
+        suffix=f"{local_repo_path.name}.tmp",
+    ) as temp_dir:
         try:
             print(f"Cloning the repository '{https_url}' .")
 


### PR DESCRIPTION
Make sure our files/directories are created in a temporary location that is on the same filesystem as the target to avoid unnecessary copies across filesystems and to make it possible to (semi)atomically move them into place using `os.rename`.

I don't have good examples yet, but this might make some of our apps faster because they used to clone to tempfs but then shutil.move (which copies across fs) to a data fs. Obviously for that the apps would need to be redeployed.