### PR TITLE
fix(app): validate websocket endpoint annotations

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -26,6 +26,7 @@ from typing import (
     Optional,
     TypeVar,
     cast,
+    get_type_hints,
     overload,
 )
 
@@ -38,10 +39,13 @@ from fastapi import FastAPI
 from fastapi import __version__ as fastapi_version
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.logger import logger as fastapi_logger
+from fastapi.params import Param
 from isolate.backends.common import Requirements
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from pydantic import __version__ as pydantic_version
+from starlette.websockets import WebSocket
 from typing_extensions import Concatenate, ParamSpec
 
 import fal.flags as flags
@@ -1713,9 +1717,7 @@ class FalServer(uvicorn.Server):
         try:
             self._handle_exit()
         except BaseException as e:
-            from fastapi.logger import logger  # noqa: PLC0415
-
-            logger.exception(f"Error in handle_exit: {e}")
+            fastapi_logger.exception(f"Error in handle_exit: {e}")
 
 
 class BaseServable:
@@ -1736,6 +1738,67 @@ class BaseServable:
     @asynccontextmanager
     async def lifespan(self, app: FastAPI):
         yield
+
+    def _validate_websocket_endpoint(
+        self,
+        signature: RouteSignature,
+        endpoint: Callable[..., Any],
+    ) -> None:
+        raw_endpoint = getattr(endpoint, "__func__", endpoint)
+        endpoint_name = getattr(raw_endpoint, "__qualname__", endpoint.__name__)
+        is_async = inspect.iscoroutinefunction(raw_endpoint)
+        endpoint_signature = inspect.signature(raw_endpoint)
+        parameter_names = [
+            name
+            for name, parameter in endpoint_signature.parameters.items()
+            if parameter.kind
+            not in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            )
+            and not isinstance(parameter.default, Param)
+        ]
+
+        try:
+            annotations = get_type_hints(raw_endpoint)
+        except Exception as exc:
+            fastapi_logger.debug("get_type_hints failed for %s: %s", endpoint_name, exc)
+            annotations = getattr(raw_endpoint, "__annotations__", {}) or {}
+
+        has_websocket_annotation = False
+        for parameter_name in parameter_names:
+            annotation = annotations.get(parameter_name)
+            if inspect.isclass(annotation) and issubclass(annotation, WebSocket):
+                has_websocket_annotation = True
+                break
+            if isinstance(annotation, str) and annotation.split(".")[-1] == "WebSocket":
+                has_websocket_annotation = True
+                break
+
+        if is_async and has_websocket_annotation:
+            return
+
+        suggested_parameter_name = "websocket"
+        for parameter_name in parameter_names:
+            if parameter_name not in {"self", "cls"}:
+                suggested_parameter_name = parameter_name
+                break
+
+        requirements = []
+        if not is_async:
+            requirements.append("be defined with async def")
+        if not has_websocket_annotation:
+            requirements.append("declare a parameter annotated as fastapi.WebSocket")
+
+        error_message = (
+            f"Websocket endpoint {endpoint_name!r} at {signature.path!r} must "
+            f"{' and '.join(requirements)}. "
+            f"Got signature {endpoint_signature}. "
+            f"For example: `async def {endpoint.__name__}(self, "
+            f"{suggested_parameter_name}: WebSocket): ...`"
+        )
+        fastapi_logger.error(error_message)
+        raise ValueError(error_message)
 
     def _build_app(self) -> FalFastAPI:
         import json  # noqa: PLC0415
@@ -1855,6 +1918,7 @@ class BaseServable:
 
         for signature, endpoint in routes.items():
             if signature.is_websocket:
+                self._validate_websocket_endpoint(signature, endpoint)
                 _app.add_websocket_route_with_metadata(signature, endpoint)
             else:
                 _app.add_api_route(
@@ -1954,8 +2018,6 @@ class BaseServable:
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
-            from fastapi.logger import logger  # noqa: PLC0415
-
             if app_task in done and metrics_task in pending:
                 metrics_task.cancel()
 
@@ -1966,10 +2028,12 @@ class BaseServable:
             )
 
             if app_exc:
-                logger.error("App server exited with error", exc_info=app_exc)
+                fastapi_logger.error("App server exited with error", exc_info=app_exc)
 
             if metrics_exc and not isinstance(metrics_exc, asyncio.CancelledError):
-                logger.error("Metrics server exited with error", exc_info=metrics_exc)
+                fastapi_logger.error(
+                    "Metrics server exited with error", exc_info=metrics_exc
+                )
 
             if app_exc:
                 raise app_exc

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -901,6 +901,79 @@ def test_openapi_websocket_barebones_has_no_realtime_marker(isolate_agent_env):
     assert "post" not in spec["paths"]["/ws"]
 
 
+def test_websocket_endpoint_requires_websocket_annotation(isolate_agent_env):
+    class MissingWebSocketAnnotationApp(App):
+        @endpoint("/ws", is_websocket=True)
+        async def generate_ws(self, websocket) -> None:
+            return None
+
+    app = MissingWebSocketAnnotationApp()
+
+    with patch("fal.api.api.fastapi_logger") as mock_logger:
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Websocket endpoint '.*generate_ws' at '/ws' must declare "
+                r"a parameter annotated as fastapi\.WebSocket\."
+            ),
+        ) as exc_info:
+            app._build_app()
+
+    message = str(exc_info.value)
+    assert "Got signature (self, websocket)" in message
+    assert "async def generate_ws(self, websocket: WebSocket):" in message
+    mock_logger.error.assert_called_once_with(message)
+
+
+def test_websocket_endpoint_requires_async_handler(isolate_agent_env):
+    class SyncWebSocketApp(App):
+        @endpoint("/ws", is_websocket=True)
+        def generate_ws(self, websocket: WebSocket) -> None:
+            return None
+
+    app = SyncWebSocketApp()
+
+    with patch("fal.api.api.fastapi_logger") as mock_logger:
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Websocket endpoint '.*generate_ws' at '/ws' must be defined "
+                r"with async def\."
+            ),
+        ) as exc_info:
+            app._build_app()
+
+    message = str(exc_info.value)
+    assert "Got signature (self, websocket" in message
+    assert (
+        "For example: `async def generate_ws(self, websocket: WebSocket): ...`"
+        in message
+    )
+    mock_logger.error.assert_called_once_with(message)
+
+
+def test_websocket_endpoint_requires_async_and_annotation(isolate_agent_env):
+    class SyncMissingAnnotationApp(App):
+        @endpoint("/ws", is_websocket=True)
+        def generate_ws(self, websocket) -> None:
+            return None
+
+    app = SyncMissingAnnotationApp()
+
+    with patch("fal.api.api.fastapi_logger") as mock_logger:
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Websocket endpoint '.*generate_ws' at '/ws' must be defined "
+                r"with async def and declare a parameter annotated as "
+                r"fastapi\.WebSocket\."
+            ),
+        ) as exc_info:
+            app._build_app()
+
+    mock_logger.error.assert_called_once_with(str(exc_info.value))
+
+
 def test_openapi_websocket_realtime_streaming_modes_marked(isolate_agent_env):
     app = RealtimeApp()
     spec = app.openapi()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- validate websocket endpoints before FastAPI route registration
- require websocket handlers to be declared with `async def` and to include a `WebSocket`-typed parameter
- log and raise a clear error when either requirement is missing, with an example signature to follow
- add unit coverage for missing annotation and sync websocket handler cases

## Testing
- `python3 -m pytest -q projects/fal/tests/unit/test_app.py -k websocket`
- `python3 -m pre_commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eddabbc6-4bad-4b6f-ad33-d56f13e2da39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eddabbc6-4bad-4b6f-ad33-d56f13e2da39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

