### PR TITLE
feat(cli): introduce --output json for fal runners list

### DIFF
--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -8,7 +8,7 @@ import fal.cli.runners as runners
 from fal.sdk import RunnerState
 
 from ._utils import get_client
-from .parser import FalClientParser
+from .parser import FalClientParser, get_output_parser
 
 if TYPE_CHECKING:
     from fal.sdk import AliasInfo, ApplicationInfo
@@ -72,6 +72,8 @@ def _list(args):
             apps_as_dicts = [asdict(a) for a in apps]
             res = json.dumps({"apps": apps_as_dicts})
             args.console.print(res)
+        else:
+            raise AssertionError(f"Invalid output format: {args.output}")
 
 
 def _add_list_parser(subparsers, parents):
@@ -80,7 +82,7 @@ def _add_list_parser(subparsers, parents):
         "list",
         description=list_help,
         help=list_help,
-        parents=parents,
+        parents=[*parents, get_output_parser()],
     )
     parser.add_argument(
         "--sort-by-runners",
@@ -91,13 +93,6 @@ def _add_list_parser(subparsers, parents):
         "--filter",
         type=str,
         help="Filter applications by alias contents",
-    )
-    parser.add_argument(
-        "--output",
-        type=str,
-        default="pretty",
-        choices=["pretty", "json"],
-        help="Modify the command output",
     )
     parser.set_defaults(func=_list)
 

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
 
 from ._utils import get_app_data_from_toml, is_app_name
-from .parser import FalClientParser, RefAction
+from .parser import FalClientParser, RefAction, get_output_parser
 
 User = namedtuple("User", ["user_id", "username"])
 
@@ -152,6 +152,8 @@ def _deploy_from_reference(
                 args.console.print(
                     f"\thttps://queue.{endpoint_host}/{user.username}/{app_name}{endpoint}"
                 )
+        else:
+            raise AssertionError(f"Invalid output format: {args.output}")
 
 
 def _deploy(args):
@@ -211,7 +213,11 @@ def add_parser(main_subparsers, parents):
 
     parser = main_subparsers.add_parser(
         "deploy",
-        parents=[*parents, FalClientParser(add_help=False)],
+        parents=[
+            *parents,
+            get_output_parser(),
+            FalClientParser(add_help=False),
+        ],
         description=deploy_help,
         help=deploy_help,
         epilog=epilog,
@@ -260,13 +266,6 @@ def add_parser(main_subparsers, parents):
         action="store_true",
         dest="app_scale_settings",
         help="Use the application code for scale settings.",
-    )
-    parser.add_argument(
-        "--output",
-        type=str,
-        default="pretty",
-        choices=["pretty", "json"],
-        help="Modify the command output",
     )
 
     parser.set_defaults(func=_deploy)

--- a/projects/fal/src/fal/cli/parser.py
+++ b/projects/fal/src/fal/cli/parser.py
@@ -103,3 +103,16 @@ class FalClientParser(FalParser):
             "--team",
             help="The team to use.",
         )
+
+
+def get_output_parser():
+    parser = FalParser(add_help=False)
+    group = parser.add_argument_group(title="Output")
+    group.add_argument(
+        "--output",
+        type=str,
+        default="pretty",
+        choices=["pretty", "json"],
+        help="Modify the command output",
+    )
+    return parser


### PR DESCRIPTION
We already have `--output json` in apps list and deploy https://github.com/fal-ai/fal/pull/588 so introducing one here as well.