### PR TITLE
fix(e2e): cap slow app test timeouts

### DIFF
--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -731,6 +731,7 @@ def test_app_cancellation(test_app: str, test_cancellable_app: str):
 
 
 @pytest.mark.flaky(max_runs=3)
+@pytest.mark.timeout(180)
 def test_app_disconnect_behavior(test_app: str, test_cancellable_app: str):
     with pytest.raises(HTTPStatusError) as e:
         apps.run(
@@ -1920,6 +1921,7 @@ def graceful_shutdown(
 
 
 @pytest.mark.flaky(max_runs=3)
+@pytest.mark.timeout(180)
 def test_graceful_shutdown(
     host: api.FalServerlessHost,
     rest_client: Client,
@@ -1931,6 +1933,7 @@ def test_graceful_shutdown(
 
 
 @pytest.mark.flaky(max_runs=3)
+@pytest.mark.timeout(180)
 def test_graceful_shutdown_force_kill(
     host: api.FalServerlessHost,
     rest_client: Client,
@@ -1942,6 +1945,7 @@ def test_graceful_shutdown_force_kill(
 
 
 @pytest.mark.flaky(max_runs=3)
+@pytest.mark.timeout(120)
 def test_forceful_shutdown(
     host: api.FalServerlessHost,
     rest_client: Client,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit pytest timeout markers to the slow/flaky e2e tests that can otherwise consume most of the workflow timeout
- keep the existing suite-wide default timeout in `projects/fal/pyproject.toml` and use per-test overrides where the runtime profile is known
- cap the shutdown-related tests separately so CI fails fast when those flows stall

## Testing
- pre-commit run --all-files
- pytest --collect-only projects/fal/tests/e2e/test_apps.py -q
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8d0a368-cc8c-4297-87f1-12ef0fff2e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8d0a368-cc8c-4297-87f1-12ef0fff2e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

