### PR TITLE
feat: make --no-scale the default and introduce --reset-scale

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -12,7 +12,7 @@ def get_client(host: str, team: str | None = None):
 
 def is_app_name(app_ref: tuple[str, str | None]) -> bool:
     is_single_file = app_ref[1] is None
-    is_python_file = app_ref[0].endswith(".py")
+    is_python_file = app_ref[0] is None or app_ref[0].endswith(".py")
 
     return is_single_file and not is_python_file
 
@@ -42,9 +42,16 @@ def get_app_data_from_toml(app_name):
 
     app_auth = app_data.pop("auth", "private")
     app_deployment_strategy = app_data.pop("deployment_strategy", "recreate")
-    app_no_scale = app_data.pop("no_scale", False)
+
+    if "no_scale" in app_data:
+        # Deprecated
+        app_no_scale = app_data.pop("no_scale")
+        print("[WARNING] no_scale is deprecated, use app_scale_settings instead")
+        app_reset_scale = not app_no_scale
+    else:
+        app_reset_scale = app_data.pop("app_scale_settings", False)
 
     if len(app_data) > 0:
         raise ValueError(f"Found unexpected keys in pyproject.toml: {app_data}")
 
-    return app_ref, app_auth, app_deployment_strategy, app_no_scale
+    return app_ref, app_auth, app_deployment_strategy, app_reset_scale

--- a/projects/fal/tests/cli/test_deploy.py
+++ b/projects/fal/tests/cli/test_deploy.py
@@ -39,7 +39,7 @@ def mock_args(
     app_name: Optional[str] = None,
     auth: Optional[str] = None,
     strategy: Optional[str] = None,
-    no_scale: bool = False,
+    reset_scale: bool = False,
 ):
     args = MagicMock()
 
@@ -47,8 +47,7 @@ def mock_args(
     args.app_name = app_name
     args.auth = auth
     args.strategy = strategy
-
-    args.no_scale = no_scale
+    args.app_scale_settings = reset_scale
 
     return args
 
@@ -287,12 +286,12 @@ def test_deploy_with_cli_deployment_strategy(
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 @patch("fal.cli.deploy._deploy_from_reference")
-def test_deploy_with_cli_no_scale(
+def test_deploy_with_cli_reset_scale(
     mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
-    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"), no_scale=True)
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"), reset_scale=True)
 
     _deploy(args)
 
@@ -302,7 +301,7 @@ def test_deploy_with_cli_no_scale(
         args,
         None,
         None,
-        scale=False,
+        scale=True,
     )
 
 


### PR DESCRIPTION
```
❯ fal deploy --help
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 1.27.1  │
│                                             │
│          pip install --upgrade fal          │
│                                             │
╰─────────────────────────────────────────────╯
Usage: fal deploy [-h] [--debug] [--pdb] [--cprofile] [--team TEAM] [--app-name APP_NAME] [--auth AUTH] [--strategy {recreate,rolling}] [--no-scale] [--reset-scale] [app_ref]

Deploy a fal application. If no app reference is provided, the command will look for a pyproject.toml file with a  section and deploy the application specified with the provided app name.

Positional Arguments:
  app_ref               Application reference. Either a file path or a file path and a function name separated by '::'. If no reference is provided, the command will look for a pyproject.toml file with a  section and deploy the application specified with the provided app name.
                        File path example: path/to/myfile.py::MyApp
                        App name example: my-app

Options:
  -h, --help            show this help message and exit
  --team TEAM           The team to use.
  --app-name APP_NAME   Application name to deploy with.
  --auth AUTH           Application authentication mode (private, public).
  --strategy {recreate,rolling}
                        Deployment strategy.
  --no-scale            Use the previous deployment of the application for scale settings. This is the default behavior.
  --reset-scale         Use the application code for scale settings.

Debug:
  --debug               Show verbose errors.
  --pdb                 Start pdb on error.
  --cprofile            Show cProfile report.

Examples:
  fal deploy
  fal deploy path/to/myfile.py
  fal deploy path/to/myfile.py::MyApp
  fal deploy path/to/myfile.py::MyApp --app-name myapp --auth public
  fal deploy my-app
```


```
❯ fal deploy t/bbasic.py
==> Preparing the environment
1970-01-01 00:00:00.000 [info     ] Using scaling options from previous revision
Registered a new revision for function 'basic' (revision='311ffcec-0c54-4c3d-8fda-ec8673d7362e').
```



```
❯ fal deploy t/bbasic.py --no-scale
==> Preparing the environment
1970-01-01 00:00:00.000 [info     ] Using scaling options from previous revision
Registered a new revision for function 'basic' (revision='311ffcec-0c54-4c3d-8fda-ec8673d7362e').
```


```
❯ fal deploy t/bbasic.py --reset-scale
Registered a new revision for function 'basic' (revision='1c4fa5b5-932c-4129-bde7-b66f1bee0d02').
```