### PR TITLE
fix: proper isolate version check

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -22,7 +22,7 @@ authors = [{ name = "Features & Labels <support@fal.ai>"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "isolate[build]>=0.13.0,<1.14.0",
+    "isolate[build]>=0.14.2,<0.15.0",
     "isolate-proto==0.5.5",
     "grpcio==1.64.0",
     "dill==0.3.7",


### PR DESCRIPTION
1. Avoid jumping breaking versions of isolate
2. Include a bump to minimum 0.14.2