### PR TITLE
feat(toolkit): introduce fal_v3 repository

### DIFF
--- a/projects/fal/src/fal/toolkit/file/file.py
+++ b/projects/fal/src/fal/toolkit/file/file.py
@@ -24,6 +24,7 @@ from fal.toolkit.file.providers.fal import (
     FalCDNFileRepository,
     FalFileRepository,
     FalFileRepositoryV2,
+    FalFileRepositoryV3,
     InMemoryRepository,
 )
 from fal.toolkit.file.providers.gcp import GoogleStorageRepository
@@ -36,6 +37,7 @@ FileRepositoryFactory = Callable[[], FileRepository]
 BUILT_IN_REPOSITORIES: dict[RepositoryId, FileRepositoryFactory] = {
     "fal": lambda: FalFileRepository(),
     "fal_v2": lambda: FalFileRepositoryV2(),
+    "fal_v3": lambda: FalFileRepositoryV3(),
     "in_memory": lambda: InMemoryRepository(),
     "gcp_storage": lambda: GoogleStorageRepository(),
     "r2": lambda: R2Repository(),

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -92,11 +92,11 @@ fal_v2_token_manager = FalV2TokenManager()
 
 @dataclass
 class ObjectLifecyclePreference:
-    expiration_duration_seconds: int | None = None
+    expiration_duration_seconds: int
 
 
 GLOBAL_LIFECYCLE_PREFERENCE = ObjectLifecyclePreference(
-    expiration_duration_seconds=None,
+    expiration_duration_seconds=86400
 )
 
 

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -92,11 +92,11 @@ fal_v2_token_manager = FalV2TokenManager()
 
 @dataclass
 class ObjectLifecyclePreference:
-    expiration_duration_seconds: int
+    expiration_duration_seconds: int | None = None
 
 
 GLOBAL_LIFECYCLE_PREFERENCE = ObjectLifecyclePreference(
-    expiration_duration_seconds=86400
+    expiration_duration_seconds=None,
 )
 
 

--- a/projects/fal/src/fal/toolkit/file/types.py
+++ b/projects/fal/src/fal/toolkit/file/types.py
@@ -29,7 +29,9 @@ class FileData:
             self.file_name = file_name
 
 
-RepositoryId = Literal["fal", "fal_v2", "in_memory", "gcp_storage", "r2", "cdn"]
+RepositoryId = Literal[
+    "fal", "fal_v2", "fal_v3", "in_memory", "gcp_storage", "r2", "cdn"
+]
 
 
 @dataclass

--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -580,6 +580,7 @@ def test_worker_env_vars(isolated_client):
             "https://storage.googleapis.com/isolate-dev-smiling-shark_toolkit_bucket/",
         ),
         ("fal_v2", "https://v2.fal.media/files"),
+        ("fal_v3", "https://v3.fal.media/files"),
     ],
 )
 def test_fal_storage(isolated_client, repo_type, url_prefix):


### PR DESCRIPTION
Straight-up v1 code copied and adapted to support v3 auth.

This allows us to start testing v3 out.

Multipart will be introduced separately.

We also change default lifecycle policy here to never expire, as that seemed to be the conclusion of our recent conversation about it. Note that we still set it for v1 too, but v1 is ignoring those.