### PR TITLE
fix(fal): set soft_wrap=True for rich Console

### DIFF
--- a/projects/fal/src/fal/console/__init__.py
+++ b/projects/fal/src/fal/console/__init__.py
@@ -3,4 +3,4 @@ from __future__ import annotations
 from rich.console import Console
 from rich.theme import Theme
 
-console = Console(theme=Theme())
+console = Console(theme=Theme(), soft_wrap=True)


### PR DESCRIPTION
Prevents broken links in some terminals with small window sizes.