### PR TITLE
fix(api): expect a different API url message

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -615,7 +615,7 @@ class FalServerlessHost(Host):
         def result_handler(partial_result):
             ret.stream = partial_result.stream
             for log in partial_result.logs:
-                if "Access your exposed service at" in log.message:
+                if "And API access through" in log.message:
                     ret.url = log.message.rsplit()[-1]
                 ret.logs.put(log)
 

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -616,7 +616,7 @@ class FalServerlessHost(Host):
             ret.stream = partial_result.stream
             for log in partial_result.logs:
                 if "And API access through" in log.message:
-                    ret.url = log.message.rsplit()[-1]
+                    ret.url = log.message.rsplit()[-1].replace("queue.", "")
                 ret.logs.put(log)
 
         self._thread_pool.submit(


### PR DESCRIPTION
The message changed in backend making our heuristic break:

```
06/18/2025 09:04:57 [global] [bridge]   [info]    Access the playground at https://fal.ai/dashboard/sdk/fal-ai/5a2c4b72-ecc8-4fc7-ab0a-bb148bc5df75
06/18/2025 09:04:57 [global] [bridge]   [info]    And API access through https://queue.shark.fal.run/fal-ai/5a2c4b72-ecc8-4fc7-ab0a-bb148bc5df75
```