### PR TITLE
feat(api): add error_code to path-not-found 404 responses

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -1293,7 +1293,10 @@ class BaseServable:
                 headers = dict(exc.headers) if exc.headers else {}
                 headers["x-fal-billable-units"] = "0"
                 return JSONResponse(
-                    {"detail": f"Path {request.url.path} not found"},
+                    {
+                        "detail": f"Path {request.url.path} not found",
+                        "error_code": "path_does_not_exist",
+                    },
                     404,
                     headers=headers,
                 )


### PR DESCRIPTION
## Summary
- Adds `"error_code": "path_does_not_exist"` to 404 responses when a path doesn't exist
- This allows the gateway to distinguish between "path doesn't exist" and "request not found" errors

Needed for fal-ai/isolate-cloud#5627

🤖 Generated with [Claude Code](https://claude.com/claude-code)