### PR TITLE
feat: assume kind=container when image is passed

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -953,6 +953,11 @@ def function(  # type: ignore
 ):
     if host is None:
         host = FalServerlessHost()
+
+    # NOTE: assuming kind="container" if image is provided
+    if config.get("image"):
+        kind = "container"
+
     options = host.parse_options(kind=kind, **config)
 
     def wrapper(func: Callable[ArgsT, ReturnT]):


### PR DESCRIPTION
Simple convenience feature that makes us no longer error out with

```
Unexpected <class 'TypeError'>: VirtualPythonEnvironment.__init__() got an unexpected keyword argument 'image'
```