### PR TITLE
Change deployment note color from dim to yellow for better visibility

### DIFF
--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -103,9 +103,9 @@ def _deploy(args):
         # Reminder about scaling parameter inheritance
         args.console.print("")
         note = (
-            "[dim]Note: Scaling parameters (keep_alive, min_concurrency, etc.) "
+            "[yellow]Note: Scaling parameters (keep_alive, min_concurrency, etc.) "
             "are inherited from the previous deployment. "
-            "Use --reset-scale to apply code changes.[/dim]"
+            "Use --reset-scale to apply code changes.[/yellow]"
         )
         args.console.print(note)
     else:


### PR DESCRIPTION
## Summary
Updated the styling of the scaling parameters reminder message in the deploy command to use a more visible color scheme.

## Changes
- Changed the console output color markup from `[dim]...[/dim]` to `[yellow]...[/yellow]` for the scaling parameters inheritance note
- This makes the important reminder about scaling parameter behavior more prominent and easier to notice during deployment

## Details
The note informs users that scaling parameters (keep_alive, min_concurrency, etc.) are inherited from previous deployments and that they should use the `--reset-scale` flag to apply code changes. By changing from dim (less visible) to yellow (more prominent), users are more likely to see and understand this important behavior.

https://claude.ai/code/session_01P1qtUR1ka9wP5Jpd7T7axq