### PR TITLE
fix: stop defaulting auth mode to private locally

### DIFF
--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -268,7 +268,7 @@ class App(fal.api.BaseServable):
         "keep_alive": 60,
     }
     app_name: ClassVar[str]
-    app_auth: ClassVar[Literal["private", "public", "shared"]] = "private"
+    app_auth: ClassVar[Literal["private", "public", "shared", None]] = None
     request_timeout: ClassVar[int | None] = None
     startup_timeout: ClassVar[int | None] = None
 

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -97,7 +97,7 @@ def _deploy_from_reference(
     )
     isolated_function = loaded.function
     app_name = app_name or loaded.app_name  # type: ignore
-    app_auth = auth or loaded.app_auth or "private"
+    app_auth = auth or loaded.app_auth
     deployment_strategy = deployment_strategy or "recreate"
 
     app_id = host.register(

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -571,11 +571,12 @@ class FalServerlessConnection:
         else:
             wrapped_requirements = None
 
+        auth_mode = None
         if application_auth_mode == "public":
             auth_mode = isolate_proto.ApplicationAuthMode.PUBLIC
         elif application_auth_mode == "shared":
             auth_mode = isolate_proto.ApplicationAuthMode.SHARED
-        else:
+        elif application_auth_mode == "private":
             auth_mode = isolate_proto.ApplicationAuthMode.PRIVATE
 
         struct_metadata = None

--- a/projects/fal/tests/test_apps.py
+++ b/projects/fal/tests/test_apps.py
@@ -655,7 +655,7 @@ def test_404_response(test_app: str, request: pytest.FixtureRequest):
 def test_app_no_auth():
     # This will just pass for users with shared apps access
     app_alias = str(uuid.uuid4()) + "-alias"
-    with pytest.raises(HTTPStatusError, match="application_auth_mode must be provided"):
+    with pytest.raises(api.FalServerlessError, match="Must specify auth_mode"):
         addition_app.host.register(
             func=addition_app.func,
             options=addition_app.options,

--- a/projects/fal/tests/test_apps.py
+++ b/projects/fal/tests/test_apps.py
@@ -652,6 +652,18 @@ def test_404_response(test_app: str, request: pytest.FixtureRequest):
         apps.run(test_app, path="/other", arguments={"lhs": 1, "rhs": 2})
 
 
+def test_app_no_auth():
+    # This will just pass for users with shared apps access
+    app_alias = str(uuid.uuid4()) + "-alias"
+    with pytest.raises(HTTPStatusError, match="application_auth_mode must be provided"):
+        addition_app.host.register(
+            func=addition_app.func,
+            options=addition_app.options,
+            # random enough
+            application_name=app_alias,
+        )
+
+
 def test_app_deploy_scale(aliased_app: Tuple[str, str]):
     from dataclasses import replace
 


### PR DESCRIPTION
```
❯ fal deploy t/bbasic.py
✘ Must specify auth_mode

# team withouth shared app rights
❯ set -x FAL_KEY ...

❯ fal deploy t/bbasic.py
Registered a new revision for function 'basic' (revision='a8e620e1-24b5-4f11-9d26-200846e4cd76').
...
```

TODO: 

- [x] add a test if possible