### PR TITLE
chore: enable debug logs in _set_logger_labels

### DIFF
--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -103,9 +103,7 @@ async def _set_logger_labels(
         code = await res.code()
         assert str(code) == "StatusCode.OK", str(code)
     except BaseException:
-        # NOTE hiding this for now to not print on every request
-        # logger.debug("Failed to set logger labels", exc_info=True)
-        pass
+        logger.debug("Failed to set logger labels", exc_info=True)
 
 
 def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:


### PR DESCRIPTION
Noticing that we might be not setting the fal_request_id label sometimes.