### PR TITLE
Fix: make token managers pickleable

### DIFF
--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -159,6 +159,17 @@ class FalV2TokenManager:
             expires_at=datetime.fromisoformat(result["expires_at"]),
         )
 
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        # Remove the lock from the state dictionary
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        # Restore the instance attributes
+        self.__dict__.update(state)
+        # Recreate the lock
+        self._lock = threading.Lock()
 
 class FalV3TokenManager(FalV2TokenManager):
     token_cls: type[FalV2Token] = FalV3Token

--- a/projects/fal/src/fal/toolkit/file/providers/fal.py
+++ b/projects/fal/src/fal/toolkit/file/providers/fal.py
@@ -171,6 +171,7 @@ class FalV2TokenManager:
         # Recreate the lock
         self._lock = threading.Lock()
 
+
 class FalV3TokenManager(FalV2TokenManager):
     token_cls: type[FalV2Token] = FalV3Token
     storage_type: str = "fal-cdn-v3"


### PR DESCRIPTION
Currently, token managers are not pickleable, and are defined at the module level.

This means multiprocessing apps must avoid importing them before the fork, or else the app will fail with `TypeError: cannot pickle '_thread.lock' object`.

The simple solution is to enable them to be pickleable by not trying to pickle the lock object, and letting each process have their own lock. An alternative solution could be to use a multiprocessing lock, but I think the overhead there wouldn't be worth it - typically only one process (the rank 0 process) will be uploading anyway.