### PR TITLE
fix(tests): don't leak apps

### DIFF
--- a/projects/fal/tests/conftest.py
+++ b/projects/fal/tests/conftest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import sys
+import uuid
 from functools import partial
+from typing import Callable
 
 import pytest
 
@@ -16,3 +18,12 @@ print("AUTH:", get_credentials(), file=sys.stderr)
 @pytest.fixture(scope="function")
 def isolated_client():
     return partial(function, machine_type="XS", keep_alive=0)
+
+
+@pytest.fixture(scope="function")
+def make_tmp_app_name() -> Callable[[str], str]:
+    def _make_tmp_app_name(prefix: str = "test") -> str:
+        short_id = uuid.uuid4().hex[:8]
+        return f"{prefix or 'test'}-{short_id}"
+
+    return _make_tmp_app_name

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -532,7 +532,7 @@ def register_app(
             client.delete_alias(app_alias)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def base_app(host: api.FalServerlessHost):
     # running apps without aliases is no longer supported
     # so we need to create an alias for the app
@@ -540,84 +540,84 @@ def base_app(host: api.FalServerlessHost):
         yield app_alias, app_revision
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_app(host: api.FalServerlessHost, user: User):
     with register_app(host, addition_app, "addition") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_nomad_app(host: api.FalServerlessHost, user: User):
     with register_app(host, nomad_addition_app, "nomad") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_container_app(host: api.FalServerlessHost, user: User):
     with register_app(host, container_addition_app, "container") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_container_build_args_app(host: api.FalServerlessHost, user: User):
     with register_app(host, container_build_args_app, "build-args") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_fastapi_app(host: api.FalServerlessHost, user: User):
     with register_app(host, calculator_app, "fastapi") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_stateful_app(host: api.FalServerlessHost, user: User):
     stateful_app = wrap_app(StatefulAdditionApp)
     with register_app(host, stateful_app, "stateful") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_pydantic_validation_error():
     with AppClient.connect(StatefulAdditionApp) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_cancellable_app(host: api.FalServerlessHost, user: User):
     cancellable_app = wrap_app(CancellableApp)
     with register_app(host, cancellable_app, "cancellable") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_exception_app():
     with AppClient.connect(ExceptionApp) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_health_check_app(host: api.FalServerlessHost, user: User):
     health_check_app = wrap_app(HealthCheckApp)
     with register_app(host, health_check_app, "health-check") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_sleep_app(host: api.FalServerlessHost, user: User):
     sleep_app = wrap_app(SleepApp)
     with register_app(host, sleep_app, "sleep") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_queue_blocking_app(host: api.FalServerlessHost, user: User):
     queue_blocking_app = wrap_app(QueueBlockingApp)
     with register_app(host, queue_blocking_app, "queue-blocking") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_realtime_app(host: api.FalServerlessHost, user: User):
     realtime_app = wrap_app(RealtimeApp)
     with register_app(host, realtime_app, "realtime") as (app_alias, _):
@@ -1738,7 +1738,7 @@ class AppRefApp(fal.App, keep_alive=300, max_concurrency=1, max_multiplexing=3):
         )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_app_ref_app(host: api.FalServerlessHost, user: User):
     app_ref_app = wrap_app(AppRefApp)
     with register_app(host, app_ref_app, "app-ref") as (app_alias, _):
@@ -1838,7 +1838,7 @@ RUN apt-get update \
         )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_graceful_shutdown_app(host: api.FalServerlessHost, user: User):
     graceful_shutdown_app = wrap_app(GracefulShutdownApp)
     with register_app(host, graceful_shutdown_app, "graceful-shutdown") as (
@@ -2011,7 +2011,7 @@ class RequestContextApp(fal.App, keep_alive=300, max_concurrency=1, max_multiple
         )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def test_request_context_app(host: api.FalServerlessHost, user: User):
     request_context_app = wrap_app(RequestContextApp)
     with register_app(host, request_context_app, "request-context") as (app_alias, _):

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -509,10 +509,10 @@ def user(rest_client: Client) -> Generator[User, None, None]:
 
 @pytest.fixture()
 def register_app(
+    host: api.FalServerlessHost,
     make_tmp_app_name: Callable[[str], str],
 ) -> Callable[
     [
-        api.FalServerlessHost,
         Union[api.ServedIsolatedFunction, api.IsolatedFunction],
         str,
     ],
@@ -520,7 +520,6 @@ def register_app(
 ]:
     @contextmanager
     def _register_app(
-        host: api.FalServerlessHost,
         app: Union[api.ServedIsolatedFunction, api.IsolatedFunction],
         suffix: str = "",
     ):
@@ -548,10 +547,10 @@ def register_app(
 
 
 @pytest.fixture()
-def base_app(host: api.FalServerlessHost, register_app):
+def base_app(register_app):
     # running apps without aliases is no longer supported
     # so we need to create an alias for the app
-    with register_app(host, addition_app, "base") as (
+    with register_app(addition_app, "base") as (
         app_alias,
         app_revision,
     ):
@@ -560,11 +559,10 @@ def base_app(host: api.FalServerlessHost, register_app):
 
 @pytest.fixture()
 def test_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
-    with register_app(host, addition_app, "addition") as (
+    with register_app(addition_app, "addition") as (
         app_alias,
         _,
     ):
@@ -573,11 +571,10 @@ def test_app(
 
 @pytest.fixture()
 def test_nomad_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
-    with register_app(host, nomad_addition_app, "nomad") as (
+    with register_app(nomad_addition_app, "nomad") as (
         app_alias,
         _,
     ):
@@ -586,42 +583,38 @@ def test_nomad_app(
 
 @pytest.fixture()
 def test_container_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
-    with register_app(host, container_addition_app, "container") as (app_alias, _):
+    with register_app(container_addition_app, "container") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_container_build_args_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
-    with register_app(host, container_build_args_app, "build-args") as (app_alias, _):
+    with register_app(container_build_args_app, "build-args") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_fastapi_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
-    with register_app(host, calculator_app, "fastapi") as (app_alias, _):
+    with register_app(calculator_app, "fastapi") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_stateful_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     stateful_app = wrap_app(StatefulAdditionApp)
-    with register_app(host, stateful_app, "stateful") as (app_alias, _):
+    with register_app(stateful_app, "stateful") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
@@ -633,12 +626,11 @@ def test_pydantic_validation_error():
 
 @pytest.fixture()
 def test_cancellable_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     cancellable_app = wrap_app(CancellableApp)
-    with register_app(host, cancellable_app, "cancellable") as (app_alias, _):
+    with register_app(cancellable_app, "cancellable") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
@@ -650,45 +642,41 @@ def test_exception_app():
 
 @pytest.fixture()
 def test_health_check_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     health_check_app = wrap_app(HealthCheckApp)
-    with register_app(host, health_check_app, "health-check") as (app_alias, _):
+    with register_app(health_check_app, "health-check") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_sleep_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     sleep_app = wrap_app(SleepApp)
-    with register_app(host, sleep_app, "sleep") as (app_alias, _):
+    with register_app(sleep_app, "sleep") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_queue_blocking_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     queue_blocking_app = wrap_app(QueueBlockingApp)
-    with register_app(host, queue_blocking_app, "queue-blocking") as (app_alias, _):
+    with register_app(queue_blocking_app, "queue-blocking") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
 def test_realtime_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     realtime_app = wrap_app(RealtimeApp)
-    with register_app(host, realtime_app, "realtime") as (app_alias, _):
+    with register_app(realtime_app, "realtime") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
@@ -1026,7 +1014,7 @@ def test_404_billable_units(test_exception_app: AppClient):
 def test_app_deploy_scale(host: api.FalServerlessHost, register_app):
     from dataclasses import replace
 
-    with register_app(host, addition_app, "deploy-scale") as (app_alias, _):
+    with register_app(addition_app, "deploy-scale") as (app_alias, _):
         options = replace(
             addition_app.options,
             host={
@@ -1726,18 +1714,15 @@ def test_container_build_args_app_client(test_container_build_args_app: str):
     assert response == "built with build args"
 
 
-def test_container_no_cache_app_client(host: api.FalServerlessHost, register_app):
+def test_container_no_cache_app_client(register_app):
     stdout = StringIO()
     with redirect_stdout(stdout):
-        with register_app(host, container_no_cache_app, "container") as (app_alias, _):
+        with register_app(container_no_cache_app, "container") as (app_alias, _):
             pass
 
     stdout = StringIO()
     with redirect_stdout(stdout):
-        with register_app(host, container_cache_enabled_app, "container") as (
-            app_alias,
-            _,
-        ):
+        with register_app(container_cache_enabled_app, "container") as (app_alias, _):
             pass
 
     logs = stdout.getvalue()
@@ -1745,7 +1730,7 @@ def test_container_no_cache_app_client(host: api.FalServerlessHost, register_app
 
     stdout = StringIO()
     with redirect_stdout(stdout):
-        with register_app(host, container_no_cache_app, "container") as (app_alias, _):
+        with register_app(container_no_cache_app, "container") as (app_alias, _):
             pass
 
     logs = stdout.getvalue()
@@ -1808,12 +1793,11 @@ class AppRefApp(fal.App, keep_alive=300, max_concurrency=1, max_multiplexing=3):
 
 @pytest.fixture()
 def test_app_ref_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     app_ref_app = wrap_app(AppRefApp)
-    with register_app(host, app_ref_app, "app-ref") as (app_alias, _):
+    with register_app(app_ref_app, "app-ref") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
@@ -1912,15 +1896,11 @@ RUN apt-get update \
 
 @pytest.fixture()
 def test_graceful_shutdown_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     graceful_shutdown_app = wrap_app(GracefulShutdownApp)
-    with register_app(host, graceful_shutdown_app, "graceful-shutdown") as (
-        app_alias,
-        _,
-    ):
+    with register_app(graceful_shutdown_app, "graceful-shutdown") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
@@ -2089,12 +2069,11 @@ class RequestContextApp(fal.App, keep_alive=300, max_concurrency=1, max_multiple
 
 @pytest.fixture()
 def test_request_context_app(
-    host: api.FalServerlessHost,
     user: User,
     register_app,
 ):
     request_context_app = wrap_app(RequestContextApp)
-    with register_app(host, request_context_app, "request-context") as (app_alias, _):
+    with register_app(request_context_app, "request-context") as (app_alias, _):
         time.sleep(1)
         yield f"{user.username}/{app_alias}"
 

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -958,65 +958,57 @@ def test_404_billable_units(test_exception_app: AppClient):
 def test_app_deploy_scale(host: api.FalServerlessHost):
     from dataclasses import replace
 
-    app_alias = str(uuid.uuid4()) + "-alias"
-    result = addition_app.host.register(
-        func=addition_app.func,
-        options=addition_app.options,
-        application_name=app_alias,
-        application_auth_mode="private",
-        deployment_strategy="recreate",
-    )
-    assert result
-    assert result.result
-    assert result.service_urls
-    app_revision = result.result.application_id
+    with register_app(host, addition_app, "deploy-scale") as (app_alias, _):
+        options = replace(
+            addition_app.options,
+            host={
+                **addition_app.options.host,
+                "max_multiplexing": 3,
+                "max_concurrency": 2,
+            },
+        )
+        kwargs = dict(
+            func=addition_app.func,
+            options=options,
+            application_name=app_alias,
+            application_auth_mode="private",
+            deployment_strategy="recreate",
+        )
 
-    options = replace(
-        addition_app.options,
-        host={
-            **addition_app.options.host,
-            "max_multiplexing": 3,
-            "max_concurrency": 2,
-        },
-    )
-    kwargs = dict(
-        func=addition_app.func,
-        options=options,
-        application_name=app_alias,
-        application_auth_mode="private",
-        deployment_strategy="recreate",
-    )
+        result = addition_app.host.register(**kwargs, scale=False)
+        assert result
+        assert result.result
+        assert result.service_urls
+        app_revision = result.result.application_id
 
-    result = addition_app.host.register(**kwargs, scale=False)
-    assert result
-    assert result.result
-    assert result.service_urls
-    app_revision = result.result.application_id
+        with host._connection as client:
+            res = client.list_aliases()
+            found = next(filter(lambda alias: alias.alias == app_alias, res), None)
+            assert found, f"Could not find app {app_alias} in {res}"
+            assert found.revision == app_revision
+            # multiplexing is revision-specific
+            assert (
+                found.max_multiplexing == 3
+            ), "Expected max_multiplexing to have changed"
+            # max_concurrency is alias-specific
+            assert (
+                found.max_concurrency == 1
+            ), "Expected max_concurrency to stay the same"
 
-    with host._connection as client:
-        res = client.list_aliases()
-        found = next(filter(lambda alias: alias.alias == app_alias, res), None)
-        assert found, f"Could not find app {app_alias} in {res}"
-        assert found.revision == app_revision
-        # multiplexing is revision-specific
-        assert found.max_multiplexing == 3, "Expected max_multiplexing to have changed"
-        # max_concurrency is alias-specific
-        assert found.max_concurrency == 1, "Expected max_concurrency to stay the same"
+        result = addition_app.host.register(**kwargs, scale=True)
+        assert result
+        assert result.result
+        assert result.service_urls
+        app_revision = result.result.application_id
 
-    result = addition_app.host.register(**kwargs, scale=True)
-    assert result
-    assert result.result
-    assert result.service_urls
-    app_revision = result.result.application_id
-
-    with host._connection as client:
-        res = client.list_aliases()
-        found = next(filter(lambda alias: alias.alias == app_alias, res), None)
-        assert found, f"Could not find app {app_alias} in {res}"
-        assert found.revision == app_revision
-        # when scaling, all values are updated
-        assert found.max_multiplexing == 3
-        assert found.max_concurrency == 2
+        with host._connection as client:
+            res = client.list_aliases()
+            found = next(filter(lambda alias: alias.alias == app_alias, res), None)
+            assert found, f"Could not find app {app_alias} in {res}"
+            assert found.revision == app_revision
+            # when scaling, all values are updated
+            assert found.max_multiplexing == 3
+            assert found.max_concurrency == 2
 
 
 # List aliases is taking long

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import (
     AsyncIterator,
+    Callable,
+    ContextManager,
     Dict,
     Generator,
     Iterator,
@@ -505,73 +507,119 @@ def user(rest_client: Client) -> Generator[User, None, None]:
     yield user
 
 
-@contextmanager
+@pytest.fixture()
 def register_app(
-    host: api.FalServerlessHost,
-    app: Union[api.ServedIsolatedFunction, api.IsolatedFunction],
-    suffix: str = "",
-):
-    app_alias = str(uuid.uuid4()) + "-test-alias" + ("-" + suffix if suffix else "")
-    result = host.register(
-        func=app.func,
-        options=app.options,
-        application_name=app_alias,
-        application_auth_mode="private",
-        deployment_strategy="recreate",
-    )
+    make_tmp_app_name: Callable[[str], str],
+) -> Callable[
+    [
+        api.FalServerlessHost,
+        Union[api.ServedIsolatedFunction, api.IsolatedFunction],
+        str,
+    ],
+    ContextManager[Tuple[str, str]],
+]:
+    @contextmanager
+    def _register_app(
+        host: api.FalServerlessHost,
+        app: Union[api.ServedIsolatedFunction, api.IsolatedFunction],
+        suffix: str = "",
+    ):
+        app_alias = make_tmp_app_name(suffix)
+        result = host.register(
+            func=app.func,
+            options=app.options,
+            application_name=app_alias,
+            application_auth_mode="private",
+            deployment_strategy="recreate",
+        )
 
-    assert result
-    assert result.result
-    assert result.service_urls
-    app_revision = result.result.application_id
+        assert result
+        assert result.result
+        assert result.service_urls
+        app_revision = result.result.application_id
 
-    try:
-        yield app_alias, app_revision
-    finally:
-        with host._connection as client:
-            client.delete_alias(app_alias)
+        try:
+            yield app_alias, app_revision
+        finally:
+            with host._connection as client:
+                client.delete_alias(app_alias)
+
+    return _register_app
 
 
 @pytest.fixture()
-def base_app(host: api.FalServerlessHost):
+def base_app(host: api.FalServerlessHost, register_app):
     # running apps without aliases is no longer supported
     # so we need to create an alias for the app
-    with register_app(host, addition_app, "base") as (app_alias, app_revision):
+    with register_app(host, addition_app, "base") as (
+        app_alias,
+        app_revision,
+    ):
         yield app_alias, app_revision
 
 
 @pytest.fixture()
-def test_app(host: api.FalServerlessHost, user: User):
-    with register_app(host, addition_app, "addition") as (app_alias, _):
+def test_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
+    with register_app(host, addition_app, "addition") as (
+        app_alias,
+        _,
+    ):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_nomad_app(host: api.FalServerlessHost, user: User):
-    with register_app(host, nomad_addition_app, "nomad") as (app_alias, _):
+def test_nomad_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
+    with register_app(host, nomad_addition_app, "nomad") as (
+        app_alias,
+        _,
+    ):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_container_app(host: api.FalServerlessHost, user: User):
+def test_container_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     with register_app(host, container_addition_app, "container") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_container_build_args_app(host: api.FalServerlessHost, user: User):
+def test_container_build_args_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     with register_app(host, container_build_args_app, "build-args") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_fastapi_app(host: api.FalServerlessHost, user: User):
+def test_fastapi_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     with register_app(host, calculator_app, "fastapi") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_stateful_app(host: api.FalServerlessHost, user: User):
+def test_stateful_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     stateful_app = wrap_app(StatefulAdditionApp)
     with register_app(host, stateful_app, "stateful") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
@@ -584,7 +632,11 @@ def test_pydantic_validation_error():
 
 
 @pytest.fixture()
-def test_cancellable_app(host: api.FalServerlessHost, user: User):
+def test_cancellable_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     cancellable_app = wrap_app(CancellableApp)
     with register_app(host, cancellable_app, "cancellable") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
@@ -597,28 +649,44 @@ def test_exception_app():
 
 
 @pytest.fixture()
-def test_health_check_app(host: api.FalServerlessHost, user: User):
+def test_health_check_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     health_check_app = wrap_app(HealthCheckApp)
     with register_app(host, health_check_app, "health-check") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_sleep_app(host: api.FalServerlessHost, user: User):
+def test_sleep_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     sleep_app = wrap_app(SleepApp)
     with register_app(host, sleep_app, "sleep") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_queue_blocking_app(host: api.FalServerlessHost, user: User):
+def test_queue_blocking_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     queue_blocking_app = wrap_app(QueueBlockingApp)
     with register_app(host, queue_blocking_app, "queue-blocking") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
 
 
 @pytest.fixture()
-def test_realtime_app(host: api.FalServerlessHost, user: User):
+def test_realtime_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     realtime_app = wrap_app(RealtimeApp)
     with register_app(host, realtime_app, "realtime") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
@@ -955,7 +1023,7 @@ def test_404_billable_units(test_exception_app: AppClient):
         assert response.headers.get("x-fal-billable-units") == "0"
 
 
-def test_app_deploy_scale(host: api.FalServerlessHost):
+def test_app_deploy_scale(host: api.FalServerlessHost, register_app):
     from dataclasses import replace
 
     with register_app(host, addition_app, "deploy-scale") as (app_alias, _):
@@ -1658,7 +1726,7 @@ def test_container_build_args_app_client(test_container_build_args_app: str):
     assert response == "built with build args"
 
 
-def test_container_no_cache_app_client(host: api.FalServerlessHost):
+def test_container_no_cache_app_client(host: api.FalServerlessHost, register_app):
     stdout = StringIO()
     with redirect_stdout(stdout):
         with register_app(host, container_no_cache_app, "container") as (app_alias, _):
@@ -1739,7 +1807,11 @@ class AppRefApp(fal.App, keep_alive=300, max_concurrency=1, max_multiplexing=3):
 
 
 @pytest.fixture()
-def test_app_ref_app(host: api.FalServerlessHost, user: User):
+def test_app_ref_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     app_ref_app = wrap_app(AppRefApp)
     with register_app(host, app_ref_app, "app-ref") as (app_alias, _):
         yield f"{user.username}/{app_alias}"
@@ -1839,7 +1911,11 @@ RUN apt-get update \
 
 
 @pytest.fixture()
-def test_graceful_shutdown_app(host: api.FalServerlessHost, user: User):
+def test_graceful_shutdown_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     graceful_shutdown_app = wrap_app(GracefulShutdownApp)
     with register_app(host, graceful_shutdown_app, "graceful-shutdown") as (
         app_alias,
@@ -2012,7 +2088,11 @@ class RequestContextApp(fal.App, keep_alive=300, max_concurrency=1, max_multiple
 
 
 @pytest.fixture()
-def test_request_context_app(host: api.FalServerlessHost, user: User):
+def test_request_context_app(
+    host: api.FalServerlessHost,
+    user: User,
+    register_app,
+):
     request_context_app = wrap_app(RequestContextApp)
     with register_app(host, request_context_app, "request-context") as (app_alias, _):
         time.sleep(1)


### PR DESCRIPTION
We keep leaking these with every run for no reason. The module-scoped get leaked if we happen to hit a github workflow timeout and pytest gets killed, so better to keep them narrow.
