### PR TITLE
feat(fal_client): fallback to sdk auth0 token

### DIFF
--- a/projects/fal_client/src/fal_client/auth.py
+++ b/projects/fal_client/src/fal_client/auth.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+import base64
+import json
 import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
 from threading import Lock
 from typing import Optional
+
+import httpx
 
 
 class GoogleColabState:
@@ -50,20 +60,195 @@ class MissingCredentialsError(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class AuthCredentials:
+    """Represents an authorization header value."""
+
+    scheme: str
+    token: str
+
+    @property
+    def header_value(self) -> str:
+        return f"{self.scheme} {self.token}"
+
+    def as_headers(self) -> dict[str, str]:
+        return {"Authorization": self.header_value}
+
+
 FAL_RUN_HOST = os.environ.get("FAL_RUN_HOST", "fal.run")
 FAL_QUEUE_RUN_HOST = os.environ.get("FAL_QUEUE_RUN_HOST", f"queue.{FAL_RUN_HOST}")
 
+AUTH0_DOMAIN = "auth.fal.ai"
+AUTH0_TOKEN_URL = f"https://{AUTH0_DOMAIN}/oauth/token"
+AUTH0_CLIENT_ID = "TwXR51Vz8JbY8GUUMy6EyuVR0fTO7N4N"
+AUTH_TOKEN_FILENAME = "auth0_token"
+AUTH_LOCK_FILENAME = ".portalock"
+DEFAULT_FAL_HOME = Path.home() / ".fal"
+
+
+def _get_fal_home_dir() -> Path:
+    return Path(os.getenv("FAL_HOME_DIR", str(DEFAULT_FAL_HOME))).expanduser()
+
+
+@contextmanager
+def _token_lock():
+    """Best effort lock shared with fal-cli."""
+
+    try:
+        import portalocker
+    except Exception:
+        yield
+        return
+
+    lock_file = _get_fal_home_dir() / AUTH_LOCK_FILENAME
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    with portalocker.utils.TemporaryFileLock(
+        str(lock_file), fail_when_locked=False, timeout=20
+    ):
+        yield
+
+
+def _read_auth_tokens() -> tuple[Optional[str], Optional[str]]:
+    path = _get_fal_home_dir() / AUTH_TOKEN_FILENAME
+    if not path.exists():
+        return None, None
+
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if not lines:
+        return None, None
+
+    refresh_token = lines[0]
+    access_token: Optional[str] = None
+    if len(lines) > 1:
+        access_token = lines[1]
+
+    return refresh_token or None, access_token or None
+
+
+def _write_auth_tokens(refresh_token: str, access_token: Optional[str]) -> None:
+    path = _get_fal_home_dir() / AUTH_TOKEN_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    contents = [refresh_token]
+    if access_token:
+        contents.append(access_token)
+
+    path.write_text("\n".join(contents))
+
+
+def _decode_jwt_exp(token: str) -> Optional[int]:
+    """Returns exp claim in seconds since epoch or None if unreadable."""
+
+    try:
+        payload_segment = token.split(".")[1]
+        padding = "=" * (-len(payload_segment) % 4)
+        payload = base64.urlsafe_b64decode(payload_segment + padding)
+        claims = json.loads(payload.decode("utf-8"))
+        return int(claims.get("exp"))
+    except Exception:
+        return None
+
+
+def _is_access_token_expired(token: str, *, leeway_seconds: int = 300) -> bool:
+    exp = _decode_jwt_exp(token)
+    if exp is None:
+        # If we cannot parse the token, assume it is expired to force refresh.
+        return True
+
+    return time.time() + leeway_seconds >= exp
+
+
+def _refresh_access_token(refresh_token: str) -> dict:
+    response = httpx.post(
+        AUTH0_TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": AUTH0_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        timeout=30,
+    )
+
+    try:
+        token_data = response.json()
+    except Exception:
+        token_data = {}
+
+    if response.status_code != 200 or "access_token" not in token_data:
+        raise MissingCredentialsError(
+            "Failed to refresh fal auth token. Please run `fal auth login` again."
+        )
+
+    return token_data
+
+
+def _load_bearer_token_from_login() -> Optional[str]:
+    """
+    Try to reuse tokens created by `fal auth login`.
+
+    We share the same file layout as fal-cli:
+    - refresh token on first line
+    - optional cached access token on second line
+    """
+
+    with _token_lock():
+        refresh_token, access_token = _read_auth_tokens()
+
+    if not refresh_token:
+        return None
+
+    if access_token and not _is_access_token_expired(access_token):
+        return access_token
+
+    token_data = _refresh_access_token(refresh_token)
+    new_refresh = token_data.get("refresh_token", refresh_token)
+    new_access = token_data["access_token"]
+
+    with _token_lock():
+        _write_auth_tokens(new_refresh, new_access)
+
+    return new_access
+
+
+def fetch_auth_credentials() -> AuthCredentials:
+    """
+    Return credentials using this priority:
+    1) FAL_KEY / FAL_KEY_ID+FAL_KEY_SECRET / Colab secret (unless FAL_FORCE_AUTH_BY_USER=1)
+    2) Tokens saved by `fal auth login`
+    """
+
+    force_user_auth = os.environ.get("FAL_FORCE_AUTH_BY_USER") == "1"
+
+    if not force_user_auth:
+        if key := os.getenv("FAL_KEY"):
+            return AuthCredentials("Key", key)
+        elif (key_id := os.getenv("FAL_KEY_ID")) and (
+            fal_key_secret := os.getenv("FAL_KEY_SECRET")
+        ):
+            return AuthCredentials("Key", f"{key_id}:{fal_key_secret}")
+        elif colab_token := get_colab_token():
+            return AuthCredentials("Key", colab_token)
+
+    if bearer := _load_bearer_token_from_login():
+        return AuthCredentials("Bearer", bearer)
+
+    raise MissingCredentialsError(
+        "No credentials found. Set FAL_KEY (or FAL_KEY_ID/FAL_KEY_SECRET) or login via `fal auth login`."
+    )
+
 
 def fetch_credentials() -> str:
-    if key := os.getenv("FAL_KEY"):
-        return key
-    elif (key_id := os.getenv("FAL_KEY_ID")) and (
-        fal_key_secret := os.getenv("FAL_KEY_SECRET")
-    ):
-        return f"{key_id}:{fal_key_secret}"
-    elif colab_token := get_colab_token():
-        return colab_token
-    else:
+    """
+    Legacy helper kept for backwards compatibility.
+
+    It only returns Key-based credentials; user-based auth (Bearer) will raise
+    MissingCredentialsError so callers don't accidentally send it as a key.
+    """
+
+    auth = fetch_auth_credentials()
+    if auth.scheme.lower() != "key":
         raise MissingCredentialsError(
-            "Please set the FAL_KEY environment variable to your API key, or set the FAL_KEY_ID and FAL_KEY_SECRET environment variables."
+            "Key credentials not found. Set FAL_KEY (or FAL_KEY_ID/FAL_KEY_SECRET)."
         )
+
+    return auth.token

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -31,7 +31,13 @@ from urllib.parse import urlencode
 import httpx
 import msgpack
 from httpx_sse import aconnect_sse, connect_sse
-from fal_client.auth import FAL_QUEUE_RUN_HOST, FAL_RUN_HOST, fetch_credentials
+from fal_client.auth import (
+    AuthCredentials,
+    FAL_QUEUE_RUN_HOST,
+    FAL_RUN_HOST,
+    MissingCredentialsError,
+    fetch_auth_credentials,
+)
 
 if TYPE_CHECKING:
     from websockets.client import WebSocketClientProtocol
@@ -65,8 +71,8 @@ class CDNToken:
 
 
 class CDNTokenManager:
-    def __init__(self, key: str) -> None:
-        self._key = key
+    def __init__(self, auth: AuthCredentials) -> None:
+        self._auth = auth
         self._token: CDNToken = CDNToken(
             token="",
             token_type="",
@@ -76,7 +82,7 @@ class CDNTokenManager:
         self._lock: threading.Lock = threading.Lock()
         self._url = f"{REST_URL}/storage/auth/token?storage_type=fal-cdn-v3"
         self._headers = {
-            "Authorization": f"Key {self._key}",
+            "Authorization": self._auth.header_value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
@@ -102,8 +108,8 @@ class CDNTokenManager:
 
 
 class AsyncCDNTokenManager:
-    def __init__(self, key: str) -> None:
-        self._key = key
+    def __init__(self, auth: AuthCredentials) -> None:
+        self._auth = auth
         self._token: CDNToken = CDNToken(
             token="",
             token_type="",
@@ -113,7 +119,7 @@ class AsyncCDNTokenManager:
         self._lock: asyncio.Lock = asyncio.Lock()
         self._url = f"{REST_URL}/storage/auth/token?storage_type=fal-cdn-v3"
         self._headers = {
-            "Authorization": f"Key {self._key}",
+            "Authorization": self._auth.header_value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
@@ -1115,21 +1121,33 @@ class AsyncClient:
     key: str | None = field(default=None, repr=False)
     default_timeout: float = 120.0
 
-    def _get_key(self) -> str:
+    @cached_property
+    def _auth(self) -> AuthCredentials:
         if self.key is None:
-            return fetch_credentials()
-        return self.key
+            return fetch_auth_credentials()
+        return AuthCredentials("Key", self.key)
+
+    def _get_auth(self) -> AuthCredentials:
+        return self._auth
+
+    def _get_key(self) -> str:
+        auth = self._get_auth()
+        if auth.scheme.lower() != "key":
+            raise MissingCredentialsError(
+                "Key credentials are required for this operation. Set FAL_KEY or FAL_KEY_ID/FAL_KEY_SECRET."
+            )
+        return auth.token
 
     @cached_property
     def _token_manager(self) -> AsyncCDNTokenManager:
-        return AsyncCDNTokenManager(self._get_key())
+        return AsyncCDNTokenManager(self._get_auth())
 
     @cached_property
     def _client(self) -> httpx.AsyncClient:
-        key = self._get_key()
+        auth = self._get_auth()
         return httpx.AsyncClient(
             headers={
-                "Authorization": f"Key {key}",
+                "Authorization": auth.header_value,
                 "User-Agent": USER_AGENT,
             },
             timeout=self.default_timeout,
@@ -1426,17 +1444,29 @@ class SyncClient:
     key: str | None = field(default=None, repr=False)
     default_timeout: float = 120.0
 
-    def _get_key(self) -> str:
+    @cached_property
+    def _auth(self) -> AuthCredentials:
         if self.key is None:
-            return fetch_credentials()
-        return self.key
+            return fetch_auth_credentials()
+        return AuthCredentials("Key", self.key)
+
+    def _get_auth(self) -> AuthCredentials:
+        return self._auth
+
+    def _get_key(self) -> str:
+        auth = self._get_auth()
+        if auth.scheme.lower() != "key":
+            raise MissingCredentialsError(
+                "Key credentials are required for this operation. Set FAL_KEY or FAL_KEY_ID/FAL_KEY_SECRET."
+            )
+        return auth.token
 
     @cached_property
     def _client(self) -> httpx.Client:
-        key = self._get_key()
+        auth = self._get_auth()
         return httpx.Client(
             headers={
-                "Authorization": f"Key {key}",
+                "Authorization": auth.header_value,
                 "User-Agent": USER_AGENT,
             },
             timeout=self.default_timeout,
@@ -1445,7 +1475,7 @@ class SyncClient:
 
     @cached_property
     def _token_manager(self) -> CDNTokenManager:
-        return CDNTokenManager(self._get_key())
+        return CDNTokenManager(self._get_auth())
 
     def _get_cdn_client(self) -> httpx.Client:
         token = self._token_manager.get_token()

--- a/projects/fal_client/tests/test_async_client.py
+++ b/projects/fal_client/tests/test_async_client.py
@@ -11,7 +11,7 @@ from PIL import Image
 async def client() -> fal_client.AsyncClient:
     client = fal_client.AsyncClient()
     try:
-        client._get_key()
+        client._get_auth()
     except fal_client.auth.MissingCredentialsError:
         pytest.skip("No credentials found")
     return client

--- a/projects/fal_client/tests/test_sync_client.py
+++ b/projects/fal_client/tests/test_sync_client.py
@@ -11,7 +11,7 @@ from fal_client.client import _maybe_retry_request
 def client() -> fal_client.SyncClient:
     client = fal_client.SyncClient()
     try:
-        client._get_key()
+        client._get_auth()
     except fal_client.auth.MissingCredentialsError:
         pytest.skip("Missing credentials")
     return client

--- a/projects/fal_client/tests/unit/test_auth.py
+++ b/projects/fal_client/tests/unit/test_auth.py
@@ -1,0 +1,82 @@
+import base64
+import json
+import time
+from pathlib import Path
+
+
+from fal_client.auth import AuthCredentials, fetch_auth_credentials
+
+
+def _make_jwt(expires_in_seconds: int) -> str:
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "none", "typ": "JWT"}).encode("utf-8")
+    ).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": int(time.time()) + expires_in_seconds}).encode("utf-8")
+    ).rstrip(b"=")
+    # Signature is unused because we don't verify it.
+    return f"{header.decode()}.{payload.decode()}."
+
+
+def _write_auth_file(tmp_path: Path, refresh_token: str, access_token: str) -> Path:
+    path = tmp_path / "auth0_token"
+    path.write_text(f"{refresh_token}\n{access_token}")
+    return path
+
+
+def test_fetch_auth_credentials_prefers_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.setenv("FAL_KEY", "abc123")
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    auth = fetch_auth_credentials()
+
+    assert auth == AuthCredentials("Key", "abc123")
+
+
+def test_fetch_auth_credentials_uses_login_token_without_refresh(
+    monkeypatch, tmp_path, mocker
+):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    access_token = _make_jwt(expires_in_seconds=3600)
+    _write_auth_file(tmp_path, "refresh-token", access_token)
+
+    httpx_post = mocker.patch("fal_client.auth.httpx.post")
+
+    auth = fetch_auth_credentials()
+
+    assert auth == AuthCredentials("Bearer", access_token)
+    httpx_post.assert_not_called()
+
+
+def test_fetch_auth_credentials_refreshes_expired_token(monkeypatch, tmp_path, mocker):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    expired_token = _make_jwt(expires_in_seconds=-3600)
+    token_file = _write_auth_file(tmp_path, "old-refresh-token", expired_token)
+
+    new_access_token = _make_jwt(expires_in_seconds=7200)
+    response = mocker.Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "access_token": new_access_token,
+        "refresh_token": "new-refresh-token",
+    }
+    httpx_post = mocker.patch("fal_client.auth.httpx.post", return_value=response)
+
+    auth = fetch_auth_credentials()
+
+    assert auth == AuthCredentials("Bearer", new_access_token)
+    httpx_post.assert_called_once()
+
+    saved = token_file.read_text().splitlines()
+    assert saved[0] == "new-refresh-token"
+    assert saved[1] == new_access_token


### PR DESCRIPTION
Super convenient for fal app development. No longer requires you to set FAL_KEY if you are already `fal auth login`ed.