### PR TITLE
Fix: remove last global lock

### DIFF
--- a/projects/fal/src/fal/auth/__init__.py
+++ b/projects/fal/src/fal/auth/__init__.py
@@ -17,6 +17,15 @@ class GoogleColabState:
         self.lock = Lock()
         self.secret: Optional[str] = None
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["lock"] = None  # type: ignore
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.lock = Lock()
+
 
 _colab_state = GoogleColabState()
 


### PR DESCRIPTION
As a follow-up from https://github.com/fal-ai/fal/pull/632 - tracing revealed there was one more global lock that tried to pickle after the token manager did.

I did a follow-up trace of `threading.Lock`s anywhere in the SDK, it looks like the only remaining one is on the `FalServerlessHost`, but that is not defined globally so it's not an issue.