### PR TITLE
chore: Bump isolate proto min version to 0.17

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.18.0,<0.21.0",
-    "isolate-proto>=0.16.0,<0.18.0",
+    "isolate-proto>=0.17.0,<0.18.0",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle==3.0.0",


### PR DESCRIPTION
https://github.com/fal-ai/fal/pull/637 is not sufficient, since this pr https://github.com/fal-ai/fal/pull/636 uses the new field, we need to make sure the isolate_proto version is at least 0.17