### PR TITLE
feat(toolkit): fallback to `fal` instead of `cdn`

### DIFF
--- a/projects/fal/src/fal/toolkit/file/file.py
+++ b/projects/fal/src/fal/toolkit/file/file.py
@@ -59,7 +59,7 @@ def get_builtin_repository(id: RepositoryId | FileRepository) -> FileRepository:
 get_builtin_repository.__module__ = "__main__"
 
 DEFAULT_REPOSITORY: FileRepository | RepositoryId = "fal_v3"
-FALLBACK_REPOSITORY: FileRepository | RepositoryId = "cdn"
+FALLBACK_REPOSITORY: FileRepository | RepositoryId = "fal"
 OBJECT_LIFECYCLE_PREFERENCE_KEY = "x-fal-object-lifecycle-preference"
 
 


### PR DESCRIPTION
`cdn` just like `fal_v3` are cloudflare-based, so if r2 or cf have an outage they will both go down. `fal` is our own legacy one that had the same feature parity as `cdn` (lacking object lifecycle, multipart) but still useful for now.