### PR TITLE
feat(client): support creating a handle from request_id

### DIFF
--- a/projects/fal_client/tests/test_async_client.py
+++ b/projects/fal_client/tests/test_async_client.py
@@ -35,6 +35,9 @@ async def test_fal_client(client: fal_client.AsyncClient):
     assert isinstance(status, fal_client.Completed)
     assert status.logs is None
 
+    new_handle = client.get_handle("fal-ai/fast-sdxl/image-to-image", handle.request_id)
+    assert new_handle == handle
+
     status_w_logs = await handle.status(with_logs=True)
     assert isinstance(status_w_logs, fal_client.Completed)
     assert status_w_logs.logs is not None

--- a/projects/fal_client/tests/test_sync_client.py
+++ b/projects/fal_client/tests/test_sync_client.py
@@ -39,6 +39,9 @@ def test_fal_client(client: fal_client.SyncClient):
     assert isinstance(status_w_logs, fal_client.Completed)
     assert status_w_logs.logs is not None
 
+    new_handle = client.get_handle("fal-ai/fast-sdxl/image-to-image", handle.request_id)
+    assert new_handle == handle
+
     output = client.run(
         "fal-ai/fast-sdxl",
         arguments={


### PR DESCRIPTION
Allows creating a handle later, in a separate thread/process/etc if the original handle is no longer available.