### PR TITLE
feat(fal): set Content-Length when uploading data

### DIFF
--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -74,7 +74,10 @@ class FalFileRepositoryBase(FileRepository):
             upload_url,
             method="PUT",
             data=file.data,
-            headers={"Content-Type": file.content_type},
+            headers={
+                "Content-Type": file.content_type,
+                "Content-Length": str(file.content_length),
+            },
         )
 
         with urlopen(req):

--- a/projects/fal/src/fal/toolkit/file/types.py
+++ b/projects/fal/src/fal/toolkit/file/types.py
@@ -15,6 +15,7 @@ class FileData:
         self, data: bytes, content_type: str | None = None, file_name: str | None = None
     ):
         self.data = data
+        self.content_length = len(data)
         if content_type is None and file_name is not None:
             content_type, _ = guess_type(file_name or "")
 


### PR DESCRIPTION
This will help server process uploading better by streaming it instead of having to read it all into memory first. E.g. s3 PUT requires Content-Length for streaming uploads.