### PR TITLE
feat(fal): support basic fal profiles

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -77,6 +77,7 @@ SERVE_REQUIREMENTS = [
     "uvicorn",
     "starlette_exporter",
     "structlog",
+    "tomli",
 ]
 
 

--- a/projects/fal/src/fal/auth/__init__.py
+++ b/projects/fal/src/fal/auth/__init__.py
@@ -8,6 +8,7 @@ from typing import Optional
 import click
 
 from fal.auth import auth0, local
+from fal.config import Config
 from fal.console import console
 from fal.console.icons import CHECK_ICON
 from fal.exceptions.auth import UnauthenticatedException
@@ -61,7 +62,9 @@ def key_credentials() -> tuple[str, str] | None:
     if os.environ.get("FAL_FORCE_AUTH_BY_USER") == "1":
         return None
 
-    key = os.environ.get("FAL_KEY") or get_colab_token()
+    config = Config()
+
+    key = os.environ.get("FAL_KEY") or config.get("key") or get_colab_token()
     if key:
         key_id, key_secret = key.split(":", 1)
         return (key_id, key_secret)

--- a/projects/fal/src/fal/config.py
+++ b/projects/fal/src/fal/config.py
@@ -1,0 +1,23 @@
+import os
+
+import tomli
+
+
+class Config:
+    DEFAULT_CONFIG_PATH = "~/.fal/config.toml"
+    DEFAULT_PROFILE = "default"
+
+    def __init__(self):
+        self.config_path = os.path.expanduser(
+            os.getenv("FAL_CONFIG_PATH", self.DEFAULT_CONFIG_PATH)
+        )
+        self.profile = os.getenv("FAL_PROFILE", self.DEFAULT_PROFILE)
+
+        try:
+            with open(self.config_path, "rb") as file:
+                self.config = tomli.load(file)
+        except FileNotFoundError:
+            self.config = {}
+
+    def get(self, key):
+        return self.config.get(self.profile, {}).get(key)

--- a/projects/fal/tests/integration_test.py
+++ b/projects/fal/tests/integration_test.py
@@ -458,7 +458,7 @@ def fal_file_content_matches(file: File, content: str):
 
 
 def test_fal_file_from_path(isolated_client):
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def fal_file_from_temp(content: str):
         with tempfile.NamedTemporaryFile() as temp_file:
             file_path = temp_file.name
@@ -475,7 +475,7 @@ def test_fal_file_from_path(isolated_client):
 
 
 def test_fal_file_from_bytes(isolated_client):
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def fal_file_from_bytes(content: str):
         return File.from_bytes(content.encode(), repository="in_memory")
 
@@ -486,7 +486,7 @@ def test_fal_file_from_bytes(isolated_client):
 
 
 def test_fal_file_save(isolated_client):
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def fal_file_to_local_file(content: str):
         file = File.from_bytes(content.encode(), repository="in_memory")
 
@@ -521,7 +521,7 @@ def test_fal_file_input(isolated_client, file_url: str, expected_content: str):
     class TestInput(BaseModel):
         file: File = Field()
 
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def init_file_on_fal(input: TestInput) -> File:
         return input.file
 
@@ -542,7 +542,7 @@ def test_fal_compressed_file(isolated_client):
     class TestInput(BaseModel):
         files: CompressedFile
 
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def init_compressed_file_on_fal(input: TestInput) -> int:
         extracted_file_paths = [file for file in input.files]
         return extracted_file_paths
@@ -557,7 +557,7 @@ def test_fal_compressed_file(isolated_client):
 
 
 def test_fal_cdn(isolated_client):
-    @isolated_client(requirements=[f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def upload_to_fal_cdn() -> FalImage:
         return FalImage.from_bytes(b"0", "jpeg", repository="cdn")
 

--- a/projects/fal/tests/toolkit/image_test.py
+++ b/projects/fal/tests/toolkit/image_test.py
@@ -77,7 +77,7 @@ def assert_fal_images_equals(fal_image_1: Image, fal_image_2: Image):
 
 
 def test_fal_image_from_pil(isolated_client):
-    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}", "tomli"])
     def fal_image_from_bytes_remote():
         pil_image = get_image()
         return Image.from_pil(pil_image, repository="in_memory")
@@ -87,7 +87,7 @@ def test_fal_image_from_pil(isolated_client):
 
 
 def test_fal_image_from_bytes(isolated_client):
-    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}", "tomli"])
     def fal_image_from_bytes_remote():
         image_bytes = get_image(as_bytes=True)
         return Image.from_bytes(image_bytes, repository="in_memory", format="png")
@@ -107,7 +107,7 @@ def test_fal_image_input(isolated_client, image_url):
     class TestInput(BaseModel):
         image: Image = Field()
 
-    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}", "tomli"])
     def init_image_on_fal(input: TestInput) -> Image:
         return TestInput(image=input.image).image
 
@@ -127,7 +127,7 @@ def test_fal_image_input_to_pil(isolated_client):
     class TestInput(BaseModel):
         image: Image = Field()
 
-    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}"])
+    @isolated_client(requirements=["pillow", f"pydantic=={pydantic_version}", "tomli"])
     def init_image_on_fal(input: TestInput) -> bytes:
         input_image = TestInput(image=input.image).image
         pil_image = input_image.to_pil()


### PR DESCRIPTION
Currently one needs to either `login` or keep using `FAL_KEY` env vars either implicitly or explicitly, but both can lead to confusion. In my case I find myself generating new keys all the time, because I can't remember which one was which. This PR introduces

* `~/.fal/config.toml` or `FAL_CONFIG_PATH` with profile sections
* `FAL_PROFILE` to set particular profile

which allows keeping keys in one place and then easily switching between them, similar to tools like aws cli or modal.

In the future we can also use this for acquiring list of teams that your account has access to and switching between them, similar to `modal profile`.