### PR TITLE
feat(fal_client): retry on httpx.TransportError

### DIFF
--- a/projects/fal_client/pyproject.toml
+++ b/projects/fal_client/pyproject.toml
@@ -28,6 +28,7 @@ docs = [
 test = [
     "pytest",
     "pytest-asyncio",
+    "pytest-mock",
     "pillow",
 ]
 dev = [

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -6,6 +6,7 @@ import os
 import mimetypes
 import asyncio
 from pathlib import Path
+import random
 import time
 import base64
 import threading
@@ -620,28 +621,54 @@ async def _async_request(
     return response
 
 
-def _should_retry(status_code: int) -> bool:
-    if status_code in [408, 409, 429] or status_code >= 500:
+MAX_ATTEMPTS = 4
+RETRY_CODES = [408, 409, 429]
+
+
+def _should_retry(exc: httpx.HTTPError) -> bool:
+    if isinstance(exc, httpx.TransportError):
         return True
+
+    if (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code in RETRY_CODES
+    ):
+        return True
+
     return False
 
 
-MAX_RETRIES = 3
+def _get_retry_delay(
+    num_retry: int,
+    base_delay: float,
+    max_delay: float,
+    backoff_type: Literal["exponential", "fixed"] = "exponential",
+    jitter: bool = False,
+) -> float:
+    if backoff_type == "exponential":
+        delay = min(base_delay * (2 ** (num_retry - 1)), max_delay)
+    else:
+        delay = min(base_delay, max_delay)
+
+    if jitter:
+        delay *= random.uniform(0.5, 1.5)
+
+    return min(delay, max_delay)
 
 
 def _maybe_retry_request(
     client: httpx.Client, method: str, url: str, **kwargs: Any
 ) -> httpx.Response:
-    retries = MAX_RETRIES
-    while retries > 0:
+    for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
             return _request(client, method, url, **kwargs)
-        except httpx.HTTPStatusError as exc:
-            if _should_retry(exc.response.status_code):
+        except httpx.HTTPError as exc:
+            if _should_retry(exc) and attempt < MAX_ATTEMPTS:
+                delay = _get_retry_delay(attempt, 0.1, 10, "exponential", True)
                 logger.debug(
-                    f"Retrying request to {url} due to {exc} ({retries} retries left)"
+                    f"Retrying request to {url} due to {exc} ({MAX_ATTEMPTS - attempt} attempts left)"
                 )
-                retries -= 1
+                time.sleep(delay)
                 continue
             raise
 
@@ -649,16 +676,16 @@ def _maybe_retry_request(
 async def _async_maybe_retry_request(
     client: httpx.AsyncClient, method: str, url: str, **kwargs: Any
 ) -> httpx.Response:
-    retries = MAX_RETRIES
-    while retries > 0:
+    for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
             return await _async_request(client, method, url, **kwargs)
-        except httpx.HTTPStatusError as exc:
-            if _should_retry(exc.response.status_code):
+        except httpx.HTTPError as exc:
+            if _should_retry(exc) and attempt < MAX_ATTEMPTS:
+                delay = _get_retry_delay(attempt, 0.1, 10, "exponential", True)
                 logger.debug(
-                    f"Retrying request to {url} due to {exc} ({retries} retries left)"
+                    f"Retrying request to {url} due to {exc} ({MAX_ATTEMPTS - attempt} attempts left)"
                 )
-                retries -= 1
+                await asyncio.sleep(delay)
                 continue
             raise
 


### PR DESCRIPTION
Covers all of these

```
TimeoutException
ConnectTimeout
ReadTimeout
WriteTimeout
PoolTimeout
NetworkError
ConnectError
ReadError
WriteError
CloseError
ProtocolError
LocalProtocolError
RemoteProtocolError
ProxyError
UnsupportedProtocol
```