### PR TITLE
misc(container): add tests for container apps and remove build_env

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -87,5 +87,8 @@ target-version = "py38"
 [tool.ruff.lint]
 select = ["E", "F", "W", "PLC", "PLE", "PLW", "I", "UP"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["fal"]
+
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = true

--- a/projects/fal/src/fal/container.py
+++ b/projects/fal/src/fal/container.py
@@ -3,7 +3,7 @@ class ContainerImage:
     from a Dockerfile.
     """
 
-    _known_keys = {"dockerfile_str", "build_env", "build_args", "registries"}
+    _known_keys = {"dockerfile_str", "build_args", "registries"}
 
     @classmethod
     def from_dockerfile_str(cls, text: str, **kwargs):

--- a/projects/fal/tests/cli/test_deploy.py
+++ b/projects/fal/tests/cli/test_deploy.py
@@ -2,6 +2,7 @@ from typing import Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from fal.cli.deploy import _deploy
 from fal.cli.main import parse_args
 from fal.files import find_project_root

--- a/projects/fal/tests/cli/test_run.py
+++ b/projects/fal/tests/cli/test_run.py
@@ -2,6 +2,7 @@ from typing import Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from fal.cli.main import parse_args
 from fal.cli.run import _run
 from fal.files import find_project_root

--- a/projects/fal/tests/conftest.py
+++ b/projects/fal/tests/conftest.py
@@ -4,6 +4,7 @@ import sys
 from functools import partial
 
 import pytest
+
 from fal import function
 from fal.flags import GRPC_HOST
 from fal.sdk import get_default_credentials

--- a/projects/fal/tests/integration_test.py
+++ b/projects/fal/tests/integration_test.py
@@ -6,8 +6,11 @@ from pathlib import Path
 from typing import Callable
 from uuid import uuid4
 
-import fal
 import pytest
+from pydantic import BaseModel, Field
+from pydantic import __version__ as pydantic_version
+
+import fal
 from fal import FalServerlessHost, FalServerlessKeyCredentials, local, sync_dir
 from fal.api import FalServerlessError, IsolatedFunction
 from fal.toolkit import (
@@ -21,8 +24,6 @@ from fal.toolkit import (
 )
 from fal.toolkit.file.file import CompressedFile
 from fal.toolkit.utils.download_utils import _get_git_revision_hash, _hash_url
-from pydantic import BaseModel, Field
-from pydantic import __version__ as pydantic_version
 
 EXAMPLE_FILE_URL = "https://raw.githubusercontent.com/fal-ai/fal/main/projects/fal/tests/assets/cat.png"
 

--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import subprocess
 from contextlib import suppress
 
-import fal
 import pytest
+from isolate.backends.common import active_python
+from pydantic import __version__ as pydantic_version
+
+import fal
 from fal.api import FalServerlessError, Options
 from fal.container import ContainerImage
 from fal.toolkit.file import File
-from isolate.backends.common import active_python
-from pydantic import __version__ as pydantic_version
 
 PACKAGE_NAME = "fall"
 

--- a/projects/fal/tests/toolkit/file_test.py
+++ b/projects/fal/tests/toolkit/file_test.py
@@ -4,6 +4,7 @@ import os
 from base64 import b64encode
 
 import pytest
+
 from fal.toolkit.file.file import File, GoogleStorageRepository
 
 

--- a/projects/fal/tests/toolkit/image_test.py
+++ b/projects/fal/tests/toolkit/image_test.py
@@ -5,10 +5,11 @@ from io import BytesIO
 from typing import Literal, overload
 
 import pytest
-from fal.toolkit import Image
 from PIL import Image as PILImage
 from pydantic import BaseModel, Field
 from pydantic import __version__ as pydantic_version
+
+from fal.toolkit import Image
 
 
 @overload

--- a/projects/fal/tests/toolkit/utils/retry.py
+++ b/projects/fal/tests/toolkit/utils/retry.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from fal.toolkit.utils.retry import retry
 
 


### PR DESCRIPTION
We currently do not exercise container apps in our tests, the container
app seems to be an unused fixture. This commit introduces basic tests to
ensure that container apps are built and work as expected. Furthermore,
this commit introduces a check that container args actually work.
Finally, this commit removes the `build_env` keyword from the
`ContainerImage` class. Docker has no concept of specifying environment
variables at build time except by declaring build arguments. Having that
keyword is messy and opens the door to non-hermetic builds, which is
a recipe for leaks and reproducibility problems.

Signed-off-by: squat <lserven@gmail.com>
