### PR TITLE
ci: run fal integration and e2e tests on dev and prod

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'cursor'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'cursor'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -35,11 +35,9 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - target: dev
-            fal_key_secret: FAL_KEY_DEV
             fal_grpc_host: api.fal.dev
             fal_run_host: run.fal.dev
           - target: prod
-            fal_key_secret: FAL_KEY_PROD
             fal_grpc_host: api.alpha.fal.ai
             fal_run_host: fal.run
         exclude:
@@ -73,7 +71,7 @@ jobs:
 
       - name: Run e2e tests
         env:
-          FAL_KEY: ${{ secrets[matrix.fal_key_secret] }}
+          FAL_KEY: ${{ matrix.target == 'prod' && secrets.FAL_KEY_PROD || secrets.FAL_KEY_DEV }}
           FAL_GRPC_HOST: ${{ matrix.fal_grpc_host }}
           FAL_RUN_HOST: ${{ matrix.fal_run_host }}
         run: |

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -32,13 +32,6 @@ jobs:
         target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          - target: dev
-            fal_grpc_host: api.fal.dev
-            fal_run_host: run.fal.dev
-          - target: prod
-            fal_grpc_host: api.alpha.fal.ai
-            fal_run_host: fal.run
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -71,7 +64,7 @@ jobs:
       - name: Run e2e tests
         env:
           FAL_KEY: ${{ matrix.target == 'prod' && secrets.FAL_KEY_PROD || secrets.FAL_KEY_DEV }}
-          FAL_GRPC_HOST: ${{ matrix.fal_grpc_host }}
-          FAL_RUN_HOST: ${{ matrix.fal_run_host }}
+          FAL_GRPC_HOST: ${{ matrix.target == 'prod' && 'api.alpha.fal.ai' || secrets.FAL_GRPC_HOST_DEV }}
+          FAL_RUN_HOST: ${{ matrix.target == 'prod' && 'fal.run' || secrets.FAL_RUN_HOST_DEV }}
         run: |
           pytest -n auto -v projects/fal/tests/e2e

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 10
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -23,15 +23,25 @@ permissions:
 
 jobs:
   e2e:
-    name: e2e (py ${{ matrix.python }}, ${{ matrix.deps }})
+    name: e2e (${{ matrix.target }}, py ${{ matrix.python }}, ${{ matrix.deps }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
+        target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - target: dev
+            fal_key_secret: FAL_KEY_DEV
+            fal_grpc_host: api.fal.dev
+            fal_run_host: run.fal.dev
+          - target: prod
+            fal_key_secret: FAL_KEY_PROD
+            fal_grpc_host: api.alpha.fal.ai
+            fal_run_host: fal.run
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -63,8 +73,8 @@ jobs:
 
       - name: Run e2e tests
         env:
-          FAL_KEY: ${{ secrets.FAL_KEY_DEV }}
-          FAL_GRPC_HOST: api.fal.dev
-          FAL_RUN_HOST: run.fal.dev
+          FAL_KEY: ${{ secrets[matrix.fal_key_secret] }}
+          FAL_GRPC_HOST: ${{ matrix.fal_grpc_host }}
+          FAL_RUN_HOST: ${{ matrix.fal_run_host }}
         run: |
           pytest -n auto -v projects/fal/tests/e2e

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -35,11 +35,9 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - target: dev
-            fal_key_secret: FAL_KEY_DEV
             fal_host: api.fal.dev
             fal_run_host: run.fal.dev
           - target: prod
-            fal_key_secret: FAL_KEY_PROD
             fal_host: api.alpha.fal.ai
             fal_run_host: fal.run
         exclude:
@@ -72,7 +70,7 @@ jobs:
 
       - name: Run integration tests
         env:
-          FAL_KEY: ${{ secrets[matrix.fal_key_secret] }}
+          FAL_KEY: ${{ matrix.target == 'prod' && secrets.FAL_KEY_PROD || secrets.FAL_KEY_DEV }}
           FAL_HOST: ${{ matrix.fal_host }}
           FAL_RUN_HOST: ${{ matrix.fal_run_host }}
         run: |

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 10
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -32,13 +32,6 @@ jobs:
         target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          - target: dev
-            fal_host: api.fal.dev
-            fal_run_host: run.fal.dev
-          - target: prod
-            fal_host: api.alpha.fal.ai
-            fal_run_host: fal.run
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -70,7 +63,7 @@ jobs:
       - name: Run integration tests
         env:
           FAL_KEY: ${{ matrix.target == 'prod' && secrets.FAL_KEY_PROD || secrets.FAL_KEY_DEV }}
-          FAL_HOST: ${{ matrix.fal_host }}
-          FAL_RUN_HOST: ${{ matrix.fal_run_host }}
+          FAL_HOST: ${{ matrix.target == 'prod' && 'api.alpha.fal.ai' || secrets.FAL_GRPC_HOST_DEV }}
+          FAL_RUN_HOST: ${{ matrix.target == 'prod' && 'fal.run' || secrets.FAL_RUN_HOST_DEV }}
         run: |
           pytest -n auto -v projects/fal/tests/integration

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -23,15 +23,25 @@ permissions:
 
 jobs:
   integration:
-    name: integration (py ${{ matrix.python }}, ${{ matrix.deps }})
+    name: integration (${{ matrix.target }}, py ${{ matrix.python }}, ${{ matrix.deps }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
+        target: ["dev", "prod"]
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - target: dev
+            fal_key_secret: FAL_KEY_DEV
+            fal_host: api.fal.dev
+            fal_run_host: run.fal.dev
+          - target: prod
+            fal_key_secret: FAL_KEY_PROD
+            fal_host: api.alpha.fal.ai
+            fal_run_host: fal.run
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -62,8 +72,8 @@ jobs:
 
       - name: Run integration tests
         env:
-          FAL_KEY: ${{ secrets.FAL_KEY_DEV }}
-          FAL_HOST: api.fal.dev
-          FAL_RUN_HOST: run.fal.dev
+          FAL_KEY: ${{ secrets[matrix.fal_key_secret] }}
+          FAL_HOST: ${{ matrix.fal_host }}
+          FAL_RUN_HOST: ${{ matrix.fal_run_host }}
         run: |
           pytest -n auto -v projects/fal/tests/integration


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebase this branch onto fresh `origin/main`
- add a `target` matrix dimension to the `fal` integration workflow so each Python/dependency combination runs against both dev and prod
- add the same `target` matrix dimension to the `fal` e2e workflow
- select `FAL_KEY_DEV` vs `FAL_KEY_PROD` with direct conditional secret references without using dynamic `secrets[...]` lookups
- read the dev gRPC/run hosts from `FAL_GRPC_HOST_DEV` and `FAL_RUN_HOST_DEV` secrets instead of hardcoding dev hostnames in the workflow files
- remove the `max-parallel` cap from the `fal` integration and e2e matrices so GitHub Actions can run as many jobs concurrently as the runner pool allows

## Testing
- `python3 -m pre_commit run --all-files`
- `python3 -c "import pathlib, yaml; [yaml.safe_load(path.read_text()) for path in map(pathlib.Path, ['.github/workflows/fal-integration-tests.yml', '.github/workflows/fal-e2e-tests.yml', '.github/workflows/claude-code-review.yml'])]; print('workflow yaml ok')"`

## Notes
- I did not run the `fal` integration/e2e suites locally because they require CI secrets and external service access.
- The Node 20 deprecation notice shown in Actions is unrelated to these changes and is only a warning.
- The repository's Claude review workflow validates its workflow file against `main`, so bot-allowlist changes to that workflow cannot be safely made from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2550661-3100-47b0-8144-f8e47deac7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2550661-3100-47b0-8144-f8e47deac7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

