### PR TITLE
fix: don't patch structlog

### DIFF
--- a/projects/fal/src/fal/logging/__init__.py
+++ b/projects/fal/src/fal/logging/__init__.py
@@ -7,11 +7,6 @@ from structlog.typing import EventDict, WrappedLogger
 
 from .style import LEVEL_STYLES
 
-# Unfortunately structlog console processor does not support
-# more general theming as a public API. Consider a PR on the
-# structlog repo to add better support for it.
-structlog.dev._ColorfulStyles.bright = ""
-
 
 class DebugConsoleLogProcessor:
     """


### PR DESCRIPTION
This causes errors in the new structlog verssions and it doesn't seem to be super useful anyway.