### PR TITLE
chore: stop alerting about new versions in dev installs (--editable)

### DIFF
--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -91,6 +91,12 @@ def _check_latest_version():
     latest_version = get_latest_version()
     parsed = parse(latest_version)
     latest_version_tuple = (parsed.major, parsed.minor, parsed.micro)
+
+    # If we have a dev version, we don't want to check for updates
+    if len(version_tuple) >= 4:
+        if "dev" in str(version_tuple[3]):
+            return
+
     if latest_version_tuple <= version_tuple:
         return
 


### PR DESCRIPTION
<img width="383" height="51" alt="Screenshot 2026-01-21 at 15 23 09" src="https://github.com/user-attachments/assets/17b6bea3-453f-4cb7-bb0d-14b3ab9782f0" />


stop alerting since im in --editable install