### PR TITLE
fix: make team selection consistent, fix auth login error, and implement auth whomai

### DIFF
--- a/projects/fal/src/fal/cli/teams.py
+++ b/projects/fal/src/fal/cli/teams.py
@@ -1,39 +1,4 @@
-def _list(args):
-    from rich.table import Table
-
-    from fal.auth import USER
-    from fal.config import Config
-
-    table = Table()
-    table.add_column("Default")
-    table.add_column("Team")
-    table.add_column("Full Name")
-    table.add_column("ID")
-
-    default_team = Config().get("team")
-
-    for team in USER.teams:
-        default = default_team and default_team.lower() == team["nickname"].lower()
-        table.add_row(
-            "*" if default else "", team["nickname"], team["full_name"], team["user_id"]
-        )
-
-    args.console.print(table)
-
-
-def _set(args):
-    from fal.config import Config
-    from fal.sdk import USER
-
-    team = args.team.lower()
-    for team_info in USER.teams:
-        if team_info["nickname"].lower() == team:
-            break
-    else:
-        raise ValueError(f"Team {args.team} not found")
-
-    with Config().edit() as config:
-        config.set("team", team)
+from fal.cli.auth import _list_accounts, _set_account
 
 
 def _unset(args):
@@ -67,7 +32,7 @@ def add_parser(main_subparsers, parents):
         help=list_help,
         parents=parents,
     )
-    list_parser.set_defaults(func=_list)
+    list_parser.set_defaults(func=_list_accounts)
 
     set_help = "Set the current team."
     set_parser = subparsers.add_parser(
@@ -76,8 +41,8 @@ def add_parser(main_subparsers, parents):
         help=set_help,
         parents=parents,
     )
-    set_parser.add_argument("team", help="The team to set.")
-    set_parser.set_defaults(func=_set)
+    set_parser.add_argument("account", help="The team to set.")
+    set_parser.set_defaults(func=_set_account)
 
     unset_help = "Unset the current team."
     unset_parser = subparsers.add_parser(

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -183,7 +183,7 @@ def get_default_credentials(team: str | None = None) -> Credentials:
     else:
         config = Config()
         team = team or config.get("team")
-        team_id = USER.get_team(team)["user_id"] if team else None
+        team_id = USER.get_account(team)["user_id"] if team else None
         return AuthenticatedCredentials(team_id=team_id)
 
 


### PR DESCRIPTION
Made fal team list and set work the same as the auth login experieince

Also auth login had errors in variables not existing and files not existing

```
❯ fal auth login
If browser didn't open automatically, on your computer or mobile device navigate to
https://auth.fal.ai/v2/...

Confirm it shows the following code: 1234-1234

✓ Authenticated successfully, welcome!
┌──────┬───────────────────────────┬──────────┐
│   1  │ chamini2                  │ Personal │
│   2  │ Matteos-Team              │ Team     │
│   3  │ ayyy                      │ Team     │
└──────┴───────────────────────────┴──────────┘
Select an account by number: 0
Please select one of the available options
Select an account by number: 1
Using personal account chamini2
```

```
❯ fal team list
┌──────┬───────────────────────────┬──────────┐
│ * 1  │ chamini2                  │ Personal │
│   2  │ Matteos-Team              │ Team     │
│   3  │ ayyy                      │ Team     │
└──────┴───────────────────────────┴──────────┘
```

```
❯ fal team set ayyy
Using team account ayyy

❯ fal team set 2
Using team account Matteos-Team
```

```
❯ fal team list
┌──────┬───────────────────────────┬──────────┐
│   1  │ chamini2                  │ Personal │
│   2  │ Matteos-Team              │ Team     │
│ * 3  │ ayyy                      │ Team     │
└──────┴───────────────────────────┴──────────┘
```