### PR TITLE
feat(AppClient): support timeout and print logs

### DIFF
--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import queue
 import re
+import threading
 import time
 import typing
 from contextlib import asynccontextmanager, contextmanager
@@ -85,7 +87,7 @@ class EndpointClient:
         with httpx.Client() as client:
             resp = client.post(
                 self.url + self.signature.path,
-                json=dict(data),
+                json=data.dict() if hasattr(data, "dict") else dict(data),
                 timeout=self.timeout,
             )
             resp.raise_for_status()
@@ -98,7 +100,12 @@ class EndpointClient:
 
 
 class AppClient:
-    def __init__(self, cls, url, timeout: int | None = None):
+    def __init__(
+        self,
+        cls,
+        url,
+        timeout: int | None = None,
+    ):
         self.url = url
         self.cls = cls
 
@@ -119,11 +126,25 @@ class AppClient:
     def connect(cls, app_cls):
         app = wrap_app(app_cls)
         info = app.spawn()
+        _shutdown_event = threading.Event()
+
+        def _print_logs():
+            while not _shutdown_event.is_set():
+                try:
+                    log = info.logs.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                print(log)
+
+        _log_printer = threading.Thread(target=_print_logs, daemon=True)
+        _log_printer.start()
+
         try:
             with httpx.Client() as client:
                 retries = 100
                 while retries:
                     resp = client.get(info.url + "/health")
+
                     if resp.is_success:
                         break
                     elif resp.status_code != 500:
@@ -131,9 +152,12 @@ class AppClient:
                     time.sleep(0.1)
                     retries -= 1
 
-            yield cls(app_cls, info.url)
+            client = cls(app_cls, info.url)
+            yield client
         finally:
             info.stream.cancel()
+            _shutdown_event.set()
+            _log_printer.join()
 
     def health(self):
         with httpx.Client() as client:


### PR DESCRIPTION
The logs are printed raw right now, but I'll make them comply with the normal styling a followup. This is useful as is and allows for easier testing.