### PR TITLE
fix(profile): use unset_internal

### DIFF
--- a/projects/fal/src/fal/cli/profile.py
+++ b/projects/fal/src/fal/cli/profile.py
@@ -33,7 +33,7 @@ def _set(args):
 
 def _unset(args):
     with Config().edit() as config:
-        config.set_internal("profile", None)
+        config.unset_internal("profile")
         args.console.print("Default profile unset.")
         config.profile = None
 

--- a/projects/fal/src/fal/config.py
+++ b/projects/fal/src/fal/config.py
@@ -89,6 +89,9 @@ class Config:
         else:
             self._config[SETTINGS_SECTION][key] = value
 
+    def unset_internal(self, key: str) -> None:
+        self._config.get(SETTINGS_SECTION, {}).pop(key, None)
+
     def delete(self, profile: str) -> None:
         del self._config[profile]
 


### PR DESCRIPTION
```
(fal-3.11.9) MacBook-Pro-2.local ➜  fal git:(ruslan/fix-unset) ✗  fal profile unset --pdb
> /Users/efiop/git/efiop/fal/projects/fal/src/fal/config.py(88)set_internal()
-> del self._config[SETTINGS_SECTION][key]
(Pdb) l
 83         def set_internal(self, key: str, value: Optional[str]) -> None:
 84             if SETTINGS_SECTION not in self._config:
 85                 self._config[SETTINGS_SECTION] = {}
 86  
 87             if value is None:
 88  ->             del self._config[SETTINGS_SECTION][key]
 89             else:
 90                 self._config[SETTINGS_SECTION][key] = value
 91  
 92         def delete(self, profile: str) -> None:
 93             del self._config[profile]
(Pdb) key
'profile'
```