### PR TITLE
chore: limit tblib <3.2.0

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "tomli>2,<3",
     "tomli-w>=1,<2",
     "fsspec",
+    "tblib<3.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
3.2.0 changed enough to break deserializing from an older version.