### PR TITLE
chore(fal): bump and unpin isolate-proto

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.18.0,<0.22.0",
-    "isolate-proto>=0.25.0,<0.26.0",
+    "isolate-proto>=0.26.0",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle==3.0.0",


### PR DESCRIPTION
Isolate-proto is backward compatible by nature, no need to limit from the top.