### PR TITLE
chore(fal): bump isolate upper bound

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -22,7 +22,7 @@ authors = [{ name = "Features & Labels <support@fal.ai>"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "isolate[build]>=0.23.1,<0.26",
+    "isolate[build]>=0.23.1,<0.27.0",
     "isolate-proto>=0.30.11,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `projects/fal/pyproject.toml` to allow `isolate[build]` versions below `0.27.0`
- keep the existing lower bound of `0.23.1`

## Testing
- `python3 -m pre_commit run --all-files`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87fc03e0-5b48-4bd3-8be7-fde93cb5389b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87fc03e0-5b48-4bd3-8be7-fde93cb5389b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

