### PR TITLE
feat(fal): introduce bundle_paths

### DIFF
--- a/projects/fal/src/fal/__init__.py
+++ b/projects/fal/src/fal/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fal import apps  # noqa: F401
-from fal.api import BundlePath, FalServerlessHost, LocalHost, cached, function
+from fal.api import FalServerlessHost, LocalHost, cached, function
 from fal.api import function as isolated  # noqa: F401
 from fal.app import App, endpoint, realtime, wrap_app  # noqa: F401
 from fal.container import ContainerImage
@@ -27,6 +27,5 @@ __all__ = [
     "sync_dir",
     "__version__",
     "version_tuple",
-    "BundlePath",
     "ContainerImage",
 ]

--- a/projects/fal/src/fal/__init__.py
+++ b/projects/fal/src/fal/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fal import apps  # noqa: F401
-from fal.api import FalServerlessHost, LocalHost, cached, function
+from fal.api import BundlePath, FalServerlessHost, LocalHost, cached, function
 from fal.api import function as isolated  # noqa: F401
 from fal.app import App, endpoint, realtime, wrap_app  # noqa: F401
 from fal.container import ContainerImage
@@ -27,5 +27,6 @@ __all__ = [
     "sync_dir",
     "__version__",
     "version_tuple",
+    "BundlePath",
     "ContainerImage",
 ]

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -493,10 +493,10 @@ class FalServerlessHost(Host):
             metadata = {}
 
         # TODO: let the user send more metadata than just openapi
-        if isinstance(func, ServeWrapper):
+        if isinstance(func, BundleWrapper) and isinstance(func.func, ServeWrapper):
             # Assigning in a separate property leaving a place for the user
             # to add more metadata in the future
-            metadata["openapi"] = func.openapi()
+            metadata["openapi"] = func.func.openapi()
 
         for partial_result in self._connection.register(
             partial_func,

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -668,6 +668,8 @@ class Options:
 
 _SERVE_PORT = 8080
 
+DEFAULT_BUNDLE_PATHS_IGNORE = ["!*.py"]
+
 # Overload @function to help users identify the correct signature.
 # NOTE: This is both in sync with host options and with environment configs from
 # `isolate` package.
@@ -687,7 +689,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -705,7 +708,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -724,7 +728,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -755,7 +760,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -793,7 +799,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -816,7 +823,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -840,7 +848,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -876,7 +885,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -906,7 +916,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -936,7 +947,8 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -957,29 +969,6 @@ def function(
 
 MAX_BUNDLE_FILE_SIZE = 1024 * 1024  # 1MB
 MAX_BUNDLE_TOTAL_SIZE = 100 * 1024 * 1024  # 100MB
-
-
-def INCLUDE_PYTHON_FILES(path: str) -> bool:
-    if path.endswith(".py"):
-        return True
-    print(f"{path} is not a python file, skipping bundling")
-    return False
-
-
-@dataclass
-class BundlePath:
-    path: str
-    filter: Callable[[str], bool] = field(default=INCLUDE_PYTHON_FILES)
-
-    def __iter__(self) -> Iterator[str]:
-        if os.path.isdir(self.path):
-            for root, _dirs, files in os.walk(self.path):
-                for file in files:
-                    if self.filter(os.path.join(root, file)):
-                        yield os.path.join(root, file)
-        else:
-            if self.filter(self.path):
-                yield self.path
 
 
 @dataclass
@@ -1005,20 +994,19 @@ class Bundle:
         zipfile.write(path, arcname)
 
     @classmethod
-    def from_paths(cls, root: str, paths: list[str | BundlePath]) -> Bundle:
+    def from_paths(cls, root: str, paths: list[str], ignore: list[str]) -> Bundle:
+        import pathspec
+
         buffer = io.BytesIO()
+
+        spec = pathspec.PathSpec.from_lines("gitwildmatch", ignore)
 
         with ZipFile(buffer, "w") as zipfile:
             for path in paths:
-                if isinstance(path, BundlePath):
-                    bundle_path = path
-                    str_path = path.path
+                if not os.path.isabs(path):
+                    str_path = os.path.join(root, path)
                 else:
-                    bundle_path = BundlePath(path)
                     str_path = path
-
-                if not os.path.isabs(str_path):
-                    str_path = os.path.join(root, str_path)
 
                 norm_path = os.path.normpath(str_path)
                 if not norm_path.startswith(root):
@@ -1026,10 +1014,20 @@ class Bundle:
                         f"Bundle path {path} is outside the fal.App directory {root}"
                     )
 
-                bundle_path = BundlePath(norm_path, filter=bundle_path.filter)
-                for file in bundle_path:
-                    arcname = os.path.relpath(file, root)
-                    cls._add_file(zipfile, file, arcname)
+                if os.path.isdir(norm_path):
+                    # Use pathspec's match_tree to get all files that should be included
+                    # (not ignored by the spec)
+                    for file_path in spec.match_tree(norm_path, negate=True):
+                        # file_path is relative to norm_path, so we need to make
+                        # it absolute
+                        absolute_file_path = os.path.join(norm_path, file_path)
+                        arcname = os.path.relpath(absolute_file_path, root)
+                        cls._add_file(zipfile, absolute_file_path, arcname)
+                else:
+                    # Single file - check if it should be included
+                    arcname = os.path.relpath(norm_path, root)
+                    if not spec.match_file(arcname):
+                        cls._add_file(zipfile, norm_path, arcname)
 
         zipfile_bytes = buffer.getvalue()
         size = len(zipfile_bytes)
@@ -1052,7 +1050,8 @@ def function(  # type: ignore
     *,
     host: Host | None = None,
     local_python_modules: list[str] | None = None,
-    bundle_paths: list[str | BundlePath] | None = None,
+    bundle_paths: list[str] | None = None,
+    bundle_paths_ignore: list[str] | None = DEFAULT_BUNDLE_PATHS_IGNORE,
     **config: Any,
 ):
     if host is None:
@@ -1075,8 +1074,14 @@ def function(  # type: ignore
 
         if bundle_paths and not isinstance(bundle_paths, list):
             raise ValueError(
-                "bundle_paths must be a list of str or BundlePath paths to bundle, got "
+                "bundle_paths must be a list of str paths to bundle, got "
                 f"{repr(bundle_paths)}"
+            )
+
+        if bundle_paths_ignore and not isinstance(bundle_paths_ignore, list):
+            raise ValueError(
+                "bundle_paths_ignore must be a list of str paths to ignore, got "
+                f"{repr(bundle_paths_ignore)}"
             )
 
         for idx, module_name in enumerate(local_python_modules or []):
@@ -1092,6 +1097,7 @@ def function(  # type: ignore
             raw_func=func,  # type: ignore
             options=options,
             bundle_paths=bundle_paths,
+            bundle_paths_ignore=bundle_paths_ignore,
         )
         return wraps(func)(proxy)  # type: ignore
 
@@ -1395,7 +1401,8 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     host: Host[ArgsT, ReturnT]
     raw_func: Callable[ArgsT, ReturnT]
     options: Options
-    bundle_paths: list[str | BundlePath] | None
+    bundle_paths: list[str] | None
+    bundle_paths_ignore: list[str] | None
     executor: ThreadPoolExecutor = field(default_factory=ThreadPoolExecutor)
     reraise: bool = True
 
@@ -1525,8 +1532,8 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
                 )
             root = os.path.dirname(file_path)
 
-        bundle = (
-            Bundle.from_paths(root, self.bundle_paths) if self.bundle_paths else None
+        bundle = Bundle.from_paths(
+            root, self.bundle_paths or [], self.bundle_paths_ignore or []
         )
 
         return BundleWrapper(func, bundle)

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -1550,6 +1550,8 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
                 )
             root = os.path.dirname(file_path)
 
+        assert os.path.isabs(root)
+
         if self.context_dir is not None and os.path.isabs(self.context_dir):
             context_dir = self.context_dir
         else:

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -1052,6 +1052,7 @@ def function(  # type: ignore
     *,
     host: Host | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     **config: Any,
 ):
     if host is None:
@@ -1061,7 +1062,7 @@ def function(  # type: ignore
     if config.get("image"):
         kind = "container"
 
-    options = host.parse_options(kind=kind, **config)
+    options = host.parse_options(kind=kind, bundle_paths=bundle_paths, **config)
 
     def wrapper(func: Callable[ArgsT, ReturnT]):
         include_modules_from(func)
@@ -1072,7 +1073,6 @@ def function(  # type: ignore
                 f"{repr(local_python_modules)}"
             )
 
-        bundle_paths = config.get("bundle_paths", None)
         if bundle_paths and not isinstance(bundle_paths, list):
             raise ValueError(
                 "bundle_paths must be a list of str or BundlePath paths to bundle, got "

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import io
 import os
 import sys
 import threading
@@ -25,6 +26,7 @@ from typing import (
     cast,
     overload,
 )
+from zipfile import ZipFile
 
 import cloudpickle
 import grpc
@@ -673,7 +675,7 @@ _SERVE_PORT = 8080
 
 ## virtualenv
 ### LocalHost
-@overload
+@overload  # type: ignore
 def function(
     kind: Literal["virtualenv"] = "virtualenv",
     *,
@@ -685,6 +687,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -702,6 +705,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -720,6 +724,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -750,6 +755,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -787,6 +793,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], IsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -809,6 +816,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
 ) -> Callable[
     [Callable[Concatenate[ArgsT], ReturnT]], ServedIsolatedFunction[ArgsT, ReturnT]
 ]: ...
@@ -832,6 +840,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -867,6 +876,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -896,6 +906,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -925,6 +936,7 @@ def function(
     exposed_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     # FalServerlessHost options
     metadata: dict[str, Any] | None = None,
     machine_type: str | list[str] = FAL_SERVERLESS_DEFAULT_MACHINE_TYPE,
@@ -943,12 +955,95 @@ def function(
 ]: ...
 
 
+MAX_BUNDLE_FILE_SIZE = 1024 * 1024  # 1MB
+
+
+def INCLUDE_PYTHON_FILES(path: str) -> bool:
+    return path.endswith(".py")
+
+
+@dataclass
+class BundlePath:
+    path: str
+    filter: Callable[[str], bool] = field(default=INCLUDE_PYTHON_FILES)
+
+    def __iter__(self) -> Iterator[str]:
+        if os.path.isdir(self.path):
+            for root, _dirs, files in os.walk(self.path):
+                for file in files:
+                    if self.filter(os.path.join(root, file)):
+                        yield os.path.join(root, file)
+        else:
+            if self.filter(self.path):
+                yield self.path
+
+
+@dataclass
+class Bundle:
+    zipfile_bytes: bytes
+    _zipfile: ZipFile | None = None
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "zipfile_bytes": self.zipfile_bytes,
+        }
+
+    def __setstate__(self, state: dict[str, Any]):
+        self.zipfile_bytes = state["zipfile_bytes"]
+
+    @classmethod
+    def _add_file(cls, zipfile: ZipFile, path: str, arcname: str):
+        size = os.path.getsize(path)
+        if size > MAX_BUNDLE_FILE_SIZE:
+            print(
+                f"Bundled file {path} is larger than"
+                f"{MAX_BUNDLE_FILE_SIZE} bytes, skipping"
+            )
+            return
+        zipfile.write(path, arcname)
+
+    @classmethod
+    def from_paths(cls, root: str, paths: list[str | BundlePath]) -> Bundle:
+        buffer = io.BytesIO()
+
+        with ZipFile(buffer, "w") as zipfile:
+            for path in paths:
+                if isinstance(path, BundlePath):
+                    bundle_path = path
+                    str_path = path.path
+                else:
+                    bundle_path = BundlePath(path)
+                    str_path = path
+
+                if not os.path.isabs(str_path):
+                    str_path = os.path.join(root, str_path)
+
+                norm_path = os.path.normpath(str_path)
+                if not norm_path.startswith(root):
+                    raise ValueError(
+                        f"Bundle path {path} is outside the fal.App directory {root}"
+                    )
+
+                bundle_path = BundlePath(norm_path, filter=bundle_path.filter)
+                for file in bundle_path:
+                    arcname = os.path.relpath(file, root)
+                    cls._add_file(zipfile, file, arcname)
+
+        return cls(buffer.getvalue())
+
+    def unpack(self, path: str):
+        buffer = io.BytesIO(self.zipfile_bytes)
+        with ZipFile(buffer, "r") as zipfile:
+            zipfile.extractall(path)
+
+
 # implementation
 def function(  # type: ignore
     kind: str = "virtualenv",
     *,
     host: Host | None = None,
     local_python_modules: list[str] | None = None,
+    bundle_paths: list[str | BundlePath] | None = None,
     **config: Any,
 ):
     if host is None:
@@ -969,6 +1064,12 @@ def function(  # type: ignore
                 f"{repr(local_python_modules)}"
             )
 
+        if bundle_paths and not isinstance(bundle_paths, list):
+            raise ValueError(
+                "bundle_paths must be a list of str or BundlePath paths to bundle, got "
+                f"{repr(bundle_paths)}"
+            )
+
         for idx, module_name in enumerate(local_python_modules or []):
             if not isinstance(module_name, str):
                 raise ValueError(
@@ -977,10 +1078,14 @@ def function(  # type: ignore
                 )
             include_module(module_name)
 
+        root = os.path.dirname(func.__code__.co_filename)
+        bundle = Bundle.from_paths(root, bundle_paths) if bundle_paths else None
+
         proxy = IsolatedFunction(
             host=host,  # type: ignore
             raw_func=func,  # type: ignore
             options=options,
+            bundle=bundle,
         )
         return wraps(func)(proxy)  # type: ignore
 
@@ -1264,6 +1369,21 @@ class ServeWrapper(BaseServable):
         self.serve()
 
 
+class BundleWrapper:
+    func: Callable
+    bundle: Bundle | None
+
+    def __init__(self, func: Callable, bundle: Bundle | None):
+        self.func = func
+        self.bundle = bundle
+
+    def __call__(self, *args, **kwargs) -> Any:
+        if self.bundle is not None:
+            self.bundle.unpack(os.getcwd())
+            sys.path.insert(0, os.getcwd())
+        return self.func(*args, **kwargs)
+
+
 @dataclass
 class IsolatedFunction(Generic[ArgsT, ReturnT]):
     host: Host[ArgsT, ReturnT]
@@ -1271,6 +1391,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     options: Options
     executor: ThreadPoolExecutor = field(default_factory=ThreadPoolExecutor)
     reraise: bool = True
+    bundle: Bundle | None = None
 
     def __getstate__(self) -> dict[str, Any]:
         # Ensure that the executor is not pickled.
@@ -1308,7 +1429,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     def __call__(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
         try:
             return self.host.run(
-                self.func,
+                BundleWrapper(self.func, self.bundle),
                 self.options,
                 args=args,
                 kwargs=kwargs,

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -125,7 +125,6 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
         kind,
         requirements=cls.requirements,
         local_python_modules=cls.local_python_modules,
-        bundle_paths=cls.bundle_paths,
         machine_type=cls.machine_type,
         num_gpus=cls.num_gpus,
         **cls.host_kwargs,
@@ -349,6 +348,9 @@ class App(BaseServable):
             cls.host_kwargs["startup_timeout"] = cls.startup_timeout
 
         cls.app_name = getattr(cls, "app_name", app_name)
+
+        if cls.bundle_paths is not None:
+            cls.host_kwargs["bundle_paths"] = cls.bundle_paths
 
         if cls.__init__ is not App.__init__:
             raise ValueError(

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -318,6 +318,8 @@ class App(BaseServable):
     requirements: ClassVar[list[str]] = []
     local_python_modules: ClassVar[list[str]] = []
     bundle_paths: ClassVar[list[str]] = []
+    bundle_paths_ignore: ClassVar[list[str]] = []
+    context_dir: ClassVar[str | None] = None
     machine_type: ClassVar[str] = "S"
     num_gpus: ClassVar[int | None] = None
     host_kwargs: ClassVar[dict[str, Any]] = {
@@ -350,6 +352,12 @@ class App(BaseServable):
 
         if cls.bundle_paths is not None:
             cls.host_kwargs["bundle_paths"] = cls.bundle_paths
+
+        if cls.bundle_paths_ignore is not None:
+            cls.host_kwargs["bundle_paths_ignore"] = cls.bundle_paths_ignore
+
+        if cls.context_dir is not None:
+            cls.host_kwargs["context_dir"] = cls.context_dir
 
         if cls.__init__ is not App.__init__:
             raise ValueError(

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -21,6 +21,7 @@ from fal._serialization import include_modules_from
 from fal.api import (
     SERVE_REQUIREMENTS,
     BaseServable,
+    BundlePath,
     IsolatedFunction,
     RouteSignature,
 )
@@ -118,6 +119,7 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
         kind,
         requirements=cls.requirements,
         local_python_modules=cls.local_python_modules,
+        bundle_paths=cls.bundle_paths,
         machine_type=cls.machine_type,
         num_gpus=cls.num_gpus,
         **cls.host_kwargs,
@@ -299,6 +301,7 @@ def _print_python_packages() -> None:
 class App(BaseServable):
     requirements: ClassVar[list[str]] = []
     local_python_modules: ClassVar[list[str]] = []
+    bundle_paths: ClassVar[list[str | BundlePath]] = []
     machine_type: ClassVar[str] = "S"
     num_gpus: ClassVar[int | None] = None
     host_kwargs: ClassVar[dict[str, Any]] = {

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -21,7 +21,6 @@ from fal._serialization import include_modules_from
 from fal.api import (
     SERVE_REQUIREMENTS,
     BaseServable,
-    BundlePath,
     IsolatedFunction,
     RouteSignature,
 )
@@ -318,7 +317,7 @@ def _print_python_packages() -> None:
 class App(BaseServable):
     requirements: ClassVar[list[str]] = []
     local_python_modules: ClassVar[list[str]] = []
-    bundle_paths: ClassVar[list[str | BundlePath]] = []
+    bundle_paths: ClassVar[list[str]] = []
     machine_type: ClassVar[str] = "S"
     num_gpus: ClassVar[int | None] = None
     host_kwargs: ClassVar[dict[str, Any]] = {

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -98,12 +98,18 @@ async def _set_logger_labels(
         pass
 
 
+class InitializeAndServe:
+    def __init__(self, cls: type[App], file_path: str):
+        self.cls = cls
+        self.__file__ = file_path
+
+    def __call__(self):
+        app = self.cls()
+        app.serve()
+
+
 def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
     include_modules_from(cls)
-
-    def initialize_and_serve():
-        app = cls()
-        app.serve()
 
     metadata = {}
     app = cls(_allow_init=True)
@@ -128,7 +134,19 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
         exposed_port=8080,
         serve=False,
     )
-    fn = wrapper(initialize_and_serve)
+
+    file_path = getattr(cls, "__file__", None)
+    if file_path is None:
+        module = inspect.getmodule(cls)
+        file_path = getattr(module, "__file__", None)
+
+    if not file_path:
+        raise ValueError(
+            f"Couldn't determine the root directory of the {cls.__name__}. "
+            "Please contact fal support."
+        )
+
+    fn = wrapper(InitializeAndServe(cls, file_path))
     fn.options.add_requirements(SERVE_REQUIREMENTS)
     if realtime_app:
         fn.options.add_requirements(REALTIME_APP_REQUIREMENTS)

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -58,6 +58,7 @@ def load_function_from(
     fal._serialization.include_package_from_path(file_path)
 
     target = module[function_name]
+    target.__file__ = module["__file__"]
     endpoints = ["/"]
     if isinstance(target, type) and issubclass(target, App):
         app_name = target.app_name

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -58,7 +58,7 @@ def load_function_from(
     fal._serialization.include_package_from_path(file_path)
 
     target = module[function_name]
-    target.__file__ = module["__file__"]
+    target.__file__ = os.path.abspath(module["__file__"])
     endpoints = ["/"]
     if isinstance(target, type) and issubclass(target, App):
         app_name = target.app_name

--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import subprocess
-import uuid
 import textwrap
+import uuid
 from contextlib import suppress
 
 import pytest

--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -693,7 +693,14 @@ def test_on_changes():
     assert "machine_type" not in op.host, "machine_type set in local host"
 
 
-def test_bundle_paths(tmpdir):
+@pytest.mark.parametrize(
+    "bundle_paths",
+    [
+        ["foo.py", "bar"],
+        ["."],
+    ],
+)
+def test_bundle_paths(tmpdir, bundle_paths):
     (tmpdir / "foo.py").write_text("def foo(): return 'foo'", encoding="utf-8")
     (tmpdir / "bar").mkdir()
     (tmpdir / "bar" / "__init__.py").write_text(
@@ -701,6 +708,41 @@ def test_bundle_paths(tmpdir):
     )
     (tmpdir / "bar" / "baz").mkdir()
     (tmpdir / "bar" / "baz" / "__init__.py").write_text(
+        "def baz(): return 'baz'", encoding="utf-8"
+    )
+    (tmpdir / "myfunc.py").write_text(
+        textwrap.dedent(
+            f"""
+            import fal
+
+            @fal.function(bundle_paths={str(bundle_paths)})
+            def myfunc():
+                from bar import bar
+                from bar.baz import baz
+                from foo import foo
+
+                return foo() + bar() + baz()
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    host = FalServerlessHost()
+    file_path = str(tmpdir / "myfunc.py")
+    func_name = "myfunc"
+    loaded = load_function_from(host, file_path, func_name)
+    isolated_function = loaded.function
+    assert isolated_function() == "foobarbaz"
+
+
+def test_bundle_paths_limits(tmpdir, monkeypatch):
+    (tmpdir / "foo.py").write_text("d", encoding="utf-8")
+    (tmpdir / "bar").mkdir()
+    (tmpdir / "bar" / "__init__.py").write_text(
+        "from .baz import baz\ndef bar(): return 'bar'", encoding="utf-8"
+    )
+    (tmpdir / "baz").mkdir()
+    (tmpdir / "baz" / "__init__.py").write_text(
         "def baz(): return 'baz'", encoding="utf-8"
     )
     (tmpdir / "myfunc.py").write_text(
@@ -723,6 +765,13 @@ def test_bundle_paths(tmpdir):
     host = FalServerlessHost()
     file_path = str(tmpdir / "myfunc.py")
     func_name = "myfunc"
-    loaded = load_function_from(host, file_path, func_name)
-    isolated_function = loaded.function
-    assert isolated_function() == "foobarbaz"
+
+    with monkeypatch.context() as m:
+        m.setattr(fal.api, "MAX_BUNDLE_TOTAL_SIZE", 1)
+        with pytest.raises(ValueError, match="Bundle size is too big"):
+            load_function_from(host, file_path, func_name)
+
+    with monkeypatch.context() as m:
+        m.setattr(fal.api, "MAX_BUNDLE_FILE_SIZE", 1)
+        with pytest.raises(ValueError, match=r"Bundle file .* is larger than"):
+            load_function_from(host, file_path, func_name)

--- a/projects/fal/tests/test_stability.py
+++ b/projects/fal/tests/test_stability.py
@@ -769,9 +769,11 @@ def test_bundle_paths_limits(tmpdir, monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(fal.api, "MAX_BUNDLE_TOTAL_SIZE", 1)
         with pytest.raises(ValueError, match="Bundle size is too big"):
-            load_function_from(host, file_path, func_name)
+            loaded = load_function_from(host, file_path, func_name)
+            loaded.function()
 
     with monkeypatch.context() as m:
         m.setattr(fal.api, "MAX_BUNDLE_FILE_SIZE", 1)
         with pytest.raises(ValueError, match=r"Bundle file .* is larger than"):
-            load_function_from(host, file_path, func_name)
+            loaded = load_function_from(host, file_path, func_name)
+            loaded.function()


### PR DESCRIPTION
```
class MyApp(fal.App):
    bundle_paths = ["foo", "bar"]
```

these files/directories relative to the MyApp file location are going to be included into our pickled code and then remotely unpacked into the current directory preserving the same path structure. By default we only include `*.py` files, but one could also use their own filter:

```
from fal import BundlePath

def myfilter(path: str) -> bool:
    return path.endswith(".py") or path.endswith(".json")

class MyApp(fal.App):
    bundle_paths = ["foo", BundlePath("bar", filter=myfilter)]
```

This works for both functions and apps.