### PR TITLE
fix(image-toolkit): request class conflict

### DIFF
--- a/projects/fal/src/fal/toolkit/image/__init__.py
+++ b/projects/fal/src/fal/toolkit/image/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import urllib.request
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from urllib.request import Request, urlopen
 
 from .image import *  # noqa: F403
 
@@ -62,8 +62,8 @@ def read_image_from_url(
     }
 
     try:
-        request = Request(url, headers=TEMP_HEADERS)
-        response = urlopen(request)
+        request = urllib.request.Request(url, headers=TEMP_HEADERS)
+        response = urllib.request.urlopen(request)
         image_pil = Image.open(response)
     except Exception:
         import traceback


### PR DESCRIPTION
fixes conflicts between two distinct Request classes.

```py
from urllib.request import Request, urlopen # this one has  a Request from urllib

from .image import *  # noqa: F403 # this one has a Request from fastapi

....

# and now this is using request from fastapi, not urllib
request = Request(url, headers=TEMP_HEADERS) 
```