### PR TITLE
feat: show concurrency_buffer when listing apps and allow adjusting it

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.16.1,<0.17.0",
-    "isolate-proto>=0.6.7,<0.7.0",
+    "isolate-proto>=0.7.0,<0.8.0",
     "grpcio==1.64.0",
     "dill==0.3.7",
     "cloudpickle==3.0.0",

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -53,6 +53,7 @@ from fal.exceptions import (
 from fal.exceptions._cuda import _is_cuda_oom_exception
 from fal.logging.isolate import IsolateLogPrinter
 from fal.sdk import (
+    FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
@@ -400,6 +401,7 @@ class FalServerlessHost(Host):
             "keep_alive",
             "max_concurrency",
             "min_concurrency",
+            "concurrency_buffer",
             "max_multiplexing",
             "setup_function",
             "metadata",
@@ -451,6 +453,7 @@ class FalServerlessHost(Host):
         scheduler_options = options.host.get("_scheduler_options", None)
         max_concurrency = options.host.get("max_concurrency")
         min_concurrency = options.host.get("min_concurrency")
+        concurrency_buffer = options.host.get("concurrency_buffer")
         max_multiplexing = options.host.get("max_multiplexing")
         exposed_port = options.get_exposed_port()
         request_timeout = options.host.get("request_timeout")
@@ -466,6 +469,7 @@ class FalServerlessHost(Host):
             max_multiplexing=max_multiplexing,
             max_concurrency=max_concurrency,
             min_concurrency=min_concurrency,
+            concurrency_buffer=concurrency_buffer,
             request_timeout=request_timeout,
             startup_timeout=startup_timeout,
         )
@@ -523,6 +527,7 @@ class FalServerlessHost(Host):
         keep_alive = options.host.get("keep_alive", FAL_SERVERLESS_DEFAULT_KEEP_ALIVE)
         max_concurrency = options.host.get("max_concurrency")
         min_concurrency = options.host.get("min_concurrency")
+        concurrency_buffer = options.host.get("concurrency_buffer")
         max_multiplexing = options.host.get("max_multiplexing")
         base_image = options.host.get("_base_image", None)
         scheduler = options.host.get("_scheduler", None)
@@ -542,6 +547,7 @@ class FalServerlessHost(Host):
             max_multiplexing=max_multiplexing,
             max_concurrency=max_concurrency,
             min_concurrency=min_concurrency,
+            concurrency_buffer=concurrency_buffer,
             request_timeout=request_timeout,
             startup_timeout=startup_timeout,
         )
@@ -709,6 +715,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
@@ -737,6 +744,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
@@ -815,6 +823,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
@@ -848,6 +857,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
@@ -875,6 +885,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
@@ -902,6 +913,7 @@ def function(
     keep_alive: int = FAL_SERVERLESS_DEFAULT_KEEP_ALIVE,
     max_multiplexing: int = FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING,
     min_concurrency: int = FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY,
+    concurrency_buffer: int = FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -235,9 +235,9 @@ def add_parser(main_subparsers, parents):
         "--no-scale",
         action="store_true",
         help=(
-            "Use min_concurrency/max_concurrency/max_multiplexing from previous "
-            "deployment of application with this name, if exists. Otherwise will "
-            "use the values from the application code."
+            "Use min_concurrency/max_concurrency/concurrency_buffer/max_multiplexing "
+            "from previous deployment of application with this name, if exists. "
+            "Otherwise will use the values from the application code."
         ),
     )
 

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -29,6 +29,7 @@ _DEFAULT_SERIALIZATION_METHOD = "cloudpickle"
 FAL_SERVERLESS_DEFAULT_KEEP_ALIVE = 10
 FAL_SERVERLESS_DEFAULT_MAX_MULTIPLEXING = 1
 FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY = 0
+FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER = 0
 ALIAS_AUTH_MODES = ["public", "private", "shared"]
 
 logger = get_logger(__name__)
@@ -197,6 +198,7 @@ class ApplicationInfo:
     max_multiplexing: int
     active_runners: int
     min_concurrency: int
+    concurrency_buffer: int
     machine_types: list[str]
     request_timeout: int
     startup_timeout: int
@@ -213,6 +215,7 @@ class AliasInfo:
     max_multiplexing: int
     active_runners: int
     min_concurrency: int
+    concurrency_buffer: int
     machine_types: list[str]
     request_timeout: int
     startup_timeout: int
@@ -323,6 +326,7 @@ def _from_grpc_application_info(
         max_multiplexing=message.max_multiplexing,
         active_runners=message.active_runners,
         min_concurrency=message.min_concurrency,
+        concurrency_buffer=message.concurrency_buffer,
         machine_types=list(message.machine_types),
         request_timeout=message.request_timeout,
         startup_timeout=message.startup_timeout,
@@ -350,6 +354,7 @@ def _from_grpc_alias_info(message: isolate_proto.AliasInfo) -> AliasInfo:
         max_multiplexing=message.max_multiplexing,
         active_runners=message.active_runners,
         min_concurrency=message.min_concurrency,
+        concurrency_buffer=message.concurrency_buffer,
         machine_types=list(message.machine_types),
         request_timeout=message.request_timeout,
         startup_timeout=message.startup_timeout,
@@ -423,6 +428,7 @@ class MachineRequirements:
     max_concurrency: int | None = None
     max_multiplexing: int | None = None
     min_concurrency: int | None = None
+    concurrency_buffer: int | None = None
     request_timeout: int | None = None
     startup_timeout: int | None = None
 
@@ -540,6 +546,7 @@ class FalServerlessConnection:
                 ),
                 max_concurrency=machine_requirements.max_concurrency,
                 min_concurrency=machine_requirements.min_concurrency,
+                concurrency_buffer=machine_requirements.concurrency_buffer,
                 max_multiplexing=machine_requirements.max_multiplexing,
                 request_timeout=machine_requirements.request_timeout,
                 startup_timeout=machine_requirements.startup_timeout,
@@ -586,6 +593,7 @@ class FalServerlessConnection:
         max_multiplexing: int | None = None,
         max_concurrency: int | None = None,
         min_concurrency: int | None = None,
+        concurrency_buffer: int | None = None,
         request_timeout: int | None = None,
         startup_timeout: int | None = None,
         valid_regions: list[str] | None = None,
@@ -597,6 +605,7 @@ class FalServerlessConnection:
             max_multiplexing=max_multiplexing,
             max_concurrency=max_concurrency,
             min_concurrency=min_concurrency,
+            concurrency_buffer=concurrency_buffer,
             request_timeout=request_timeout,
             startup_timeout=startup_timeout,
             valid_regions=valid_regions,
@@ -645,6 +654,7 @@ class FalServerlessConnection:
                 max_concurrency=machine_requirements.max_concurrency,
                 max_multiplexing=machine_requirements.max_multiplexing,
                 min_concurrency=machine_requirements.min_concurrency,
+                concurrency_buffer=machine_requirements.concurrency_buffer,
                 request_timeout=machine_requirements.request_timeout,
                 startup_timeout=machine_requirements.startup_timeout,
             )

--- a/projects/fal/tests/cli/test_apps.py
+++ b/projects/fal/tests/cli/test_apps.py
@@ -42,6 +42,8 @@ def test_scale():
             "7",
             "--max-concurrency",
             "10",
+            "--concurrency-buffer",
+            "3",
         ]
     )
     assert args.func == _scale
@@ -50,6 +52,7 @@ def test_scale():
     assert args.max_multiplexing == 321
     assert args.min_concurrency == 7
     assert args.max_concurrency == 10
+    assert args.concurrency_buffer == 3
 
 
 def test_runners():


### PR DESCRIPTION
Also, add a column to display runners with missing leases (=zombies)
