### PR TITLE
fix(tests): restore Python 3.8 compatibility

### DIFF
--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pickle
+from contextlib import ExitStack
 from contextvars import ContextVar
 from typing import AsyncIterator, Iterator
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -506,11 +507,12 @@ async def test_lifespan_startup_timeout_warning(
     app = TestApp()
     fastapi_app = fastapi.FastAPI()
 
-    with (
-        patch("builtins.print") as mock_print,
-        patch("fal.app._print_python_packages"),
-        patch("fal.app.time.perf_counter", side_effect=[0.0, elapsed_seconds]),
-    ):
+    with ExitStack() as stack:
+        mock_print = stack.enter_context(patch("builtins.print"))
+        stack.enter_context(patch("fal.app._print_python_packages"))
+        stack.enter_context(
+            patch("fal.app.time.perf_counter", side_effect=[0.0, elapsed_seconds])
+        )
         async with app.lifespan(fastapi_app):
             pass
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the parenthesized multi-context-manager `with (...)` block in `projects/fal/tests/unit/test_app.py` with `ExitStack`
- preserve the test behavior while keeping the syntax valid on Python 3.8
- fix the regression introduced in the warning test added today

## Testing
- `python3 - <<'PY' ... ast.parse(..., feature_version=(3, 8)) ... PY`
- `python3 -m pytest -q projects/fal/tests/unit/test_app.py -k startup_timeout_warning`
- `/home/ubuntu/.local/bin/pre-commit run --all-files`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65c56589-6863-4689-abb5-cb0308c6fe2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65c56589-6863-4689-abb5-cb0308c6fe2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

