### PR TITLE
fix: Skip symlinks during file collection to prevent path traversal errors

### DIFF
--- a/projects/fal/src/fal/file_sync.py
+++ b/projects/fal/src/fal/file_sync.py
@@ -238,6 +238,10 @@ class FileSync:
             elif abs_path.is_dir():
                 # Recursively walk directory tree
                 for file_path in abs_path.rglob("*"):
+                    # Skip symlinks - they can point outside the project and cause
+                    # path traversal issues when resolved
+                    if file_path.is_symlink():
+                        continue
                     if file_path.is_file():
                         file_abs_str, file_rel_path = normalize_path(
                             str(file_path), self.local_file_path, files_context_dir


### PR DESCRIPTION
When deploying an app from a directory containing symlinks that point outside the project (e.g., `.venv/bin/python` → `/usr/local/bin/python3`), the `collect_files` method would fail with "Parent directory reference is not allowed".

This happens because `normalize_path` uses `Path.resolve()` which follows symlinks to their target. When the target is outside the project directory, computing the relative path produces `../../../...` which fails the `sanitize_relative_path` security check.

The fix skips symlinks during directory traversal in `collect_files`. Symlinks are inherently problematic for deployment since their targets may not exist on the server, so skipping them is the safest behavior.