### PR TITLE
chore: improve error message for relative parent paths

### DIFF
--- a/projects/fal/src/fal/file_sync.py
+++ b/projects/fal/src/fal/file_sync.py
@@ -89,8 +89,10 @@ def sanitize_relative_path(rel_path: str, original_path: Path) -> str:
         raise FalServerlessException(f"Absolute Path is not allowed: {rel_path}")
     if ".." in pure_path.parts or "." in pure_path.parts:
         raise FalServerlessException(
-            f"Parent directory reference is not allowed: {rel_path} for {original_path}\n"
-            + "If you didn't mean to sync this file, please ignore it using `app_files_ignore`."
+            "Parent directory reference is not allowed: "
+            + f"{rel_path} for {original_path}\n"
+            + "If you didn't mean to sync this file, please ignore it using "
+            + "`app_files_ignore`."
         )
 
     return pure_path.as_posix()


### PR DESCRIPTION
This makes `fal` give a better error message if the user is trying to sync a file using `app_files` which is a symlink that points outside of the current directory.