### PR TITLE
refactor: add fal auth list and fal auth account to replace team

### DIFF
--- a/projects/fal/src/fal/cli/auth.py
+++ b/projects/fal/src/fal/cli/auth.py
@@ -143,3 +143,26 @@ def add_parser(main_subparsers, parents):
         parents=parents,
     )
     whoami_parser.set_defaults(func=_whoami)
+
+    account_list_help = "List available accounts."
+    account_list_parser = subparsers.add_parser(
+        "list",
+        description=account_list_help,
+        help=account_list_help,
+        parents=parents,
+    )
+    account_list_parser.set_defaults(func=_list_accounts)
+
+    account_help = "Set the current account."
+    account_parser = subparsers.add_parser(
+        "account",
+        description=account_help,
+        help=account_help,
+        parents=parents,
+    )
+    account_parser.add_argument(
+        "account",
+        help="The account to set.",
+        nargs="?",
+    )
+    account_parser.set_defaults(func=_set_account)


### PR DESCRIPTION
the idea would be we can drop `fal team` to manage all in `fal auth`.

Also, `fal auth account` offers usage like `fal auth account 1` to choose by index, `fal auth account name` to choose by name, fal auth account` to show the list and make a decision after.