### PR TITLE
feat(cli): add --strategy flag to apps set-rev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 # pyenv
 .python-version
 
+*.code-workspace
+
 # Environments
 .env
 .venv

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.23.1,<0.26",
-    "isolate-proto>=0.30.10,<1",
+    "isolate-proto>=0.30.11,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle==3.0.0",

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.23.1,<0.26",
-    "isolate-proto>=0.30.6,<1",
+    "isolate-proto>=0.30.10,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle==3.0.0",

--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -346,7 +346,11 @@ def _set_rev(args):
     client = get_client(args.host, args.team)
     with client.connect() as connection:
         alias_info = connection.create_alias(
-            args.app_name, args.app_rev, args.auth, environment_name=args.env
+            args.app_name,
+            args.app_rev,
+            args.auth,
+            environment_name=args.env,
+            deployment_strategy=args.strategy,
         )
         table = _apps_table([alias_info])
 
@@ -354,7 +358,7 @@ def _set_rev(args):
 
 
 def _add_set_rev_parser(subparsers, parents):
-    from fal.sdk import ALIAS_AUTH_MODES
+    from fal.sdk import ALIAS_AUTH_MODES, DEPLOYMENT_STRATEGIES
 
     set_help = "Set application to a particular revision."
     parser = subparsers.add_parser(
@@ -376,6 +380,12 @@ def _add_set_rev_parser(subparsers, parents):
         choices=ALIAS_AUTH_MODES,
         default=None,
         help="Application authentication mode.",
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=DEPLOYMENT_STRATEGIES,
+        required=True,
+        help="Deployment strategy.",
     )
     add_env_argument(parser)
     parser.set_defaults(func=_set_rev)

--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -384,7 +384,7 @@ def _add_set_rev_parser(subparsers, parents):
     parser.add_argument(
         "--strategy",
         choices=DEPLOYMENT_STRATEGIES,
-        required=True,
+        default=None,
         help="Deployment strategy.",
     )
     add_env_argument(parser)

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -41,6 +41,7 @@ FAL_SERVERLESS_DEFAULT_MIN_CONCURRENCY = 0
 FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER = 0
 FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER_PERC = 0
 ALIAS_AUTH_MODES = ["public", "private", "shared"]
+DEPLOYMENT_STRATEGIES = ["recreate", "rolling"]
 
 logger = get_logger(__name__)
 
@@ -1054,6 +1055,7 @@ class FalServerlessConnection:
         auth_mode: Optional[AuthModeLiteral],
         *,
         environment_name: str | None = None,
+        deployment_strategy: DeploymentStrategyLiteral | None = None,
     ) -> AliasInfo:
         if auth_mode == "public":
             auth = isolate_proto.ApplicationAuthMode.PUBLIC
@@ -1066,11 +1068,18 @@ class FalServerlessConnection:
 
         full_alias = construct_alias(alias, environment_name)
 
+        deployment_strategy_proto = (
+            DeploymentStrategy[deployment_strategy.upper()].to_proto()
+            if deployment_strategy is not None
+            else None
+        )
+
         request = isolate_proto.SetAliasRequest(
             alias=full_alias,
             revision=revision,
             auth_mode=auth,
             environment_name=environment_name,
+            deployment_strategy=deployment_strategy_proto,
         )
         res = self.stub.SetAlias(request)
         return from_grpc(res.alias_info)


### PR DESCRIPTION
## Summary
- Plumb `deployment_strategy` from `SetAliasRequest` proto through `FalServerlessConnection.create_alias`
- Add optional `--strategy rolling|recreate` flag to `fal apps set-rev` CLI command
- Add `DEPLOYMENT_STRATEGIES` constant to `sdk.py`


🤖 Generated with [Claude Code](https://claude.com/claude-code)