### PR TITLE
chore(cli): hide internal debug options

### DIFF
--- a/projects/fal/src/fal/cli/debug.py
+++ b/projects/fal/src/fal/cli/debug.py
@@ -1,3 +1,4 @@
+import argparse
 from contextlib import ExitStack, contextmanager
 
 from .parser import FalParser
@@ -45,17 +46,23 @@ def debugtools(args):
 
 
 def get_debug_parser():
+    from fal.flags import DEBUG
+
     parser = FalParser(add_help=False)
     group = parser.add_argument_group(title="Debug")
-    group.add_argument("--debug", action="store_true", help="Show verbose errors.")
+    group.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show verbose errors." if DEBUG else argparse.SUPPRESS,
+    )
     group.add_argument(
         "--pdb",
         action="store_true",
-        help="Start pdb on error.",
+        help="Start pdb on error." if DEBUG else argparse.SUPPRESS,
     )
     group.add_argument(
         "--cprofile",
         action="store_true",
-        help="Show cProfile report.",
+        help="Show cProfile report." if DEBUG else argparse.SUPPRESS,
     )
     return parser


### PR DESCRIPTION
These were only meant for internal use, but users are getting confused and trying to use these for user code for which we already show pretty tracebacks by default. Lets hide these for now. In the future `--pdb` and `--cprofile` will support user code as well, but not now.