### PR TITLE
fix: include tblib into SERVE_REQUIREMENTS

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -84,6 +84,7 @@ _UNSET = object()
 SERVE_REQUIREMENTS = [
     f"fastapi=={fastapi_version}",
     f"pydantic=={pydantic_version}",
+    f"tblib=={tblib.__version__}",
     "uvicorn",
     "starlette_exporter",
     # workaround for prometheus_client 0.23.0


### PR DESCRIPTION
tblib is not that well compatible across the versions, so we better ask for particular version here.