### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/projects/fal/src/fal/auth/__init__.py
+++ b/projects/fal/src/fal/auth/__init__.py
@@ -70,19 +70,30 @@ def key_credentials() -> tuple[str, str] | None:
 
     config = Config()
 
-    key = os.environ.get("FAL_KEY") or config.get("key") or get_colab_token()
-    if key:
+    def _check_key(key: str, key_name: str) -> tuple[str, str] | None:
         try:
             key_id, key_secret = key.split(":", 1)
             return (key_id, key_secret)
         except ValueError:
-            print("Invalid key format for FAL key. Expected '<id>:<secret>'.")
+            print(f"Invalid key format for {key_name}. Expected '<id>:<secret>'.")
             return None
 
-    elif "FAL_KEY_ID" in os.environ and "FAL_KEY_SECRET" in os.environ:
+    env_key = os.environ.get("FAL_KEY")
+    if env_key:
+        return _check_key(env_key, "FAL_KEY environment variable")
+
+    config_key = config.get("key")
+    if config_key:
+        return _check_key(config_key, f"key in fal config {config.config_path}")
+
+    colab_key = get_colab_token()
+    if colab_key:
+        return _check_key(colab_key, "FAL_KEY in google colab")
+
+    if "FAL_KEY_ID" in os.environ and "FAL_KEY_SECRET" in os.environ:
         return (os.environ["FAL_KEY_ID"], os.environ["FAL_KEY_SECRET"])
-    else:
-        return None
+
+    return None
 
 
 def _fetch_access_token() -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/fal-ai/fal/security/code-scanning/10](https://github.com/fal-ai/fal/security/code-scanning/10)

In general, the problem is that the code logs the full value of a secret key in an error message when its format is invalid. To fix this, we should avoid including the secret itself in the log message. We can still provide useful diagnostics by logging a generic message (e.g., "Invalid key format") and optionally non-sensitive metadata, such as the *source* of the key (environment variable vs config vs Colab), but not the key value. This preserves functionality (the function still returns `None` on invalid format) while eliminating clear-text exposure of the secret.

The best minimal fix here is to change the `print(f"Invalid key format: {key}")` line in `key_credentials` to a message that does not interpolate `key`. For example: `print("Invalid key format for FAL key. Expected '<id>:<secret>'.")`. This keeps behavior the same except for the log text: same control flow and same return value, but without leaking the secret. No new imports or additional methods are required, since we are still using the built-in `print`.

Concretely:
- In `projects/fal/src/fal/auth/__init__.py`, within `key_credentials`, replace line 79 (`print(f"Invalid key format: {key}")`) with a static, non-sensitive message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
