### PR TITLE
fix(toolkit): don't forget to set content_type

### DIFF
--- a/projects/fal/src/fal/toolkit/image/image.py
+++ b/projects/fal/src/fal/toolkit/image/image.py
@@ -132,6 +132,7 @@ class Image(File):
             size,
             file_name,
             repository,
+            content_type=f"image/{format}",
             fallback_repository=fallback_repository,
         )
 


### PR DESCRIPTION
So that we get a nice auto-generated file_name