### PR TITLE
feat(fal): support teams

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from fal.files import find_project_root, find_pyproject_toml, parse_pyproject_toml
 
 
+def get_client(host: str, team: str | None = None):
+    from fal.sdk import FalServerlessClient, get_default_credentials
+
+    credentials = get_default_credentials(team=team)
+    return FalServerlessClient(host, credentials)
+
+
 def is_app_name(app_ref: tuple[str, str | None]) -> bool:
     is_single_file = app_ref[1] is None
     is_python_file = app_ref[0].endswith(".py")

--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ._utils import get_client
 from .parser import FalClientParser
 
 if TYPE_CHECKING:
@@ -47,9 +48,7 @@ def _apps_table(apps: list[AliasInfo]):
 
 
 def _list(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         apps = connection.list_aliases()
 
@@ -120,9 +119,7 @@ def _app_rev_table(revs: list[ApplicationInfo]):
 
 
 def _list_rev(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         revs = connection.list_applications()
         table = _app_rev_table(revs)
@@ -142,9 +139,7 @@ def _add_list_rev_parser(subparsers, parents):
 
 
 def _scale(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         if (
             args.keep_alive is None
@@ -240,9 +235,7 @@ def _add_scale_parser(subparsers, parents):
 
 
 def _set_rev(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.create_alias(args.app_name, args.app_rev, args.auth)
 
@@ -277,9 +270,7 @@ def _add_set_rev_parser(subparsers, parents):
 def _runners(args):
     from rich.table import Table
 
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         runners = connection.list_alias_runners(alias=args.app_name)
 
@@ -350,9 +341,7 @@ def _add_runners_parser(subparsers, parents):
 
 
 def _delete(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.delete_alias(args.app_name)
 
@@ -373,9 +362,7 @@ def _add_delete_parser(subparsers, parents):
 
 
 def _delete_rev(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.delete_application(args.app_rev)
 

--- a/projects/fal/src/fal/cli/auth.py
+++ b/projects/fal/src/fal/cli/auth.py
@@ -2,11 +2,38 @@ from fal.auth import USER, login, logout
 
 
 def _login(args):
+    from rich.prompt import Prompt
+
+    from fal.config import Config
+
     login()
+    teams = [team["nickname"].lower() for team in USER.teams]
+    if not teams:
+        return
+
+    team = Prompt.ask(
+        "\nPlease choose a team account to use or leave blank to "
+        "use your personal account:",
+        choices=teams,
+        default=None,
+    )
+    with Config().edit() as config:
+        if team:
+            args.console.print(
+                f"Setting team to [cyan]{team}[/]. "
+                "You can change this later with [bold]fal team set[/]."
+            )
+            config.set("team", team)
+        else:
+            config.unset("team")
 
 
 def _logout(args):
+    from fal.config import Config
+
     logout()
+    with Config().edit() as config:
+        config.unset("team")
 
 
 def _whoami(args):

--- a/projects/fal/src/fal/cli/keys.py
+++ b/projects/fal/src/fal/cli/keys.py
@@ -1,12 +1,11 @@
 from fal.sdk import KeyScope
 
+from ._utils import get_client
 from .parser import FalClientParser
 
 
 def _create(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         parsed_scope = KeyScope(args.scope)
         result = connection.create_user_key(parsed_scope, args.desc)
@@ -43,15 +42,13 @@ def _add_create_parser(subparsers, parents):
 def _list(args):
     from rich.table import Table
 
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
     table = Table()
     table.add_column("Key ID")
     table.add_column("Created At")
     table.add_column("Scope")
     table.add_column("Description")
 
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         keys = connection.list_user_keys()
         for key in keys:
@@ -77,9 +74,7 @@ def _add_list_parser(subparsers, parents):
 
 
 def _revoke(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.revoke_user_key(args.key_id)
 

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -18,6 +18,7 @@ from . import (
     run,
     runners,
     secrets,
+    teams,
 )
 from .debug import debugtools, get_debug_parser
 from .parser import FalParser, FalParserExit
@@ -55,6 +56,7 @@ def _get_main_parser() -> argparse.ArgumentParser:
         doctor,
         create,
         runners,
+        teams,
     ]:
         cmd.add_parser(subparsers, parents)
 

--- a/projects/fal/src/fal/cli/parser.py
+++ b/projects/fal/src/fal/cli/parser.py
@@ -99,3 +99,7 @@ class FalClientParser(FalParser):
             default=GRPC_HOST,
             help=argparse.SUPPRESS,
         )
+        self.add_argument(
+            "--team",
+            help="The team to use.",
+        )

--- a/projects/fal/src/fal/cli/profile.py
+++ b/projects/fal/src/fal/cli/profile.py
@@ -4,13 +4,12 @@ from fal.config import Config
 
 
 def _list(args):
-    config = Config()
-
     table = Table()
     table.add_column("Default")
     table.add_column("Profile")
     table.add_column("Settings")
 
+    config = Config()
     for profile in config.profiles():
         table.add_row(
             "*" if profile == config._profile else "",
@@ -22,28 +21,24 @@ def _list(args):
 
 
 def _set(args):
-    config = Config()
-    config.set_internal("profile", args.PROFILE)
-    args.console.print(f"Default profile set to [cyan]{args.PROFILE}[/].")
-    config.profile = args.PROFILE
-    if not config.get("key"):
-        args.console.print(
-            "No key set for profile. Use [bold]fal profile key[/] to set a key."
-        )
-    config.save()
+    with Config().edit() as config:
+        config.set_internal("profile", args.PROFILE)
+        args.console.print(f"Default profile set to [cyan]{args.PROFILE}[/].")
+        config.profile = args.PROFILE
+        if not config.get("key"):
+            args.console.print(
+                "No key set for profile. Use [bold]fal profile key[/] to set a key."
+            )
 
 
 def _unset(args):
-    config = Config()
-    config.set_internal("profile", None)
-    args.console.print("Default profile unset.")
-    config.profile = None
-    config.save()
+    with Config().edit() as config:
+        config.set_internal("profile", None)
+        args.console.print("Default profile unset.")
+        config.profile = None
 
 
 def _key_set(args):
-    config = Config()
-
     while True:
         key = input("Enter the key: ")
         if ":" in key:
@@ -52,25 +47,25 @@ def _key_set(args):
             "[red]Invalid key. The key must be in the format [bold]key:value[/].[/]"
         )
 
-    config.set("key", key)
-    args.console.print(f"Key set for profile [cyan]{config.profile}[/].")
-    config.save()
+    with Config().edit() as config:
+        config.set("key", key)
+        args.console.print(f"Key set for profile [cyan]{config.profile}[/].")
 
 
 def _delete(args):
-    config = Config()
-    if config.profile == args.PROFILE:
-        config.set_internal("profile", None)
+    with Config().edit() as config:
+        if config.profile == args.PROFILE:
+            config.set_internal("profile", None)
 
-    config.delete(args.PROFILE)
-    args.console.print(f"Profile [cyan]{args.PROFILE}[/] deleted.")
-    config.save()
+        config.delete(args.PROFILE)
+        args.console.print(f"Profile [cyan]{args.PROFILE}[/] deleted.")
 
 
 def add_parser(main_subparsers, parents):
     auth_help = "Profile management."
     parser = main_subparsers.add_parser(
         "profile",
+        aliases=["profiles"],
         description=auth_help,
         help=auth_help,
         parents=parents,

--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -1,10 +1,9 @@
+from ._utils import get_client
 from .parser import FalClientParser
 
 
 def _kill(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.kill_runner(args.id)
 

--- a/projects/fal/src/fal/cli/secrets.py
+++ b/projects/fal/src/fal/cli/secrets.py
@@ -1,10 +1,9 @@
+from ._utils import get_client
 from .parser import DictAction, FalClientParser
 
 
 def _set(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         for name, value in args.secrets.items():
             connection.set_secret(name, value)
@@ -34,13 +33,11 @@ def _add_set_parser(subparsers, parents):
 def _list(args):
     from rich.table import Table
 
-    from fal.sdk import FalServerlessClient
-
     table = Table()
     table.add_column("Secret Name")
     table.add_column("Created At")
 
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         for secret in connection.list_secrets():
             table.add_row(secret.name, str(secret.created_at))
@@ -60,9 +57,7 @@ def _add_list_parser(subparsers, parents):
 
 
 def _unset(args):
-    from fal.sdk import FalServerlessClient
-
-    client = FalServerlessClient(args.host)
+    client = get_client(args.host, args.team)
     with client.connect() as connection:
         connection.delete_secret(args.secret)
 

--- a/projects/fal/src/fal/cli/teams.py
+++ b/projects/fal/src/fal/cli/teams.py
@@ -1,0 +1,89 @@
+def _list(args):
+    from rich.table import Table
+
+    from fal.auth import USER
+    from fal.config import Config
+
+    table = Table()
+    table.add_column("Default")
+    table.add_column("Team")
+    table.add_column("Full Name")
+    table.add_column("ID")
+
+    default_team = Config().get("team")
+
+    for team in USER.teams:
+        default = default_team and default_team.lower() == team["nickname"].lower()
+        table.add_row(
+            "*" if default else "", team["nickname"], team["full_name"], team["user_id"]
+        )
+
+    args.console.print(table)
+
+
+def _set(args):
+    from fal.config import Config
+    from fal.sdk import USER
+
+    team = args.team.lower()
+    for team_info in USER.teams:
+        if team_info["nickname"].lower() == team:
+            break
+    else:
+        raise ValueError(f"Team {args.team} not found")
+
+    with Config().edit() as config:
+        config.set("team", team)
+
+
+def _unset(args):
+    from fal.config import Config
+
+    with Config().edit() as config:
+        config.unset("team")
+
+
+def add_parser(main_subparsers, parents):
+    teams_help = "Manage teams."
+    parser = main_subparsers.add_parser(
+        "teams",
+        aliases=["team"],
+        description=teams_help,
+        help=teams_help,
+        parents=parents,
+    )
+
+    subparsers = parser.add_subparsers(
+        title="Commands",
+        metavar="command",
+        dest="cmd",
+        required=True,
+    )
+
+    list_help = "List teams."
+    list_parser = subparsers.add_parser(
+        "list",
+        description=list_help,
+        help=list_help,
+        parents=parents,
+    )
+    list_parser.set_defaults(func=_list)
+
+    set_help = "Set the current team."
+    set_parser = subparsers.add_parser(
+        "set",
+        description=set_help,
+        help=set_help,
+        parents=parents,
+    )
+    set_parser.add_argument("team", help="The team to set.")
+    set_parser.set_defaults(func=_set)
+
+    unset_help = "Unset the current team."
+    unset_parser = subparsers.add_parser(
+        "unset",
+        description=unset_help,
+        help=unset_help,
+        parents=parents,
+    )
+    unset_parser.set_defaults(func=_unset)


### PR DESCRIPTION
E.g. `fal apps list --team myteamnickname`

`fal auth login` will now suggest setting a team you want to use right away. E.g.

```
(fal-3.11.9) MacBook-Pro-2.local ➜  fal git:(ruslan/user-teams) ✗  fal auth login                
Please choose a team account to use or leave blank to use your personal account: 
[team1/team2/team3]: team1
Setting team to team1. You can change this later with fal teams.
```