### PR TITLE
fix(app): use debug() for label error

### DIFF
--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -79,7 +79,7 @@ async def _set_logger_labels(
         code = await res.code()
         assert str(code) == "StatusCode.OK"
     except BaseException:
-        logger.exception("Failed to set logger labels")
+        logger.debug("Failed to set logger labels", exc_info=True)
 
 
 def wrap_app(cls: type[App], **kwargs) -> fal.api.IsolatedFunction:


### PR DESCRIPTION
This message is not really critical, so we can just debug() it and not scare users with a traceback.