### PR TITLE
ui(deploy): show sync and async endpoints

### DIFF
--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -142,10 +142,15 @@ def _deploy_from_reference(
                 args.console.print(
                     f"\thttps://{playground_host}/models/{user.username}/{app_name}{endpoint}"
                 )
-            args.console.print("Endpoints:")
+            args.console.print("Synchronous Endpoints:")
             for endpoint in loaded.endpoints:
                 args.console.print(
                     f"\thttps://{endpoint_host}/{user.username}/{app_name}{endpoint}"
+                )
+            args.console.print("Asynchronous Endpoints (Recommended):")
+            for endpoint in loaded.endpoints:
+                args.console.print(
+                    f"\thttps://queue.{endpoint_host}/{user.username}/{app_name}{endpoint}"
                 )
 
 


### PR DESCRIPTION
```
==> Setting up runtime
2025-08-22 14:23:07.769 [info     ] Using scaling options from previous revision
Registered a new revision for function 'sana' (revision='8eb845b2-6084-44c5-bce8-f496c9f6d8dc').
Playground:
        https://fal.ai/models/efiop/sana/
Synchronous Endpoints:
        https://fal.run/efiop/sana/
Asynchronous Endpoints (Recommended):
        https://queue.fal.run/efiop/sana/
```