### PR TITLE
feat: increase keepalive timeout

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -1048,7 +1048,9 @@ class BaseServable:
         from uvicorn import Config
 
         app = self._build_app()
-        server = Server(config=Config(app, host="0.0.0.0", port=8080))
+        server = Server(
+            config=Config(app, host="0.0.0.0", port=8080, timeout_keep_alive=300)
+        )
         metrics_app = FastAPI()
         metrics_app.add_route("/metrics", handle_metrics)
         metrics_server = Server(config=Config(metrics_app, host="0.0.0.0", port=9090))


### PR DESCRIPTION
The default uvicorn keepalive timeout is 5s.
This will allow servers connecting to served fal apps to use longer
keepalives and reuse TCP connections, avoiding extra roundtrips.

Signed-off-by: squat <lserven@gmail.com>
