### PR TITLE
chore: expand description of --request-timeout option and fix --help

### DIFF
--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -257,7 +257,7 @@ def _add_scale_parser(subparsers, parents):
     parser.add_argument(
         "--concurrency-buffer-perc",
         type=int,
-        help="Concurrency buffer %",
+        help="Concurrency buffer %%",
     )
     parser.add_argument(
         "--scaling-delay",
@@ -267,7 +267,8 @@ def _add_scale_parser(subparsers, parents):
     parser.add_argument(
         "--request-timeout",
         type=int,
-        help="Request timeout (seconds).",
+        help="Request timeout (seconds). If a request takes longer, it is aborted and "
+        "the runner gracefully stopped as it could be in a bad state.",
     )
     parser.add_argument(
         "--startup-timeout",


### PR DESCRIPTION
Single `%` was causing the weird `invalid format` error when doing `--help`. Fixed by changing to `%%`.