### PR TITLE
fix: preserve unset private_logs on register

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -758,8 +758,7 @@ class FalServerlessHost(Host):
             deployment_strategy=deployment_strategy,
             scale=scale,
             health_check_config=health_check_config,
-            # By default, logs are public
-            private_logs=options.host.get("private_logs", False),
+            private_logs=options.host.get("private_logs"),
             files=files,
             skip_retry_conditions=skip_retry_conditions,
             environment_name=environment_name,

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -799,7 +799,7 @@ class FalServerlessConnection:
         metadata: dict[str, Any] | None = None,
         deployment_strategy: DeploymentStrategyLiteral,
         scale: bool = True,
-        private_logs: bool = False,
+        private_logs: bool | None = None,
         files: list[File] | None = None,
         skip_retry_conditions: list[RetryConditionLiteral] | None = None,
         environment_name: str | None = None,
@@ -883,7 +883,6 @@ class FalServerlessConnection:
             metadata=struct_metadata,
             deployment_strategy=deployment_strategy_proto,
             scale=scale,
-            private_logs=private_logs,
             files=files,
             source_code=source_code,
             health_check_config=wrapped_health_check_config,
@@ -891,6 +890,8 @@ class FalServerlessConnection:
             environment_name=environment_name,
             termination_grace_period_seconds=termination_grace_period_seconds,
         )
+        if private_logs is not None:
+            request.private_logs = private_logs
         for partial_result in self.stub.RegisterApplication(request):
             yield from_grpc(partial_result)
 

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -124,6 +124,65 @@ def test_run_forwards_regions_to_machine_requirements():
     assert call_kwargs["machine_requirements"].valid_regions == ["us-east"]
 
 
+def test_register_leaves_private_logs_unset_by_default():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult
+
+    host = FalServerlessHost()
+    options = Options()
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult()
+    partial_result.result = "ok"
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            lambda: "ok",
+            options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    assert call_kwargs["private_logs"] is None
+
+
+def test_register_forwards_explicit_private_logs_false():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult
+
+    host = FalServerlessHost()
+    options = Options()
+    options.host["private_logs"] = False
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult()
+    partial_result.result = "ok"
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            lambda: "ok",
+            options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    assert call_kwargs["private_logs"] is False
+
+
 def test_wrap_app_allows_resolver_with_container_kind():
     from fal.app import wrap_app
 

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -126,15 +126,16 @@ def test_run_forwards_regions_to_machine_requirements():
 
 def test_register_leaves_private_logs_unset_by_default():
     from fal.api.api import FalServerlessHost, Options
-    from fal.sdk import RegisterApplicationResult
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
 
     host = FalServerlessHost()
     options = Options()
 
     connection = MagicMock()
     connection.define_environment.return_value = object()
-    partial_result = RegisterApplicationResult()
-    partial_result.result = "ok"
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
     connection.register.return_value = iter([partial_result])
 
     with patch.object(
@@ -155,7 +156,7 @@ def test_register_leaves_private_logs_unset_by_default():
 
 def test_register_forwards_explicit_private_logs_false():
     from fal.api.api import FalServerlessHost, Options
-    from fal.sdk import RegisterApplicationResult
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
 
     host = FalServerlessHost()
     options = Options()
@@ -163,8 +164,9 @@ def test_register_forwards_explicit_private_logs_false():
 
     connection = MagicMock()
     connection.define_environment.return_value = object()
-    partial_result = RegisterApplicationResult()
-    partial_result.result = "ok"
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
     connection.register.return_value = iter([partial_result])
 
     with patch.object(

--- a/projects/isolate_proto/tests/test_proto.py
+++ b/projects/isolate_proto/tests/test_proto.py
@@ -72,3 +72,20 @@ def test_callable_entrypoint_fields():
     )
     assert register_request_last_write_wins.WhichOneof("callable") == "entrypoint"
     assert register_request_last_write_wins.entrypoint == "pkg.mod:App.run"
+
+
+def test_register_application_private_logs_presence():
+    request_without_private_logs = isolate_proto.RegisterApplicationRequest()
+    assert request_without_private_logs.HasField("private_logs") is False
+
+    request_with_private_logs_false = isolate_proto.RegisterApplicationRequest(
+        private_logs=False
+    )
+    assert request_with_private_logs_false.HasField("private_logs") is True
+    assert request_with_private_logs_false.private_logs is False
+
+    request_with_private_logs_true = isolate_proto.RegisterApplicationRequest(
+        private_logs=True
+    )
+    assert request_with_private_logs_true.HasField("private_logs") is True
+    assert request_with_private_logs_true.private_logs is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve `private_logs=None` through the fal deploy path so the optional gRPC field stays unset by default
- only set `RegisterApplicationRequest.private_logs` when the caller explicitly provides a value
- add regression coverage for protobuf field presence and fal host forwarding behavior

## Testing
- `python3 -m pytest projects/isolate_proto/tests/test_proto.py projects/fal/tests/unit/test_app.py -k "private_logs_presence or register_leaves_private_logs_unset_by_default or register_forwards_explicit_private_logs_false"`
- `python3 -m pre_commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f053f6f2-0296-4774-9222-9580679cc719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f053f6f2-0296-4774-9222-9580679cc719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

