### PR TITLE
chore: bump structlog version

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "dill==0.3.7",
     "cloudpickle==3.0.0",
     "typing-extensions>=4.7.1,<5",
-    "structlog>=22.3.0,<23",
+    "structlog>=22.3.0,<24.3.0",
     "opentelemetry-api>=1.15.0,<2",
     "opentelemetry-sdk>=1.15.0,<2",
     "grpc-interceptor>=0.15.0,<1",


### PR DESCRIPTION
Bumps structlog to include some 24.x versions