### PR TITLE
feat: highlight build/prepare/run stages in remote isolate logs

### DIFF
--- a/projects/fal/src/fal/logging/isolate.py
+++ b/projects/fal/src/fal/logging/isolate.py
@@ -17,10 +17,30 @@ class IsolateLogPrinter:
 
     def __init__(self, debug: bool = False) -> None:
         self.debug = debug
+        self._current_source: LogSource | None = None
+
+    def _maybe_print_header(self, source: LogSource):
+        from fal.console import console
+
+        if source == self._current_source:
+            return
+
+        msg = {
+            LogSource.BUILDER: "Building the environment",
+            LogSource.BRIDGE: "Unpacking user code",
+            LogSource.USER: "Running",
+        }.get(source)
+
+        if msg:
+            console.print(f"==> {msg}", style="bold green")
+
+        self._current_source = source
 
     def print(self, log: Log):
         if log.level < LogLevel.INFO and not self.debug:
             return
+
+        self._maybe_print_header(log.source)
 
         if log.source == LogSource.USER:
             stream = sys.stderr if log.level == LogLevel.STDERR else sys.stdout


### PR DESCRIPTION
Some basic highlights to start with, kinda following the style of flyctl since it is so nice :)

We still hang without anything when serializing/connecting locally and some of the user logs (like the ones about compressing the env) are not ideal, but those need a bit more work, so this is just a start.

<img width="1237" alt="Screenshot 2024-07-15 at 14 45 13" src="https://github.com/user-attachments/assets/dc2bef90-ab60-4c83-9200-5491e5fe1e27">
