### PR TITLE
chore: mark flaky tests

### DIFF
--- a/projects/fal/tests/integration_test.py
+++ b/projects/fal/tests/integration_test.py
@@ -473,6 +473,7 @@ def fal_file_content_matches(file: File, content: str):
     return file.as_bytes().decode() == content
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_fal_file_from_path(isolated_client):
     @isolated_client(requirements=[f"pydantic=={pydantic_version}", "tomli"])
     def fal_file_from_temp(content: str):

--- a/projects/fal/tests/test_apps.py
+++ b/projects/fal/tests/test_apps.py
@@ -1005,6 +1005,7 @@ def test_field_exception_billing(test_exception_app: AppClient):
         assert not hasattr(response.headers, "x-fal-billable-units")
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_stop_runner(host: api.FalServerlessHost, test_sleep_app: str):
     def submit_and_wait_for_runner():
         handle = apps.submit(test_sleep_app, arguments={"wait_time": 1})
@@ -1067,6 +1068,7 @@ def test_stop_runner(host: api.FalServerlessHost, test_sleep_app: str):
         assert len(runners) == 2
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_kill_runner(host: api.FalServerlessHost, test_sleep_app: str):
     # Kill all the replicas of the app that is already running
     handle = apps.submit(test_sleep_app, arguments={"wait_time": 10})


### PR DESCRIPTION
Marking as flaky delays a proper solution but this is fine for now.