### PR TITLE
test(fal): improve pytest defaults

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -112,4 +112,8 @@ known-first-party = ["fal"]
 keep-runtime-typing = true
 
 [tool.pytest.ini_options]
+addopts = "-ra --durations=20"
+asyncio_mode = "auto"
+faulthandler_timeout = 60
+testpaths = "tests"
 timeout = 300

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -112,7 +112,7 @@ known-first-party = ["fal"]
 keep-runtime-typing = true
 
 [tool.pytest.ini_options]
-addopts = "-ra --durations=20"
+addopts = "-ra --durations=50"
 asyncio_mode = "auto"
 faulthandler_timeout = 60
 testpaths = "tests"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add default pytest reporting of skips/xfails and slowest tests for the `fal` package
- configure `pytest-asyncio` auto mode and enable `faulthandler_timeout`
- scope default collection to `tests` without changing existing xfail pass/fail behavior

## Testing
- `python3 -m pytest --help`
- `python3 -m pre_commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae3fdb3f-fc88-4cf8-b216-fcabf40ed8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae3fdb3f-fc88-4cf8-b216-fcabf40ed8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

