### PR TITLE
feat(fal): print routes for ephemeral runs

### DIFF
--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -604,7 +604,7 @@ class FalServerlessHost(Host):
 
             if service_urls := partial_result.service_urls:
                 console.print("Playground:")
-                endpoints = func._routes  # type: ignore[attr-defined]
+                endpoints = func._routes or ["/"]  # type: ignore[attr-defined]
                 for endpoint in endpoints:
                     console.print(f"\t{service_urls.playground}{endpoint}")
                 console.print("Synchronous Endpoints:")
@@ -615,6 +615,12 @@ class FalServerlessHost(Host):
                     console.print(f"\t{service_urls.queue}{endpoint}")
 
             for log in partial_result.logs:
+                if (
+                    "Access the playground at" in log.message
+                    or "And API access through" in log.message
+                ):
+                    # Obsolete messages from before service_urls were added.
+                    continue
                 self._log_printer.print(log)
 
         return self._run(func, options, args, kwargs, result_handler=result_handler)

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -600,8 +600,22 @@ class FalServerlessHost(Host):
         kwargs: dict[str, Any],
     ) -> ReturnT:
         def result_handler(partial_result):
+            from isolate.logs import Log, LogLevel, LogSource
+
             for log in partial_result.logs:
                 self._log_printer.print(log)
+
+                if "Access the playground at" in log.message:
+                    _url = log.message.rsplit()[-1]
+                    for route in func._routes:  # type: ignore[attr-defined]
+                        self._log_printer.print(
+                            Log(
+                                message=f"{_url}{route}",
+                                source=LogSource.USER,
+                                level=LogLevel.INFO,
+                                timestamp=log.timestamp,
+                            )
+                        )
 
         return self._run(func, options, args, kwargs, result_handler=result_handler)
 

--- a/projects/fal/src/fal/api.py
+++ b/projects/fal/src/fal/api.py
@@ -600,22 +600,22 @@ class FalServerlessHost(Host):
         kwargs: dict[str, Any],
     ) -> ReturnT:
         def result_handler(partial_result):
-            from isolate.logs import Log, LogLevel, LogSource
+            from fal.console import console
+
+            if service_urls := partial_result.service_urls:
+                console.print("Playground:")
+                endpoints = func._routes  # type: ignore[attr-defined]
+                for endpoint in endpoints:
+                    console.print(f"\t{service_urls.playground}{endpoint}")
+                console.print("Synchronous Endpoints:")
+                for endpoint in endpoints:
+                    console.print(f"\t{service_urls.run}{endpoint}")
+                console.print("Asynchronous Endpoints (Recommended):")
+                for endpoint in endpoints:
+                    console.print(f"\t{service_urls.queue}{endpoint}")
 
             for log in partial_result.logs:
                 self._log_printer.print(log)
-
-                if "Access the playground at" in log.message:
-                    _url = log.message.rsplit()[-1]
-                    for route in func._routes:  # type: ignore[attr-defined]
-                        self._log_printer.print(
-                            Log(
-                                message=f"{_url}{route}",
-                                source=LogSource.USER,
-                                level=LogLevel.INFO,
-                                timestamp=log.timestamp,
-                            )
-                        )
 
         return self._run(func, options, args, kwargs, result_handler=result_handler)
 

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -110,6 +110,7 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
     metadata["openapi"] = app.openapi()
 
     routes = app.collect_routes()
+    initialize_and_serve._routes = [r.path for r in routes.keys()]  # type: ignore[attr-defined]
     realtime_app = any(route.is_websocket for route in routes)
 
     kind = cls.host_kwargs.pop("kind", "virtualenv")


### PR DESCRIPTION
introduce a hacky solution to print the routes for ephemeral runs. at the moment only the root path is being printed and then the user needs to copy-paste an existing endpoint to playground url to render the playground. however this is really boring and time-consuming. this will make sure all of the endpoints are being printed  