### PR TITLE
feat: make sure to fail on OpenAPI generation

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -501,16 +501,7 @@ class FalServerlessHost(Host):
         if isinstance(func, ServeWrapper):
             # Assigning in a separate property leaving a place for the user
             # to add more metadata in the future
-            try:
-                metadata["openapi"] = func.openapi()
-            except Exception as e:
-                print(
-                    f"[warning] Failed to generate OpenAPI metadata for function: {e}"
-                )
-                raise FalServerlessException(
-                    "Failed to generate OpenAPI metadata for function. "
-                    "Please fix the OpenAPI generation to be make deployments work."
-                ) from e
+            metadata["openapi"] = func.openapi()
 
         for partial_result in self._connection.register(
             partial_func,
@@ -1158,7 +1149,12 @@ class BaseServable:
         Build the OpenAPI specification for the served function.
         Attach needed metadata for a better integration to fal.
         """
-        return self._build_app().openapi()
+        try:
+            return self._build_app().openapi()
+        except Exception as e:
+            raise FalServerlessException(
+                "Failed to generate OpenAPI metadata for function"
+            ) from e
 
     def serve(self) -> None:
         import asyncio

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -507,6 +507,10 @@ class FalServerlessHost(Host):
                 print(
                     f"[warning] Failed to generate OpenAPI metadata for function: {e}"
                 )
+                raise FalServerlessException(
+                    "Failed to generate OpenAPI metadata for function. "
+                    "Please fix the OpenAPI generation to be make deployments work."
+                ) from e
 
         for partial_result in self._connection.register(
             partial_func,

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -105,15 +105,12 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
         app.serve()
 
     metadata = {}
-    try:
-        app = cls(_allow_init=True)
-        metadata["openapi"] = app.openapi()
-    except Exception:
-        logger.warning("Failed to build OpenAPI specification for %s", cls.__name__)
-        realtime_app = False
-    else:
-        routes = app.collect_routes()
-        realtime_app = any(route.is_websocket for route in routes)
+    app = cls(_allow_init=True)
+
+    metadata["openapi"] = app.openapi()
+
+    routes = app.collect_routes()
+    realtime_app = any(route.is_websocket for route in routes)
 
     kind = cls.host_kwargs.pop("kind", "virtualenv")
     if kind == "container":


### PR DESCRIPTION
closes FEA-5224

```
❯ fal deploy t/bbasic.py --auth shared
✘ Failed to generate OpenAPI metadata for function: Invalid args for response field! Hint: check that typing.Union[<run_path>.HelloOutput, <run_path>.TextEventStream] is a valid Pydantic field type. If you are using a return type annotation that is not a valid Pydantic field (e.g. Union[Response, dict, None]) you can
disable generating the response model from the type annotation with the path operation decorator parameter response_model=None. Read more: https://fastapi.tiangolo.com/tutorial/response-model/
```