### PR TITLE
feat(fal-file): convert the app-ref to a path relative to the project root

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fal.files import find_pyproject_toml, parse_pyproject_toml
+from fal.files import find_project_root, find_pyproject_toml, parse_pyproject_toml
 
 
 def is_app_name(app_ref: tuple[str, str | None]) -> bool:
@@ -28,6 +28,10 @@ def get_app_data_from_toml(app_name):
         app_ref = app_data["ref"]
     except KeyError:
         raise ValueError(f"App {app_name} does not have a ref key in pyproject.toml")
+
+    # Convert the app_ref to a path relative to the project root
+    project_root, _ = find_project_root(None)
+    app_ref = str(project_root / app_ref)
 
     app_auth = app_data.get("auth", "private")
 

--- a/projects/fal/tests/cli/test_deploy.py
+++ b/projects/fal/tests/cli/test_deploy.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fal.cli.deploy import _deploy
 from fal.cli.main import parse_args
+from fal.files import find_project_root
 
 
 def test_deploy():
@@ -53,9 +54,14 @@ def test_deploy_with_toml_success(
 
     _deploy(args)
 
+    project_root, _ = find_project_root(None)
+
     # Ensure the correct app is deployed
     mock_deploy_ref.assert_called_once_with(
-        ("src/my_app/inference.py", "MyApp"), "my-app", "shared", args
+        (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
+        "my-app",
+        "shared",
+        args,
     )
 
 
@@ -72,9 +78,14 @@ def test_deploy_with_toml_no_auth(
 
     _deploy(args)
 
+    project_root, _ = find_project_root(None)
+
     # Since auth is not provided for "another-app", it should default to "private"
     mock_deploy_ref.assert_called_once_with(
-        ("src/another_app/inference.py", "AnotherApp"), "another-app", "private", args
+        (f"{project_root / 'src/another_app/inference.py'}", "AnotherApp"),
+        "another-app",
+        "private",
+        args,
     )
 
 

--- a/projects/fal/tests/cli/test_run.py
+++ b/projects/fal/tests/cli/test_run.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fal.cli.main import parse_args
 from fal.cli.run import _run
+from fal.files import find_project_root
 
 
 def test_run():
@@ -60,9 +61,11 @@ def test_run_with_toml_success(
 
     _run(args)
 
-    # Ensure the correct app is deployed
+    project_root, _ = find_project_root(None)
+
+    # Ensure the correct app is ran
     mock_load_function_from.assert_called_once_with(
-        host, "src/my_app/inference.py", "MyApp"
+        host, f"{project_root / 'src/my_app/inference.py'}", "MyApp"
     )
 
 


### PR DESCRIPTION
Otherwise we would need to know in which directory the command needed to be run