### PR TITLE
feat(toolkit): set default expiration for cdn to never

### DIFF
--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -110,9 +110,7 @@ class ObjectLifecyclePreference:
     expiration_duration_seconds: int
 
 
-GLOBAL_LIFECYCLE_PREFERENCE = ObjectLifecyclePreference(
-    expiration_duration_seconds=86400
-)
+GLOBAL_LIFECYCLE_PREFERENCE = ObjectLifecyclePreference(expiration_duration_seconds=0)
 
 
 @dataclass


### PR DESCRIPTION
We have per-request one working already, so no reason to limit really.