### PR TITLE
fix(fal): don't forget to sys.exit when running as a module

### DIFF
--- a/projects/fal/src/fal/__main__.py
+++ b/projects/fal/src/fal/__main__.py
@@ -1,4 +1,6 @@
+import sys
+
 from .cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Kudos @badayvedat for reporting this.