### PR TITLE
docs: refresh repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,106 @@
-projects/fal/README.md
+[![PyPI](https://img.shields.io/pypi/v/fal.svg?logo=PyPI)](https://pypi.org/project/fal)
+[![Tests](https://img.shields.io/github/actions/workflow/status/fal-ai/fal/fal-unit-tests.yml?label=Tests)](https://github.com/fal-ai/fal/actions)
+
+# fal
+
+fal is a serverless Python runtime that lets you run and scale code in the cloud with no infra management.
+
+With fal, you can build pipelines, serve ML models and scale them up to many users. You scale down to 0 when you don't use any resources.
+
+This repository contains the main Python packages for building on [fal](https://fal.ai):
+
+- `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal
+- `fal-client` (in `projects/fal_client`): call fal model APIs or your deployed endpoints from Python
+
+For full product and platform documentation, see [fal.ai/docs](https://fal.ai/docs/documentation).
+
+## Which package should I use?
+
+### Use `fal` when you want to deploy Python code to fal
+
+The `fal` package includes the Python SDK and CLI for building serverless apps, testing them with temporary URLs, and deploying them to production.
+
+```bash
+pip install fal
+fal auth login
+```
+
+Create a minimal app:
+
+```python
+import fal
+
+
+class MyApp(fal.App):
+    @fal.endpoint("/")
+    def run(self) -> dict:
+        return {"message": "Hello, World!"}
+```
+
+Run it on fal for testing:
+
+```bash
+fal run hello_world.py::MyApp
+```
+
+Deploy it to a persistent endpoint:
+
+```bash
+fal deploy hello_world.py::MyApp
+```
+
+Docs:
+
+- [Quick start](https://fal.ai/docs/documentation/development/getting-started/quick-start)
+- [Deploy to production](https://fal.ai/docs/documentation/deployment/deploy-to-production)
+- [Serverless documentation](https://fal.ai/docs/documentation/serverless)
+
+### Use `fal-client` when you want to call models or deployed endpoints
+
+The `fal-client` package is the simplest way to call model APIs on fal from Python.
+
+```bash
+pip install fal-client
+export FAL_KEY="your-api-key"
+```
+
+Call a model:
+
+```python
+import fal_client
+
+result = fal_client.subscribe(
+    "fal-ai/flux/schnell",
+    arguments={
+        "prompt": "a futuristic cityscape at sunset",
+        "image_size": "landscape_16_9",
+    },
+)
+
+print(result["images"][0]["url"])
+```
+
+You can also use `fal-client` to call your own deployed `fal` apps by passing your endpoint ID instead of a model ID.
+
+Docs:
+
+- [Client setup](https://fal.ai/docs/documentation/model-apis/inference/client-setup)
+- [Inference methods](https://fal.ai/docs/documentation/model-apis/inference)
+- [Model APIs documentation](https://fal.ai/docs/documentation/model-apis)
+
+## Install from source
+
+From the repository root:
+
+```bash
+pip install -e 'projects/fal[dev]'
+pip install -e 'projects/fal_client[dev]'
+pip install -e 'projects/isolate_proto[dev]'
+```
+
+## More resources
+
+- [Documentation index](https://fal.ai/docs/documentation)
+- [API reference](https://fal.ai/docs/api-reference)
+- [Model gallery](https://fal.ai/models)
+- [Dashboard](https://fal.ai/dashboard)

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -5,6 +5,8 @@
 
 fal is a serverless Python runtime that lets you run and scale code in the cloud with no infra management.
 
+With fal, you can build pipelines, serve ML models and scale them up to many users. You scale down to 0 when you don't use any resources.
+
 This repository contains the main Python packages for building on [fal](https://fal.ai):
 
 - `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -12,7 +12,7 @@ This repository contains the main Python packages for building on [fal](https://
 - `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal
 - `fal-client` (in `projects/fal_client`): call fal model APIs or your deployed endpoints from Python
 
-If you want the full product and platform documentation, start at [fal.ai/docs](https://fal.ai/docs/documentation).
+For full product and platform documentation, see [fal.ai/docs](https://fal.ai/docs/documentation).
 
 ## Which package should I use?
 

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -1,4 +1,7 @@
-# fal Python SDKs
+[![PyPI](https://img.shields.io/pypi/v/fal.svg?logo=PyPI)](https://pypi.org/project/fal)
+[![Tests](https://img.shields.io/github/actions/workflow/status/fal-ai/fal/fal-unit-tests.yml?label=Tests)](https://github.com/fal-ai/fal/actions)
+
+# fal for Python
 
 This repository contains the Python packages for building on [fal](https://fal.ai):
 

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -1,9 +1,11 @@
 [![PyPI](https://img.shields.io/pypi/v/fal.svg?logo=PyPI)](https://pypi.org/project/fal)
 [![Tests](https://img.shields.io/github/actions/workflow/status/fal-ai/fal/fal-unit-tests.yml?label=Tests)](https://github.com/fal-ai/fal/actions)
 
-# fal for Python
+# fal
 
-This repository contains the Python packages for building on [fal](https://fal.ai):
+fal is a serverless Python runtime that lets you run and scale code in the cloud with no infra management.
+
+This repository contains the main Python packages for building on [fal](https://fal.ai):
 
 - `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal
 - `fal-client` (in `projects/fal_client`): call fal model APIs or your deployed endpoints from Python

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -1,75 +1,99 @@
-[![PyPI](https://img.shields.io/pypi/v/fal.svg?logo=PyPI)](https://pypi.org/project/fal)
-[![Tests](https://img.shields.io/github/actions/workflow/status/fal-ai/fal/fal-unit-tests.yml?label=Tests)](https://github.com/fal-ai/fal/actions)
+# fal Python SDKs
 
-# fal
+This repository contains the Python packages for building on [fal](https://fal.ai):
 
-fal is a serverless Python runtime that lets you run and scale code in the cloud with no infra management.
+- `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal
+- `fal-client` (in `projects/fal_client`): call fal model APIs or your deployed endpoints from Python
 
-With fal, you can build pipelines, serve ML models and scale them up to many users. You scale down to 0 when you don't use any resources.
+If you want the full product and platform documentation, start at [fal.ai/docs](https://fal.ai/docs/documentation).
 
-## Quickstart
+## Which package should I use?
 
-First, you need to install the `fal` package. You can do so using pip:
+### Use `fal` when you want to deploy Python code to fal
 
-```shell
+The `fal` package includes the Python SDK and CLI for building serverless apps, testing them with temporary URLs, and deploying them to production.
+
+```bash
 pip install fal
-```
-
-Then you need to authenticate:
-
-```shell
 fal auth login
 ```
 
-You can also use fal keys that you can get from [our dashboard](https://fal.ai/dashboard/keys).
+Create a minimal app:
 
-Now can use the fal package in your Python scripts as follows:
-
-```py
+```python
 import fal
 
-@fal.function(
-    "virtualenv",
-    requirements=["pyjokes"],
-)
-def tell_joke() -> str:
-    import pyjokes
 
-    joke = pyjokes.get_joke()
-    return joke
-
-print("Joke from the clouds: ", tell_joke())
+class MyApp(fal.App):
+    @fal.endpoint("/")
+    def run(self) -> dict:
+        return {"message": "Hello, World!"}
 ```
 
-A new virtual environment will be created by fal in the cloud and the set of requirements that we passed will be installed as soon as this function is called. From that point on, our code will be executed as if it were running locally, and the joke prepared by the pyjokes library will be returned.
+Run it on fal for testing:
 
-## Next steps
+```bash
+fal run hello_world.py::MyApp
+```
 
-If you would like to find out more about the capabilities of fal, check out to the [docs](https://fal.ai/docs). You can learn more about persistent storage, function caches and deploying your functions as API endpoints.
+Deploy it to a persistent endpoint:
 
-## Contributing
+```bash
+fal deploy hello_world.py::MyApp
+```
 
-### Installing in editable mode with dev dependencies
+Docs:
 
-```py
+- [Quick start](https://fal.ai/docs/documentation/development/getting-started/quick-start)
+- [Deploy to production](https://fal.ai/docs/documentation/deployment/deploy-to-production)
+- [Serverless documentation](https://fal.ai/docs/documentation/serverless)
+
+### Use `fal-client` when you want to call models or deployed endpoints
+
+The `fal-client` package is the simplest way to call model APIs on fal from Python.
+
+```bash
+pip install fal-client
+export FAL_KEY="your-api-key"
+```
+
+Call a model:
+
+```python
+import fal_client
+
+result = fal_client.subscribe(
+    "fal-ai/flux/schnell",
+    arguments={
+        "prompt": "a futuristic cityscape at sunset",
+        "image_size": "landscape_16_9",
+    },
+)
+
+print(result["images"][0]["url"])
+```
+
+You can also use `fal-client` to call your own deployed `fal` apps by passing your endpoint ID instead of a model ID.
+
+Docs:
+
+- [Client setup](https://fal.ai/docs/documentation/model-apis/inference/client-setup)
+- [Inference methods](https://fal.ai/docs/documentation/model-apis/inference)
+- [Model APIs documentation](https://fal.ai/docs/documentation/model-apis)
+
+## Install from source
+
+From the repository root:
+
+```bash
 pip install -e 'projects/fal[dev]'
 pip install -e 'projects/fal_client[dev]'
 pip install -e 'projects/isolate_proto[dev]'
 ```
 
-### Running tests
+## More resources
 
-```py
-pytest
-```
-
-### Pre-commit
-
-```bash
-cd projects/fal
-pre-commit install
-```
-
-### Commit format
-
-Please follow [conventional commits specification](https://www.conventionalcommits.org/) for descriptions/messages.
+- [Documentation index](https://fal.ai/docs/documentation)
+- [API reference](https://fal.ai/docs/api-reference)
+- [Model gallery](https://fal.ai/models)
+- [Dashboard](https://fal.ai/dashboard)

--- a/projects/fal/README.md
+++ b/projects/fal/README.md
@@ -7,18 +7,11 @@ fal is a serverless Python runtime that lets you run and scale code in the cloud
 
 With fal, you can build pipelines, serve ML models and scale them up to many users. You scale down to 0 when you don't use any resources.
 
-This repository contains the main Python packages for building on [fal](https://fal.ai):
-
-- `fal` (in `projects/fal`): define, test, and deploy serverless apps on fal
-- `fal-client` (in `projects/fal_client`): call fal model APIs or your deployed endpoints from Python
-
 For full product and platform documentation, see [fal.ai/docs](https://fal.ai/docs/documentation).
 
-## Which package should I use?
+## Quickstart
 
-### Use `fal` when you want to deploy Python code to fal
-
-The `fal` package includes the Python SDK and CLI for building serverless apps, testing them with temporary URLs, and deploying them to production.
+Install the package and authenticate:
 
 ```bash
 pip install fal
@@ -49,44 +42,13 @@ Deploy it to a persistent endpoint:
 fal deploy hello_world.py::MyApp
 ```
 
-Docs:
+## Next steps
+
+If you want to go deeper, start with:
 
 - [Quick start](https://fal.ai/docs/documentation/development/getting-started/quick-start)
 - [Deploy to production](https://fal.ai/docs/documentation/deployment/deploy-to-production)
 - [Serverless documentation](https://fal.ai/docs/documentation/serverless)
-
-### Use `fal-client` when you want to call models or deployed endpoints
-
-The `fal-client` package is the simplest way to call model APIs on fal from Python.
-
-```bash
-pip install fal-client
-export FAL_KEY="your-api-key"
-```
-
-Call a model:
-
-```python
-import fal_client
-
-result = fal_client.subscribe(
-    "fal-ai/flux/schnell",
-    arguments={
-        "prompt": "a futuristic cityscape at sunset",
-        "image_size": "landscape_16_9",
-    },
-)
-
-print(result["images"][0]["url"])
-```
-
-You can also use `fal-client` to call your own deployed `fal` apps by passing your endpoint ID instead of a model ID.
-
-Docs:
-
-- [Client setup](https://fal.ai/docs/documentation/model-apis/inference/client-setup)
-- [Inference methods](https://fal.ai/docs/documentation/model-apis/inference)
-- [Model APIs documentation](https://fal.ai/docs/documentation/model-apis)
 
 ## Install from source
 
@@ -94,13 +56,26 @@ From the repository root:
 
 ```bash
 pip install -e 'projects/fal[dev]'
-pip install -e 'projects/fal_client[dev]'
-pip install -e 'projects/isolate_proto[dev]'
 ```
 
-## More resources
+## Contributing
 
-- [Documentation index](https://fal.ai/docs/documentation)
-- [API reference](https://fal.ai/docs/api-reference)
-- [Model gallery](https://fal.ai/models)
-- [Dashboard](https://fal.ai/dashboard)
+### Running tests
+
+Use the smallest relevant scope first:
+
+```bash
+pytest -n auto -v projects/fal/tests/unit
+```
+
+### Pre-commit
+
+Run the repository hooks before opening or finishing work:
+
+```bash
+pre-commit run --all-files
+```
+
+### Commit format
+
+Please follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rewrite the root README into a simpler docs-first landing page for the repository
- split the root README from `projects/fal/README.md` so the package README can stay focused on `fal`
- restore `projects/fal/README.md` as a package-specific README with quickstart, install-from-source, test, pre-commit, and commit-format guidance
- keep basic `fal` and `fal-client` usage in the root README and link to fal.ai docs for deeper coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b77ab44-8039-454f-9e12-3c5fcc8612d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b77ab44-8039-454f-9e12-3c5fcc8612d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

