### PR TITLE
feat(fal-file): add deployment strategy

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -34,5 +34,6 @@ def get_app_data_from_toml(app_name):
     app_ref = str(project_root / app_ref)
 
     app_auth = app_data.get("auth", "private")
+    app_deployment_strategy = app_data.get("deployment_strategy", "recreate")
 
-    return app_ref, app_auth
+    return app_ref, app_auth, app_deployment_strategy

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -10,7 +10,7 @@ def _run(args):
 
     if is_app_name(args.func_ref):
         app_name = args.func_ref[0]
-        app_ref, _ = get_app_data_from_toml(app_name)
+        app_ref, _, _ = get_app_data_from_toml(app_name)
         file_path, func_name = RefAction.split_ref(app_ref)
     else:
         file_path, func_name = args.func_ref


### PR DESCRIPTION
makes it possible to pass deployment strategy in the fal file, example:

```toml
[tool.fal.apps.my-app]
ref = "src/my-app/inference.py::MyApp"
auth = "private"
deployment_strategy = "rolling"
```