### PR TITLE
refactor: profile command remove default profile

### DIFF
--- a/projects/fal/src/fal/cli/profile.py
+++ b/projects/fal/src/fal/cli/profile.py
@@ -23,14 +23,38 @@ def _list(args):
 
 
 def _set(args):
-    with Config().edit() as config:
-        config.set_internal("profile", args.PROFILE)
-        args.console.print(f"Default profile set to [cyan]{args.PROFILE}[/].")
-        config.profile = args.PROFILE
-        if not config.get("key"):
+    config = Config()
+
+    # Check if the profile exists
+    if args.PROFILE not in config._config:
+        # Profile doesn't exist, offer to create it
+        args.console.print(f"Profile [cyan]{args.PROFILE}[/] does not exist.")
+        create_profile = input("Would you like to create it? (y/N): ").strip().lower()
+
+        if create_profile in ["y", "yes"]:
+            # Create the profile by setting it
+            with config.edit() as config:
+                config.set_internal("profile", args.PROFILE)
+                config._config[args.PROFILE] = {}
+                config._profile = args.PROFILE
             args.console.print(
-                "No key set for profile. Use [bold]fal profile key[/] to set a key."
+                f"Profile [cyan]{args.PROFILE}[/] created and set as default."
             )
+        else:
+            args.console.print("Profile creation cancelled.")
+            return
+    else:
+        # Profile exists, just set it as default
+        with config.edit() as config:
+            config.set_internal("profile", args.PROFILE)
+            config._profile = args.PROFILE
+        args.console.print(f"Default profile set to [cyan]{args.PROFILE}[/].")
+
+    # Check if key is set for the profile
+    if not config.get("key"):
+        args.console.print(
+            "No key set for profile. Use [bold]fal profile key[/] to set a key."
+        )
 
 
 def _unset(args, config: Config | None = None):
@@ -42,6 +66,8 @@ def _unset(args, config: Config | None = None):
 
 
 def _key_set(args):
+    config = Config(validate_profile=True)
+
     while True:
         key = input("Enter the key: ")
         if ":" in key:
@@ -50,7 +76,7 @@ def _key_set(args):
             "[red]Invalid key. The key must be in the format [bold]key:value[/].[/]"
         )
 
-    with Config().edit() as config:
+    with config.edit():
         config.set("key", key)
         args.console.print(f"Key set for profile [cyan]{config.profile}[/].")
 
@@ -59,6 +85,24 @@ def _host_set(args):
     with Config().edit() as config:
         config.set("host", args.HOST)
         args.console.print(f"Fal host set to [cyan]{args.HOST}[/].")
+
+
+def _create(args):
+    config = Config()
+
+    # Check if the profile already exists
+    if args.PROFILE in config._config:
+        args.console.print(f"Profile [cyan]{args.PROFILE}[/] already exists.")
+        return
+
+    # Create the profile
+    with config.edit() as config:
+        config._config[args.PROFILE] = {}
+
+    args.console.print(f"Profile [cyan]{args.PROFILE}[/] created.")
+    args.console.print(
+        f"Use [bold]fal profile set {args.PROFILE}[/] to set it as default."
+    )
 
 
 def _delete(args):
@@ -96,7 +140,7 @@ def add_parser(main_subparsers, parents):
     )
     list_parser.set_defaults(func=_list)
 
-    set_help = "Set default profile."
+    set_help = "Set default profile. If the profile doesn't exist, you'll be prompted to create it."  # noqa: E501
     set_parser = subparsers.add_parser(
         "set",
         description=set_help,
@@ -139,6 +183,19 @@ def add_parser(main_subparsers, parents):
         help="Fal host.",
     )
     host_set_parser.set_defaults(func=_host_set)
+
+    create_help = "Create a new profile. Use 'fal profile set <name>' to set it as default after creation."  # noqa: E501
+    create_parser = subparsers.add_parser(
+        "create",
+        description=create_help,
+        help=create_help,
+        parents=parents,
+    )
+    create_parser.add_argument(
+        "PROFILE",
+        help="Profile name.",
+    )
+    create_parser.set_defaults(func=_create)
 
     delete_help = "Delete profile."
     delete_parser = subparsers.add_parser(


### PR DESCRIPTION
I have found myself making mistakes by always having some profile set. Making it so you _can_ have no profile enabled is a easier to understand experience.

Here we remove the default profile 'default' and we also ask if the user wants to create a new profile when an unknown name is set.

We also offer a `fal profile create <name>` command.

Finally, if no profile is set, `fal profile key` and `fal profile host` will now fail