### PR TITLE
fix: pickle tblib by value to avoid errors

### DIFF
--- a/projects/fal/src/fal/_serialization.py
+++ b/projects/fal/src/fal/_serialization.py
@@ -231,3 +231,4 @@ def patch_pickle() -> None:
     _patch_exceptions()
 
     include_module("fal")
+    include_module("tblib")


### PR DESCRIPTION
tblib introduced some changes that made it no longer pickable across diferent tblib versions.

cause = AttributeError("Can't get attribute 'unpickle_exception_with_attrs' on <module 'tblib.pickling_support' from '/home/runner/work/isolate-cloud/isolate-cloud/.venv/lib/python3.11/site-packages/tblib/pickling_support.py'>")