### PR TITLE
feat: introduce local_python_modules

### DIFF
--- a/projects/fal/src/fal/_serialization.py
+++ b/projects/fal/src/fal/_serialization.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 import cloudpickle
 
 
-def _register_pickle_by_value(name) -> None:
+def include_module(name) -> None:
     # cloudpickle.register_pickle_by_value wants an imported module object,
     # but there is really no reason to go through that complication, as
     # it might be prone to errors.
@@ -22,7 +22,7 @@ def include_package_from_path(raw_path: str) -> None:
         parent = parent.parent
 
     if parent != path:
-        _register_pickle_by_value(parent.name)
+        include_module(parent.name)
 
 
 def include_modules_from(obj: Any) -> None:
@@ -33,7 +33,7 @@ def include_modules_from(obj: Any) -> None:
     if "." in module_name:
         # Just include the whole package
         package_name, *_ = module_name.partition(".")
-        _register_pickle_by_value(package_name)
+        include_module(package_name)
         return
 
     if module_name == "__main__":
@@ -44,7 +44,7 @@ def include_modules_from(obj: Any) -> None:
         include_package_from_path(__main__.__file__)
         return
 
-    _register_pickle_by_value(module_name)
+    include_module(module_name)
 
 
 def _register(cls: Any, func: Callable) -> None:
@@ -230,4 +230,4 @@ def patch_pickle() -> None:
     _patch_console_thread_locals()
     _patch_exceptions()
 
-    _register_pickle_by_value("fal")
+    include_module("fal")

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -39,7 +39,7 @@ from pydantic import __version__ as pydantic_version
 from typing_extensions import Concatenate, ParamSpec
 
 import fal.flags as flags
-from fal._serialization import include_modules_from, patch_pickle
+from fal._serialization import include_module, include_modules_from, patch_pickle
 from fal.container import ContainerImage
 from fal.exceptions import (
     AppException,
@@ -694,6 +694,7 @@ def function(
     serve: Literal[False] = False,
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -710,6 +711,7 @@ def function(
     serve: Literal[True],
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -727,6 +729,7 @@ def function(
     serve: Literal[False] = False,
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -756,6 +759,7 @@ def function(
     serve: Literal[True],
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -792,6 +796,7 @@ def function(
     serve: Literal[False] = False,
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -813,6 +818,7 @@ def function(
     serve: Literal[True],
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -835,6 +841,7 @@ def function(
     serve: Literal[False] = False,
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -869,6 +876,7 @@ def function(
     serve: Literal[True],
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -897,6 +905,7 @@ def function(
     serve: Literal[False] = False,
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -925,6 +934,7 @@ def function(
     serve: Literal[True],
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
+    local_python_modules: list[str] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -948,6 +958,7 @@ def function(  # type: ignore
     kind: str = "virtualenv",
     *,
     host: Host | None = None,
+    local_python_modules: list[str] | None = None,
     **config: Any,
 ):
     if host is None:
@@ -956,6 +967,10 @@ def function(  # type: ignore
 
     def wrapper(func: Callable[ArgsT, ReturnT]):
         include_modules_from(func)
+
+        for module_name in local_python_modules or []:
+            include_module(module_name)
+
         proxy = IsolatedFunction(
             host=host,  # type: ignore
             raw_func=func,  # type: ignore

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -122,6 +122,7 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
     wrapper = fal_function(
         kind,
         requirements=cls.requirements,
+        local_python_modules=cls.local_python_modules,
         machine_type=cls.machine_type,
         num_gpus=cls.num_gpus,
         **cls.host_kwargs,
@@ -265,6 +266,7 @@ def _print_python_packages() -> None:
 
 class App(BaseServable):
     requirements: ClassVar[list[str]] = []
+    local_python_modules: ClassVar[list[str]] = []
     machine_type: ClassVar[str] = "S"
     num_gpus: ClassVar[int | None] = None
     host_kwargs: ClassVar[dict[str, Any]] = {

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -21,8 +21,11 @@ def load_function_from(
     file_path: str,
     function_name: str | None = None,
 ) -> LoadedFunction:
+    import os
     import runpy
+    import sys
 
+    sys.path.append(os.getcwd())
     module = runpy.run_path(file_path)
     if function_name is None:
         fal_objects = {


### PR DESCRIPTION
Sometimes users just have their own module lying around next to the fal app python file, which makes it tricky for us to detect when they want to include it into their app or how. This introduces a new `App.local_python_modules` that allows you to just tell us which modules you want us to bring together with the app.

For example, say you have this file structure (parent is not a python module):

```
mymodule/
myfalapp.py
```

now you can just

```
from mymodule import mysetup
 
class MyApp(fal.App, ...):
    requirements = ["torch", ...]
    local_python_modules = ["mymodule"]
    
    def setup(self):
        mysetup()
    ...
```