### PR TITLE
fix: remove default object lifecycle for CDN and use header when possible

### DIFF
--- a/projects/fal/src/fal/toolkit/file/file.py
+++ b/projects/fal/src/fal/toolkit/file/file.py
@@ -22,6 +22,7 @@ else:
 from pydantic import BaseModel, Field
 
 from fal.toolkit.file.providers.fal import (
+    LIFECYCLE_PREFERENCE,
     FalCDNFileRepository,
     FalFileRepository,
     FalFileRepositoryV2,
@@ -149,7 +150,9 @@ class File(BaseModel):
 
         fdata = FileData(data, content_type, file_name)
 
-        object_lifecycle_preference = get_lifecycle_preference(request)
+        object_lifecycle_preference = (
+            request_lifecycle_repference(request) or LIFECYCLE_PREFERENCE.get()
+        )
 
         try:
             url = repo.save(fdata, object_lifecycle_preference, **save_kwargs)
@@ -203,7 +206,9 @@ class File(BaseModel):
         fallback_save_kwargs = fallback_save_kwargs or {}
 
         content_type = content_type or "application/octet-stream"
-        object_lifecycle_preference = get_lifecycle_preference(request)
+        object_lifecycle_preference = (
+            request_lifecycle_repference(request) or LIFECYCLE_PREFERENCE.get()
+        )
 
         try:
             url, data = repo.save_file(
@@ -288,7 +293,7 @@ class CompressedFile(File):
             shutil.rmtree(self.extract_dir)
 
 
-def get_lifecycle_preference(request: Optional[Request]) -> dict[str, str] | None:
+def request_lifecycle_repference(request: Optional[Request]) -> dict[str, str] | None:
     import json
 
     if request is None:

--- a/projects/fal/src/fal/toolkit/file/file.py
+++ b/projects/fal/src/fal/toolkit/file/file.py
@@ -288,21 +288,18 @@ class CompressedFile(File):
             shutil.rmtree(self.extract_dir)
 
 
-def get_lifecycle_preference(request: Request) -> dict[str, str] | None:
+def get_lifecycle_preference(request: Optional[Request]) -> dict[str, str] | None:
     import json
 
-    preference_str = (
-        request.headers.get(OBJECT_LIFECYCLE_PREFERENCE_KEY)
-        if request is not None
-        else None
-    )
+    if request is None:
+        return None
+
+    preference_str = request.headers.get(OBJECT_LIFECYCLE_PREFERENCE_KEY)
     if preference_str is None:
         return None
 
-    object_lifecycle_preference = {}
     try:
-        object_lifecycle_preference = json.loads(preference_str)
-        return object_lifecycle_preference
+        return json.loads(preference_str)
     except Exception as e:
         print(f"Failed to parse object lifecycle preference: {e}")
         return None

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -601,10 +601,7 @@ class InternalFalFileRepositoryV3(FileRepository):
         object_lifecycle_preference: dict[str, str] | None,
     ):
         if object_lifecycle_preference:
-            if "expiration_duration_seconds" in object_lifecycle_preference:
-                headers["X-Fal-Object-Lifecycle-Expiration-Duration-Seconds"] = (
-                    object_lifecycle_preference["expiration_duration_seconds"]
-                )
+            headers["X-Fal-Object-Lifecycle"] = json.dumps(object_lifecycle_preference)
 
     @retry(max_retries=3, base_delay=1, backoff_type="exponential", jitter=True)
     def save(

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import json
 import math
 import os
@@ -539,10 +538,13 @@ class FalCDNFileRepository(FileRepository):
             "Accept": "application/json",
             "Content-Type": file.content_type,
             "X-Fal-File-Name": file.file_name,
-            "X-Fal-Object-Lifecycle-Preference": json.dumps(
-                dataclasses.asdict(GLOBAL_LIFECYCLE_PREFERENCE)
-            ),
         }
+
+        if object_lifecycle_preference:
+            headers["X-Fal-Object-Lifecycle-Preference"] = json.dumps(
+                object_lifecycle_preference
+            )
+
         url = os.getenv("FAL_CDN_HOST", _FAL_CDN) + "/files/upload"
         request = Request(url, headers=headers, method="POST", data=file.data)
         try:
@@ -582,22 +584,18 @@ class InternalFalFileRepositoryV3(FileRepository):
     def save(
         self, file: FileData, object_lifecycle_preference: dict[str, str] | None
     ) -> str:
-        lifecycle = dataclasses.asdict(GLOBAL_LIFECYCLE_PREFERENCE)
-        if object_lifecycle_preference is not None:
-            lifecycle = {
-                key: object_lifecycle_preference[key]
-                if key in object_lifecycle_preference
-                else value
-                for key, value in lifecycle.items()
-            }
-
         headers = {
             **self.auth_headers,
             "Accept": "application/json",
             "Content-Type": file.content_type,
             "X-Fal-File-Name": file.file_name,
-            "X-Fal-Object-Lifecycle-Preference": json.dumps(lifecycle),
         }
+
+        if object_lifecycle_preference:
+            headers["X-Fal-Object-Lifecycle-Preference"] = json.dumps(
+                object_lifecycle_preference
+            )
+
         url = os.getenv("FAL_CDN_V3_HOST", _FAL_CDN_V3) + "/files/upload"
         request = Request(url, headers=headers, method="POST", data=file.data)
         try:

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -8,6 +8,7 @@ from base64 import b64encode
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Generic, TypeVar
 from urllib.error import HTTPError
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
@@ -104,14 +105,21 @@ fal_v2_token_manager = FalV2TokenManager()
 fal_v3_token_manager = FalV3TokenManager()
 
 
-@dataclass
-class ObjectLifecyclePreference:
-    expiration_duration_seconds: int
+VariableType = TypeVar("VariableType")
 
 
-GLOBAL_LIFECYCLE_PREFERENCE = ObjectLifecyclePreference(
-    expiration_duration_seconds=86400
-)
+class VariableReference(Generic[VariableType]):
+    def __init__(self, value: VariableType) -> None:
+        self.set(value)
+
+    def get(self) -> VariableType:
+        return self.value
+
+    def set(self, value: VariableType) -> None:
+        self.value = value
+
+
+LIFECYCLE_PREFERENCE: VariableReference[dict[str, str] | None] = VariableReference(None)
 
 
 @dataclass


### PR DESCRIPTION
1. no longer default to 1 day
2. tries to use the request's headers almost always