### PR TITLE
Migrate to new datetime API

### DIFF
--- a/projects/fal/tests/test_apps.py
+++ b/projects/fal/tests/test_apps.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import uuid
 from contextlib import contextmanager, suppress
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Generator, List, Tuple
 
 import httpx
@@ -549,7 +549,7 @@ def test_app_client_async(test_sleep_app: str):
 # If the logging subsystem is not working for some nodes, this test will flake
 @pytest.mark.flaky(max_runs=10)
 def test_traceback_logs(test_exception_app: AppClient):
-    date = (datetime.utcnow() - timedelta(seconds=1)).isoformat()
+    date = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=1)).isoformat()
 
     with pytest.raises(AppClientError):
         test_exception_app.fail({})


### PR DESCRIPTION
# PR Summary
This small PR resolves the deperaction warning coming from the `datetime`:
```python
/home/runner/work/fal/fal/projects/fal/tests/test_apps.py:552: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```