### PR TITLE
fix(fal_client): avoid blocking io in async client

### DIFF
--- a/projects/fal_client/pyproject.toml
+++ b/projects/fal_client/pyproject.toml
@@ -17,6 +17,8 @@ readme = "README.md"
 authors = [{ name = "Features & Labels <support@fal.ai>" }]
 requires-python = ">=3.8"
 dependencies = [
+    "aiofiles>=24.1.0,<26",
+    "asyncstdlib>=3.12.5,<4",
     "httpx>=0.21.0,<1",
     "httpx-sse>=0.4.0,<0.5",
     "msgpack>=1.0.7,<2",

--- a/projects/fal_client/src/fal_client/auth.py
+++ b/projects/fal_client/src/fal_client/auth.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import os
+import sys
 import time
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from threading import Lock
-from typing import Optional
+from typing import Callable, Optional, TypeVar
 
+import aiofiles
+import aiofiles.os
 import httpx
 
 
@@ -21,6 +26,7 @@ class GoogleColabState:
 
 
 _colab_state = GoogleColabState()
+_T = TypeVar("_T")
 
 
 def is_google_colab() -> bool:
@@ -84,10 +90,43 @@ AUTH0_CLIENT_ID = "TwXR51Vz8JbY8GUUMy6EyuVR0fTO7N4N"
 AUTH_TOKEN_FILENAME = "auth0_token"
 AUTH_LOCK_FILENAME = ".portalock"
 DEFAULT_FAL_HOME = Path.home() / ".fal"
+MISSING_CREDENTIALS_MESSAGE = (
+    "No credentials found. Set FAL_KEY (or FAL_KEY_ID/FAL_KEY_SECRET) "
+    "or login via `fal auth login`."
+)
 
 
 def _get_fal_home_dir() -> Path:
     return Path(os.getenv("FAL_HOME_DIR", str(DEFAULT_FAL_HOME))).expanduser()
+
+
+def _resolve_env_or_colab_auth(force_user_auth: bool) -> Optional[AuthCredentials]:
+    if force_user_auth:
+        return None
+
+    if key := os.getenv("FAL_KEY"):
+        return AuthCredentials("Key", key)
+
+    if (key_id := os.getenv("FAL_KEY_ID")) and (
+        fal_key_secret := os.getenv("FAL_KEY_SECRET")
+    ):
+        return AuthCredentials("Key", f"{key_id}:{fal_key_secret}")
+
+    if colab_token := get_colab_token():
+        return AuthCredentials("Key", colab_token)
+
+    return None
+
+
+async def _run_sync_in_thread(
+    func: Callable[..., _T], *args: object, **kwargs: object
+) -> _T:
+    # Python 3.8 compatibility: asyncio.to_thread was added in 3.9.
+    if hasattr(asyncio, "to_thread"):
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(func, *args, **kwargs))
 
 
 @contextmanager
@@ -108,12 +147,63 @@ def _token_lock():
         yield
 
 
+@asynccontextmanager
+async def _token_lock_async():
+    """Best effort async lock shared with fal-cli."""
+
+    try:
+        import portalocker
+    except Exception:
+        yield
+        return
+
+    lock_file = _get_fal_home_dir() / AUTH_LOCK_FILENAME
+    await aiofiles.os.makedirs(lock_file.parent, exist_ok=True)
+    lock = portalocker.utils.TemporaryFileLock(
+        str(lock_file), fail_when_locked=False, timeout=20
+    )
+    exc_info = (None, None, None)
+    entered = False
+    try:
+        await _run_sync_in_thread(lock.__enter__)
+        entered = True
+        yield
+    except BaseException:
+        # sys.exc_info() returns (exc_type, exc_value, traceback), matching
+        # the context manager __exit__ signature.
+        exc_info = sys.exc_info()
+        raise
+    finally:
+        if entered:
+            await _run_sync_in_thread(lock.__exit__, *exc_info)
+
+
 def _read_auth_tokens() -> tuple[Optional[str], Optional[str]]:
     path = _get_fal_home_dir() / AUTH_TOKEN_FILENAME
     if not path.exists():
         return None, None
 
     lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if not lines:
+        return None, None
+
+    refresh_token = lines[0]
+    access_token: Optional[str] = None
+    if len(lines) > 1:
+        access_token = lines[1]
+
+    return refresh_token or None, access_token or None
+
+
+async def _read_auth_tokens_async() -> tuple[Optional[str], Optional[str]]:
+    path = _get_fal_home_dir() / AUTH_TOKEN_FILENAME
+    if not await aiofiles.os.path.exists(path):
+        return None, None
+
+    async with aiofiles.open(path) as file:
+        contents = await file.read()
+
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
     if not lines:
         return None, None
 
@@ -134,6 +224,20 @@ def _write_auth_tokens(refresh_token: str, access_token: Optional[str]) -> None:
         contents.append(access_token)
 
     path.write_text("\n".join(contents))
+
+
+async def _write_auth_tokens_async(
+    refresh_token: str, access_token: Optional[str]
+) -> None:
+    path = _get_fal_home_dir() / AUTH_TOKEN_FILENAME
+    await aiofiles.os.makedirs(path.parent, exist_ok=True)
+
+    contents = [refresh_token]
+    if access_token:
+        contents.append(access_token)
+
+    async with aiofiles.open(path, "w") as file:
+        await file.write("\n".join(contents))
 
 
 def _decode_jwt_exp(token: str) -> Optional[int]:
@@ -182,6 +286,30 @@ def _refresh_access_token(refresh_token: str) -> dict:
     return token_data
 
 
+async def _refresh_access_token_async(refresh_token: str) -> dict:
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(
+            AUTH0_TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": AUTH0_CLIENT_ID,
+                "refresh_token": refresh_token,
+            },
+        )
+
+    try:
+        token_data = response.json()
+    except Exception:
+        token_data = {}
+
+    if response.status_code != 200 or "access_token" not in token_data:
+        raise MissingCredentialsError(
+            "Failed to refresh fal auth token. Please run `fal auth login` again."
+        )
+
+    return token_data
+
+
 def _load_bearer_token_from_login() -> Optional[str]:
     """
     Try to reuse tokens created by `fal auth login`.
@@ -210,6 +338,37 @@ def _load_bearer_token_from_login() -> Optional[str]:
     return new_access
 
 
+async def _load_bearer_token_from_login_async() -> Optional[str]:
+    """
+    Try to reuse tokens created by `fal auth login`.
+
+    We share the same file layout as fal-cli:
+    - refresh token on first line
+    - optional cached access token on second line
+    """
+
+    async with _token_lock_async():
+        refresh_token, access_token = await _read_auth_tokens_async()
+
+    if not refresh_token:
+        return None
+
+    if access_token and not _is_access_token_expired(access_token):
+        return access_token
+
+    # Keep the file lock narrow and do not hold it across the Auth0 refresh
+    # request. Another process may refresh in parallel, but this mirrors the
+    # sync path and avoids blocking fal CLI/client token file access on network I/O.
+    token_data = await _refresh_access_token_async(refresh_token)
+    new_refresh = token_data.get("refresh_token", refresh_token)
+    new_access = token_data["access_token"]
+
+    async with _token_lock_async():
+        await _write_auth_tokens_async(new_refresh, new_access)
+
+    return new_access
+
+
 def fetch_auth_credentials() -> AuthCredentials:
     """
     Return credentials using this priority:
@@ -219,22 +378,33 @@ def fetch_auth_credentials() -> AuthCredentials:
 
     force_user_auth = os.environ.get("FAL_FORCE_AUTH_BY_USER") == "1"
 
-    if not force_user_auth:
-        if key := os.getenv("FAL_KEY"):
-            return AuthCredentials("Key", key)
-        elif (key_id := os.getenv("FAL_KEY_ID")) and (
-            fal_key_secret := os.getenv("FAL_KEY_SECRET")
-        ):
-            return AuthCredentials("Key", f"{key_id}:{fal_key_secret}")
-        elif colab_token := get_colab_token():
-            return AuthCredentials("Key", colab_token)
+    if auth := _resolve_env_or_colab_auth(force_user_auth):
+        return auth
 
     if bearer := _load_bearer_token_from_login():
         return AuthCredentials("Bearer", bearer)
 
-    raise MissingCredentialsError(
-        "No credentials found. Set FAL_KEY (or FAL_KEY_ID/FAL_KEY_SECRET) or login via `fal auth login`."
-    )
+    raise MissingCredentialsError(MISSING_CREDENTIALS_MESSAGE)
+
+
+async def fetch_auth_credentials_async() -> AuthCredentials:
+    """
+    Async variant of fetch_auth_credentials for async client usage.
+
+    Return credentials using this priority:
+    1) FAL_KEY / FAL_KEY_ID+FAL_KEY_SECRET / Colab secret (unless FAL_FORCE_AUTH_BY_USER=1)
+    2) Tokens saved by `fal auth login`
+    """
+
+    force_user_auth = os.environ.get("FAL_FORCE_AUTH_BY_USER") == "1"
+
+    if auth := _resolve_env_or_colab_auth(force_user_auth):
+        return auth
+
+    if bearer := await _load_bearer_token_from_login_async():
+        return AuthCredentials("Bearer", bearer)
+
+    raise MissingCredentialsError(MISSING_CREDENTIALS_MESSAGE)
 
 
 def fetch_credentials() -> str:

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -33,15 +33,18 @@ from typing import (
 from urllib.parse import urlencode
 import warnings
 
+import aiofiles
+import aiofiles.os
 import httpx
+from asyncstdlib import cached_property as async_cached_property
 from httpx_sse import aconnect_sse, connect_sse
 
 from fal_client.auth import (
     AuthCredentials,
     FAL_QUEUE_RUN_HOST,
     FAL_RUN_HOST,
-    MissingCredentialsError,
     fetch_auth_credentials,
+    fetch_auth_credentials_async,
 )
 from fal_client._version import __version__
 from fal_client._headers import (
@@ -439,8 +442,7 @@ class AsyncMultipartUpload:
             raise ValueError("Upload not initiated")
         return self._upload_id
 
-    @property
-    async def auth_headers(self) -> dict[str, str]:
+    async def get_auth_headers(self) -> dict[str, str]:
         token = await self._token_manager.get_token()
         return {
             "Authorization": f"{token.token_type} {token.token}",
@@ -452,9 +454,9 @@ class AsyncMultipartUpload:
     ):
         token = await self._token_manager.get_token()
         url = f"{token.base_upload_url}/files/upload/multipart"
-        headers = await self.auth_headers
         request_headers = {
-            **headers,
+            "Authorization": f"{token.token_type} {token.token}",
+            "User-Agent": USER_AGENT,
             "Accept": "application/json",
             "Content-Type": self.content_type,
             "X-Fal-File-Name": self.file_name,
@@ -472,7 +474,7 @@ class AsyncMultipartUpload:
 
     async def upload_part(self, part_number: int, data: bytes) -> None:
         url = f"{self.access_url}/multipart/{self.upload_id}/{part_number}"
-        headers = await self.auth_headers
+        headers = await self.get_auth_headers()
 
         response = await _async_request(
             self._client,
@@ -497,7 +499,7 @@ class AsyncMultipartUpload:
 
     async def complete(self) -> str:
         url = f"{self.access_url}/multipart/{self.upload_id}/complete"
-        headers = await self.auth_headers
+        headers = await self.get_auth_headers()
         await _async_maybe_retry_request(
             self._client,
             "POST",
@@ -536,19 +538,15 @@ class AsyncMultipartUpload:
             chunk = data[start : start + multipart.chunk_size]
             await multipart.upload_part(part_number, chunk)
 
-        tasks = [
-            asyncio.create_task(upload_part(part_number))
-            for part_number in range(1, parts + 1)
-        ]
-
-        # Process concurrent uploads with semaphore to limit concurrency
         sem = asyncio.Semaphore(multipart.max_concurrency)
 
-        async def bounded_upload(task):
+        async def bounded_upload(part_number: int) -> None:
             async with sem:
-                await task
+                await upload_part(part_number)
 
-        await asyncio.gather(*[bounded_upload(task) for task in tasks])
+        await asyncio.gather(
+            *(bounded_upload(part_number) for part_number in range(1, parts + 1))
+        )
         return await multipart.complete()
 
     @classmethod
@@ -564,7 +562,7 @@ class AsyncMultipartUpload:
         object_lifecycle_preference: LifecyclePreferencePayload | None = None,
     ) -> str:
         file_name = os.path.basename(file_path)
-        size = os.path.getsize(file_path)
+        size = await aiofiles.os.path.getsize(file_path)
         multipart = cls(
             file_name=file_name,
             client=client,
@@ -577,25 +575,21 @@ class AsyncMultipartUpload:
         parts = math.ceil(size / multipart.chunk_size)
 
         async def upload_part(part_number: int) -> None:
-            with open(file_path, "rb") as f:
+            async with aiofiles.open(file_path, "rb") as f:
                 start = (part_number - 1) * multipart.chunk_size
-                f.seek(start)
-                data = f.read(multipart.chunk_size)
+                await f.seek(start)
+                data = await f.read(multipart.chunk_size)
                 await multipart.upload_part(part_number, data)
 
-        tasks = [
-            asyncio.create_task(upload_part(part_number))
-            for part_number in range(1, parts + 1)
-        ]
-
-        # Process concurrent uploads with semaphore to limit concurrency
         sem = asyncio.Semaphore(multipart.max_concurrency)
 
-        async def bounded_upload(task):
+        async def bounded_upload(part_number: int) -> None:
             async with sem:
-                await task
+                await upload_part(part_number)
 
-        await asyncio.gather(*[bounded_upload(task) for task in tasks])
+        await asyncio.gather(
+            *(bounded_upload(part_number) for part_number in range(1, parts + 1))
+        )
         return await multipart.complete()
 
 
@@ -1448,14 +1442,11 @@ def _try_upload_with_fallback(
 
 
 async def _async_try_upload_with_fallback(
-    attempts: list[tuple[str, Callable[[], Any]]],
+    attempts: list[tuple[str, Callable[[], Awaitable[str]]]],
 ) -> str:
     for idx, (label, attempt) in enumerate(attempts):
         try:
-            result = attempt()
-            if asyncio.iscoroutine(result):
-                return await result
-            return result
+            return await attempt()
         except Exception as exc:
             if idx >= len(attempts) - 1:
                 raise
@@ -1639,35 +1630,22 @@ class AsyncRequestHandle(_BaseRequestHandle):
         _raise_for_status(response)
 
 
-@dataclass(frozen=True)
+# async_cached_property stores values on __dict__, so AsyncClient cannot be
+# frozen like SyncClient. Keep hash generation for backwards compatibility.
+@dataclass(unsafe_hash=True)
 class AsyncClient:
     key: str | None = field(default=None, repr=False)
     default_timeout: float = 120.0
 
-    @cached_property
-    def _auth(self) -> AuthCredentials:
-        if self.key is None:
-            return fetch_auth_credentials()
-        return AuthCredentials("Key", self.key)
+    @async_cached_property(asyncio.Lock)
+    async def _auth(self) -> AuthCredentials:
+        if self.key is not None:
+            return AuthCredentials("Key", self.key)
+        return await fetch_auth_credentials_async()
 
-    def _get_auth(self) -> AuthCredentials:
-        return self._auth
-
-    def _get_key(self) -> str:
-        auth = self._get_auth()
-        if auth.scheme.lower() != "key":
-            raise MissingCredentialsError(
-                "Key credentials are required for this operation. Set FAL_KEY or FAL_KEY_ID/FAL_KEY_SECRET."
-            )
-        return auth.token
-
-    @cached_property
-    def _token_manager(self) -> AsyncCDNTokenManager:
-        return AsyncCDNTokenManager(self._get_auth())
-
-    @cached_property
-    def _client(self) -> httpx.AsyncClient:
-        auth = self._get_auth()
+    @async_cached_property(asyncio.Lock)
+    async def _client(self) -> httpx.AsyncClient:
+        auth = await self._auth
         return httpx.AsyncClient(
             headers={
                 "Authorization": auth.header_value,
@@ -1676,15 +1654,17 @@ class AsyncClient:
             timeout=self.default_timeout,
         )
 
-    async def _get_cdn_client(self) -> httpx.AsyncClient:
-        token = await self._token_manager.get_token()
-        return httpx.AsyncClient(
-            headers={
-                "Authorization": f"{token.token_type} {token.token}",
-                "User-Agent": USER_AGENT,
-            },
+    @async_cached_property(asyncio.Lock)
+    async def _token_manager(self) -> AsyncCDNTokenManager:
+        return AsyncCDNTokenManager(await self._auth)
+
+    @asynccontextmanager
+    async def _cdn_client(self) -> AsyncIterator[httpx.AsyncClient]:
+        async with httpx.AsyncClient(
+            headers={"User-Agent": USER_AGENT},
             timeout=self.default_timeout,
-        )
+        ) as client:
+            yield client
 
     async def _get_realtime_token(
         self,
@@ -1692,12 +1672,13 @@ class AsyncClient:
         *,
         token_expiration: int = REALTIME_TOKEN_EXPIRATION_SECONDS,
     ) -> str:
+        client = await self._client
         payload = {
             "allowed_apps": [AppId.from_endpoint_id(application).alias],
             "token_expiration": token_expiration,
         }
         response = await _async_maybe_retry_request(
-            self._client,
+            client,
             "POST",
             f"{REST_URL}/tokens/",
             json=payload,
@@ -1725,6 +1706,7 @@ class AsyncClient:
                 waiting before processing starts. Does not apply once the application begins processing.
         """
 
+        client = await self._client
         url = RUN_URL_FORMAT + application
         if path:
             url += "/" + path.lstrip("/")
@@ -1741,7 +1723,7 @@ class AsyncClient:
         add_fal_app_context_headers(_headers)
 
         response = await _async_maybe_retry_request(
-            self._client,
+            client,
             "POST",
             url,
             json=arguments,
@@ -1775,6 +1757,7 @@ class AsyncClient:
                 routing). Does not apply once the application begins processing.
         """
 
+        client = await self._client
         url = QUEUE_URL_FORMAT + application
         if path:
             url += "/" + path.lstrip("/")
@@ -1797,7 +1780,7 @@ class AsyncClient:
         add_fal_app_context_headers(_headers)
 
         response = await _async_maybe_retry_request(
-            self._client,
+            client,
             "POST",
             url,
             json=arguments,
@@ -1813,7 +1796,7 @@ class AsyncClient:
             response_url=data["response_url"],
             status_url=data["status_url"],
             cancel_url=data["cancel_url"],
-            client=self._client,
+            client=client,
         )
 
     async def subscribe(
@@ -1896,21 +1879,23 @@ class AsyncClient:
                 request_id=request_id,
             ) from e
 
-    def get_handle(self, application: str, request_id: str) -> AsyncRequestHandle:
-        return AsyncRequestHandle.from_request_id(self._client, application, request_id)
+    async def get_handle(self, application: str, request_id: str) -> AsyncRequestHandle:
+        return AsyncRequestHandle.from_request_id(
+            await self._client, application, request_id
+        )
 
     async def status(
         self, application: str, request_id: str, *, with_logs: bool = False
     ) -> Status:
-        handle = self.get_handle(application, request_id)
+        handle = await self.get_handle(application, request_id)
         return await handle.status(with_logs=with_logs)
 
     async def result(self, application: str, request_id: str) -> AnyJSON:
-        handle = self.get_handle(application, request_id)
+        handle = await self.get_handle(application, request_id)
         return await handle.get()
 
     async def cancel(self, application: str, request_id: str) -> None:
-        handle = self.get_handle(application, request_id)
+        handle = await self.get_handle(application, request_id)
         await handle.cancel()
 
     async def stream(
@@ -1928,12 +1913,13 @@ class AsyncClient:
         The function will iterate over each event that is streamed from the server.
         """
 
+        client = await self._client
         url = RUN_URL_FORMAT + application
         if path:
             url += "/" + path.lstrip("/")
 
         async with aconnect_sse(
-            self._client,
+            client,
             "POST",
             url,
             json=arguments,
@@ -1961,7 +1947,7 @@ class AsyncClient:
         control uploaded object expiration and initial ACL settings.
         """
 
-        auth = self._get_auth()
+        token_manager = await self._token_manager
 
         if isinstance(data, str):
             data = data.encode("utf-8")
@@ -1974,38 +1960,48 @@ class AsyncClient:
         if len(data) > MULTIPART_THRESHOLD and repository_chain[0] == "fal_v3":
             if file_name is None:
                 file_name = "upload.bin"
-            client = await self._get_cdn_client()
-            return await AsyncMultipartUpload.save(
-                client=client,
-                token_manager=self._token_manager,
-                file_name=file_name,
-                data=data,
-                content_type=content_type,
-                object_lifecycle_preference=resolved_lifecycle,
-            )
+            async with self._cdn_client() as cdn_client:
+                return await AsyncMultipartUpload.save(
+                    client=cdn_client,
+                    token_manager=token_manager,
+                    file_name=file_name,
+                    data=data,
+                    content_type=content_type,
+                    object_lifecycle_preference=resolved_lifecycle,
+                )
 
         headers = {"Content-Type": content_type}
         if file_name is not None:
             headers["X-Fal-File-Name"] = file_name
         _object_lifecycle_headers(headers, resolved_lifecycle)
 
-        attempts: list[tuple[str, Callable[[], Any]]] = []
+        auth: AuthCredentials | None = None
+        client: httpx.AsyncClient | None = None
+
+        async def _v3_attempt() -> str:
+            cdn_token = await token_manager.get_token()
+            v3_headers = {
+                **headers,
+                "Authorization": f"{cdn_token.token_type} {cdn_token.token}",
+            }
+            async with self._cdn_client() as cdn_client:
+                return await _async_upload_v3(cdn_client, data=data, headers=v3_headers)
+
+        attempts: list[tuple[str, Callable[[], Awaitable[str]]]] = []
         for repo in repository_chain:
             if repo == "fal_v3":
-                client = await self._get_cdn_client()
-                attempts.append(
-                    (
-                        "fal_v3",
-                        partial(_async_upload_v3, client, data=data, headers=headers),
-                    )
-                )
+                attempts.append(("fal_v3", _v3_attempt))
             elif repo == "cdn":
+                if auth is None:
+                    auth = await self._auth
+                if client is None:
+                    client = await self._client
                 attempts.append(
                     (
                         "cdn",
                         partial(
                             _async_upload_cdn,
-                            self._client,
+                            client,
                             auth,
                             data=data,
                             content_type=content_type,
@@ -2015,12 +2011,16 @@ class AsyncClient:
                     )
                 )
             elif repo == "fal":
+                if auth is None:
+                    auth = await self._auth
+                if client is None:
+                    client = await self._client
                 attempts.append(
                     (
                         "fal",
                         partial(
                             _async_upload_via_storage,
-                            self._client,
+                            client,
                             auth,
                             data=data,
                             content_type=content_type,
@@ -2056,22 +2056,23 @@ class AsyncClient:
             repository, fallback_repository
         )
         if (
-            os.path.getsize(path) > MULTIPART_THRESHOLD
+            await aiofiles.os.path.getsize(path) > MULTIPART_THRESHOLD
             and repository_chain[0] == "fal_v3"
         ):
             resolved_lifecycle = _normalize_upload_lifecycle(lifecycle)
-            client = await self._get_cdn_client()
-            return await AsyncMultipartUpload.save_file(
-                file_path=str(path),
-                client=client,
-                token_manager=self._token_manager,
-                content_type=mime_type,
-                object_lifecycle_preference=resolved_lifecycle,
-            )
+            token_manager = await self._token_manager
+            async with self._cdn_client() as client:
+                return await AsyncMultipartUpload.save_file(
+                    file_path=str(path),
+                    client=client,
+                    token_manager=token_manager,
+                    content_type=mime_type,
+                    object_lifecycle_preference=resolved_lifecycle,
+                )
 
-        with open(path, "rb") as file:
+        async with aiofiles.open(path, "rb") as file:
             return await self.upload(
-                file.read(),
+                await file.read(),
                 mime_type,
                 file_name=os.path.basename(path),
                 repository=repository,
@@ -2125,7 +2126,7 @@ class AsyncClient:
                 application, token_expiration=token_expiration
             )
         else:
-            auth = self._get_auth()
+            auth = await self._auth
             headers = {"Authorization": auth.header_value, "User-Agent": USER_AGENT}
 
         url = _build_realtime_url(application, token, max_buffering, path=path)
@@ -2151,7 +2152,7 @@ class AsyncClient:
                 application, token_expiration=token_expiration
             )
         else:
-            auth = self._get_auth()
+            auth = await self._auth
             headers = {"Authorization": auth.header_value, "User-Agent": USER_AGENT}
 
         url = _build_runner_ws_url(
@@ -2175,20 +2176,9 @@ class SyncClient:
             return fetch_auth_credentials()
         return AuthCredentials("Key", self.key)
 
-    def _get_auth(self) -> AuthCredentials:
-        return self._auth
-
-    def _get_key(self) -> str:
-        auth = self._get_auth()
-        if auth.scheme.lower() != "key":
-            raise MissingCredentialsError(
-                "Key credentials are required for this operation. Set FAL_KEY or FAL_KEY_ID/FAL_KEY_SECRET."
-            )
-        return auth.token
-
     @cached_property
     def _client(self) -> httpx.Client:
-        auth = self._get_auth()
+        auth = self._auth
         return httpx.Client(
             headers={
                 "Authorization": auth.header_value,
@@ -2200,7 +2190,7 @@ class SyncClient:
 
     @cached_property
     def _token_manager(self) -> CDNTokenManager:
-        return CDNTokenManager(self._get_auth())
+        return CDNTokenManager(self._auth)
 
     @property
     def _executor(self) -> concurrent.futures.ThreadPoolExecutor:
@@ -2478,7 +2468,7 @@ class SyncClient:
         control uploaded object expiration and initial ACL settings.
         """
 
-        auth = self._get_auth()
+        auth = self._auth
 
         if isinstance(data, str):
             data = data.encode("utf-8")
@@ -2642,7 +2632,7 @@ class SyncClient:
                 application, token_expiration=token_expiration
             )
         else:
-            auth = self._get_auth()
+            auth = self._auth
             headers = {"Authorization": auth.header_value, "User-Agent": USER_AGENT}
 
         url = _build_realtime_url(application, token, max_buffering, path=path)
@@ -2668,7 +2658,7 @@ class SyncClient:
                 application, token_expiration=token_expiration
             )
         else:
-            auth = self._get_auth()
+            auth = self._auth
             headers = {"Authorization": auth.header_value, "User-Agent": USER_AGENT}
 
         url = _build_runner_ws_url(

--- a/projects/fal_client/tests/test_async_client.py
+++ b/projects/fal_client/tests/test_async_client.py
@@ -11,7 +11,7 @@ from PIL import Image
 async def client() -> fal_client.AsyncClient:
     client = fal_client.AsyncClient()
     try:
-        client._get_auth()
+        await client._auth
     except fal_client.auth.MissingCredentialsError:
         pytest.skip("No credentials found")
     return client
@@ -47,7 +47,9 @@ async def test_fal_client(client: fal_client.AsyncClient):
     assert isinstance(status, fal_client.Completed)
     assert status.logs is None
 
-    new_handle = client.get_handle("fal-ai/fast-sdxl/image-to-image", handle.request_id)
+    new_handle = await client.get_handle(
+        "fal-ai/fast-sdxl/image-to-image", handle.request_id
+    )
     assert new_handle == handle
 
     status_w_logs = await handle.status(with_logs=True)

--- a/projects/fal_client/tests/test_sync_client.py
+++ b/projects/fal_client/tests/test_sync_client.py
@@ -11,7 +11,7 @@ from fal_client.client import _maybe_retry_request
 def client() -> fal_client.SyncClient:
     client = fal_client.SyncClient()
     try:
-        client._get_auth()
+        client._auth
     except fal_client.auth.MissingCredentialsError:
         pytest.skip("Missing credentials")
     return client

--- a/projects/fal_client/tests/unit/test_auth.py
+++ b/projects/fal_client/tests/unit/test_auth.py
@@ -3,8 +3,14 @@ import json
 import time
 from pathlib import Path
 
+import pytest
 
-from fal_client.auth import AuthCredentials, fetch_auth_credentials
+
+from fal_client.auth import (
+    AuthCredentials,
+    fetch_auth_credentials,
+    fetch_auth_credentials_async,
+)
 
 
 def _make_jwt(expires_in_seconds: int) -> str:
@@ -76,6 +82,77 @@ def test_fetch_auth_credentials_refreshes_expired_token(monkeypatch, tmp_path, m
 
     assert auth == AuthCredentials("Bearer", new_access_token)
     httpx_post.assert_called_once()
+
+    saved = token_file.read_text().splitlines()
+    assert saved[0] == "new-refresh-token"
+    assert saved[1] == new_access_token
+
+
+@pytest.mark.asyncio
+async def test_fetch_auth_credentials_async_prefers_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.setenv("FAL_KEY", "abc123")
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    auth = await fetch_auth_credentials_async()
+
+    assert auth == AuthCredentials("Key", "abc123")
+
+
+@pytest.mark.asyncio
+async def test_fetch_auth_credentials_async_uses_login_token_without_refresh(
+    monkeypatch, tmp_path, mocker
+):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    access_token = _make_jwt(expires_in_seconds=3600)
+    _write_auth_file(tmp_path, "refresh-token", access_token)
+
+    httpx_post = mocker.patch("fal_client.auth.httpx.AsyncClient.post")
+
+    auth = await fetch_auth_credentials_async()
+
+    assert auth == AuthCredentials("Bearer", access_token)
+    httpx_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_auth_credentials_async_refreshes_expired_token(
+    monkeypatch, tmp_path, mocker
+):
+    monkeypatch.setenv("FAL_HOME_DIR", str(tmp_path))
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY_ID", raising=False)
+    monkeypatch.delenv("FAL_KEY_SECRET", raising=False)
+
+    expired_token = _make_jwt(expires_in_seconds=-3600)
+    token_file = _write_auth_file(tmp_path, "old-refresh-token", expired_token)
+
+    new_access_token = _make_jwt(expires_in_seconds=7200)
+    response = mocker.Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "access_token": new_access_token,
+        "refresh_token": "new-refresh-token",
+    }
+
+    async_client = mocker.Mock()
+    async_client.post = mocker.AsyncMock(return_value=response)
+    async_client.__aenter__ = mocker.AsyncMock(return_value=async_client)
+    async_client.__aexit__ = mocker.AsyncMock(return_value=None)
+    httpx_client = mocker.patch(
+        "fal_client.auth.httpx.AsyncClient", return_value=async_client
+    )
+
+    auth = await fetch_auth_credentials_async()
+
+    assert auth == AuthCredentials("Bearer", new_access_token)
+    httpx_client.assert_called_once()
+    async_client.post.assert_awaited_once()
 
     saved = token_file.read_text().splitlines()
     assert saved[0] == "new-refresh-token"

--- a/projects/fal_client/tests/unit/test_client.py
+++ b/projects/fal_client/tests/unit/test_client.py
@@ -5,7 +5,7 @@ import time
 import json
 from contextlib import asynccontextmanager, contextmanager
 from typing import Dict, Optional
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import httpx
 import msgpack
@@ -13,6 +13,7 @@ import pytest
 
 from fal_client.client import (
     AsyncClient,
+    AsyncMultipartUpload,
     AsyncRequestHandle,
     CDN_URL,
     Completed,
@@ -33,6 +34,21 @@ from fal_client.client import (
     _BaseRequestHandle,
     _raise_for_status,
 )
+
+
+def test_clients_remain_hashable():
+    assert isinstance(hash(AsyncClient(key="test-key")), int)
+    assert isinstance(hash(SyncClient(key="test-key")), int)
+
+
+@pytest.mark.asyncio
+async def test_async_client_get_handle_uses_async_client_cache():
+    client = AsyncClient(key="test-key")
+
+    handle = await client.get_handle("fal-ai/fast-sdxl", "request-id")
+
+    assert isinstance(handle, AsyncRequestHandle)
+    assert await client._client is handle.client
 
 
 @pytest.mark.parametrize(
@@ -262,11 +278,11 @@ def test_sync_client_subscribe_with_headers():
 def test_sync_upload_falls_back_to_cdn():
     with patch("fal_client.client._maybe_retry_request") as mock_request, patch(
         "fal_client.client.SyncClient._get_cdn_client"
-    ) as mock_cdn_client:
+    ) as mock_cdn_context:
         fallback_response = Mock()
         fallback_response.json.return_value = {"access_url": "https://fallback/file"}
         mock_request.side_effect = [Exception("boom"), fallback_response]
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.return_value = Mock()
         settings = StorageSettings(expires_in=3600)
 
         client = SyncClient(key="test-key")
@@ -297,7 +313,7 @@ def test_sync_upload_falls_back_to_cdn():
 def test_sync_upload_falls_back_to_storage():
     with patch("fal_client.client._maybe_retry_request") as mock_request, patch(
         "fal_client.client.SyncClient._get_cdn_client"
-    ) as mock_cdn_client:
+    ) as mock_cdn_context:
         init_response = Mock()
         init_response.json.return_value = {
             "upload_url": "https://upload.example.com/put",
@@ -309,7 +325,7 @@ def test_sync_upload_falls_back_to_storage():
             init_response,
             Mock(),
         ]
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.return_value = Mock()
         settings = StorageSettings(expires_in=3600)
 
         client = SyncClient(key="test-key")
@@ -403,11 +419,11 @@ def test_sync_upload_lifecycle_expires_in_is_normalized():
 def test_sync_upload_lifecycle_is_sent_to_fal_v3():
     with patch("fal_client.client._maybe_retry_request") as mock_request, patch(
         "fal_client.client.SyncClient._get_cdn_client"
-    ) as mock_cdn_client:
+    ) as mock_cdn_context:
         response = Mock()
         response.json.return_value = {"access_url": "https://v3-only/file"}
         mock_request.return_value = response
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.return_value = Mock()
 
         client = SyncClient(key="test-key")
         url = client.upload(
@@ -685,20 +701,77 @@ async def test_async_client_run_with_headers():
 
 
 @pytest.mark.asyncio
+async def test_async_client_resolves_auth_when_no_key():
+    auth = Mock(header_value="Key resolved-auth", scheme="Key", token="resolved-auth")
+
+    with patch(
+        "fal_client.client.fetch_auth_credentials_async",
+        new_callable=AsyncMock,
+        return_value=auth,
+    ) as mock_fetch:
+        client = AsyncClient()
+        resolved = await client._auth
+
+    assert resolved is auth
+    mock_fetch.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_client_run_reuses_async_auth_cache():
+    auth = Mock(header_value="Key resolved-auth", scheme="Key", token="resolved-auth")
+
+    with patch(
+        "fal_client.client.fetch_auth_credentials_async",
+        new_callable=AsyncMock,
+        return_value=auth,
+    ) as mock_fetch, patch(
+        "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_request.return_value = mock_response
+
+        client = AsyncClient()
+        first_result = await client.run("test-app", {"input": "first"})
+        second_result = await client.run("test-app", {"input": "second"})
+
+    assert first_result == {"result": "success"}
+    assert second_result == {"result": "success"}
+    mock_fetch.assert_awaited_once_with()
+    assert mock_request.await_count == 2
+
+
+class FakeAsyncTokenManager:
+    def __await__(self):
+        async def _return_self():
+            return self
+
+        return _return_self().__await__()
+
+    async def get_token(self):
+        return Mock(token_type="Bearer", token="cdn-token")
+
+
+@pytest.mark.asyncio
 async def test_async_upload_falls_back_to_cdn():
+    @asynccontextmanager
+    async def fake_cdn_client():
+        yield Mock()
+
     with patch(
         "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
     ) as mock_request, patch(
-        "fal_client.client.AsyncClient._get_cdn_client", new_callable=AsyncMock
-    ) as mock_cdn_client:
+        "fal_client.client.AsyncClient._cdn_client"
+    ) as mock_cdn_context:
         fallback_response = httpx.Response(
             status_code=200, json={"access_url": "https://fallback/file"}
         )
         mock_request.side_effect = [Exception("boom"), fallback_response]
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.side_effect = lambda: fake_cdn_client()
         settings = StorageSettings(expires_in=3600)
 
         client = AsyncClient(key="test-key")
+        client.__dict__["_token_manager"] = FakeAsyncTokenManager()
         url = await client.upload(
             b"hello",
             content_type="text/plain",
@@ -725,11 +798,15 @@ async def test_async_upload_falls_back_to_cdn():
 
 @pytest.mark.asyncio
 async def test_async_upload_falls_back_to_storage():
+    @asynccontextmanager
+    async def fake_cdn_client():
+        yield Mock()
+
     with patch(
         "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
     ) as mock_request, patch(
-        "fal_client.client.AsyncClient._get_cdn_client", new_callable=AsyncMock
-    ) as mock_cdn_client:
+        "fal_client.client.AsyncClient._cdn_client"
+    ) as mock_cdn_context:
         init_response = httpx.Response(
             status_code=200,
             json={
@@ -743,10 +820,11 @@ async def test_async_upload_falls_back_to_storage():
             init_response,
             Mock(),
         ]
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.side_effect = lambda: fake_cdn_client()
         settings = StorageSettings(expires_in=3600)
 
         client = AsyncClient(key="test-key")
+        client.__dict__["_token_manager"] = FakeAsyncTokenManager()
         url = await client.upload(
             b"hello",
             content_type="text/plain",
@@ -776,15 +854,16 @@ async def test_async_upload_falls_back_to_storage():
 async def test_async_upload_passes_lifecycle_to_multipart(monkeypatch):
     monkeypatch.setattr("fal_client.client.MULTIPART_THRESHOLD", 1)
     settings = StorageSettings(expires_in=3600)
+    cdn_client = AsyncMock()
+    cdn_client.__aenter__.return_value = Mock()
+    cdn_client.__aexit__.return_value = None
 
     with patch(
         "fal_client.client.AsyncMultipartUpload.save",
         new_callable=AsyncMock,
         return_value="https://file",
-    ) as mock_save, patch(
-        "fal_client.client.AsyncClient._get_cdn_client", new_callable=AsyncMock
-    ) as mock_cdn:
-        mock_cdn.return_value = Mock()
+    ) as mock_save, patch("fal_client.client.AsyncClient._cdn_client") as mock_cdn:
+        mock_cdn.return_value = cdn_client
         client = AsyncClient(key="test-key")
         url = await client.upload(
             b"hello",
@@ -800,6 +879,10 @@ async def test_async_upload_passes_lifecycle_to_multipart(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_async_upload_file_passes_lifecycle_to_multipart(tmp_path, monkeypatch):
+    @asynccontextmanager
+    async def fake_cdn_client():
+        yield Mock()
+
     monkeypatch.setattr("fal_client.client.MULTIPART_THRESHOLD", 1)
     file_path = tmp_path / "upload.txt"
     file_path.write_bytes(b"hello")
@@ -809,10 +892,8 @@ async def test_async_upload_file_passes_lifecycle_to_multipart(tmp_path, monkeyp
         "fal_client.client.AsyncMultipartUpload.save_file",
         new_callable=AsyncMock,
         return_value="https://file",
-    ) as mock_save, patch(
-        "fal_client.client.AsyncClient._get_cdn_client", new_callable=AsyncMock
-    ) as mock_cdn:
-        mock_cdn.return_value = Mock()
+    ) as mock_save, patch("fal_client.client.AsyncClient._cdn_client") as mock_cdn:
+        mock_cdn.return_value = fake_cdn_client()
         client = AsyncClient(key="test-key")
         url = await client.upload_file(file_path, lifecycle=settings)
 
@@ -823,19 +904,169 @@ async def test_async_upload_file_passes_lifecycle_to_multipart(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_async_upload_file_uses_aiofiles_for_non_multipart_path(
+    tmp_path, monkeypatch
+):
+    class FakeAsyncFile:
+        def __init__(self, data: bytes) -> None:
+            self.read = AsyncMock(return_value=data)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    file_path = tmp_path / "upload.txt"
+    file_path.write_bytes(b"hello")
+    fake_file = FakeAsyncFile(b"hello")
+    monkeypatch.setattr("fal_client.client.MULTIPART_THRESHOLD", 1024)
+
+    with patch("fal_client.client.aiofiles.open", return_value=fake_file) as mock_open:
+        client = AsyncClient(key="test-key")
+        with patch(
+            "fal_client.client.AsyncClient.upload",
+            new_callable=AsyncMock,
+            return_value="https://file",
+        ) as mock_upload:
+            url = await client.upload_file(file_path)
+
+    assert url == "https://file"
+    mock_open.assert_called_once_with(file_path, "rb")
+    fake_file.read.assert_awaited_once_with()
+    assert mock_upload.await_count == 1
+    assert mock_upload.await_args.args == (b"hello", "text/plain")
+    assert mock_upload.await_args.kwargs == {
+        "file_name": "upload.txt",
+        "repository": None,
+        "fallback_repository": None,
+        "lifecycle": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_multipart_save_file_uses_aiofiles(tmp_path):
+    class FakeAsyncFile:
+        def __init__(self, data_by_offset: dict[int, bytes]) -> None:
+            self.offset: int | None = None
+            self.seek = AsyncMock(side_effect=self._seek)
+            self.read = AsyncMock(side_effect=lambda size: data_by_offset[self.offset])
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def _seek(self, offset: int) -> None:
+            self.offset = offset
+
+    file_path = tmp_path / "upload.txt"
+    file_path.write_bytes(b"abcd")
+    first_file = FakeAsyncFile({0: b"ab"})
+    second_file = FakeAsyncFile({2: b"cd"})
+
+    open_calls = {"count": 0}
+
+    def open_side_effect(*args, **kwargs):
+        open_calls["count"] += 1
+        return first_file if open_calls["count"] == 1 else second_file
+
+    with patch(
+        "fal_client.client.aiofiles.open",
+        side_effect=open_side_effect,
+    ) as mock_open, patch.object(
+        AsyncMultipartUpload,
+        "create",
+        new_callable=AsyncMock,
+    ) as mock_create, patch.object(
+        AsyncMultipartUpload,
+        "upload_part",
+        new_callable=AsyncMock,
+    ) as mock_upload_part, patch.object(
+        AsyncMultipartUpload,
+        "complete",
+        new_callable=AsyncMock,
+        return_value="https://file",
+    ) as mock_complete:
+        url = await AsyncMultipartUpload.save_file(
+            client=Mock(),
+            token_manager=Mock(),
+            file_path=file_path,
+            chunk_size=2,
+        )
+
+    assert url == "https://file"
+    mock_create.assert_awaited_once_with(object_lifecycle_preference=None)
+    assert mock_open.call_count == 2
+    first_file.seek.assert_awaited_once_with(0)
+    first_file.read.assert_awaited_once_with(2)
+    second_file.seek.assert_awaited_once_with(2)
+    second_file.read.assert_awaited_once_with(2)
+    mock_upload_part.assert_has_awaits([call(1, b"ab"), call(2, b"cd")], any_order=True)
+    mock_complete.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_multipart_save_respects_max_concurrency():
+    active_uploads = 0
+    max_active_uploads = 0
+
+    async def upload_part(self, part_number: int, data: bytes) -> None:
+        nonlocal active_uploads, max_active_uploads
+        active_uploads += 1
+        max_active_uploads = max(max_active_uploads, active_uploads)
+        await asyncio.sleep(0)
+        active_uploads -= 1
+
+    with patch.object(
+        AsyncMultipartUpload,
+        "create",
+        new_callable=AsyncMock,
+    ) as mock_create, patch.object(
+        AsyncMultipartUpload,
+        "upload_part",
+        new=upload_part,
+    ), patch.object(
+        AsyncMultipartUpload,
+        "complete",
+        new_callable=AsyncMock,
+        return_value="https://file",
+    ) as mock_complete:
+        url = await AsyncMultipartUpload.save(
+            client=Mock(),
+            token_manager=Mock(),
+            file_name="upload.bin",
+            data=b"abcdef",
+            chunk_size=2,
+            max_concurrency=2,
+        )
+
+    assert url == "https://file"
+    mock_create.assert_awaited_once_with(object_lifecycle_preference=None)
+    mock_complete.assert_awaited_once_with()
+    assert max_active_uploads == 2
+
+
+@pytest.mark.asyncio
 async def test_async_upload_lifecycle_is_sent_to_fal_v3():
+    @asynccontextmanager
+    async def fake_cdn_client():
+        yield Mock()
+
     with patch(
         "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
     ) as mock_request, patch(
-        "fal_client.client.AsyncClient._get_cdn_client", new_callable=AsyncMock
-    ) as mock_cdn_client:
+        "fal_client.client.AsyncClient._cdn_client"
+    ) as mock_cdn_context:
         response = httpx.Response(
             status_code=200, json={"access_url": "https://v3-only/file"}
         )
         mock_request.return_value = response
-        mock_cdn_client.return_value = Mock()
+        mock_cdn_context.return_value = fake_cdn_client()
 
         client = AsyncClient(key="test-key")
+        client.__dict__["_token_manager"] = FakeAsyncTokenManager()
         url = await client.upload(
             b"hello",
             content_type="text/plain",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch async `fal_client` file upload paths from blocking file reads/stats to `aiofiles` / `aiofiles.os`
- add a direct async auth credentials path in `fal_client.auth`
- factor shared env/colab credential resolution logic so sync and async auth paths stay aligned
- use `asyncstdlib.cached_property` directly for async-safe cached auth/client/token-manager initialization in `AsyncClient`
- close short-lived async CDN clients with an explicit async context-manager helper in both multipart and non-multipart upload paths
- keep CDN auth at the request layer for async v3 uploads while avoiding redundant client default auth headers
- make `AsyncClient.get_handle()` async so it uses async-safe client initialization
- remove dead private `_get_key()` helpers
- preserve hashability for both client dataclasses while keeping `SyncClient` frozen
- avoid eager auth/client initialization in async multipart upload paths
- fix async multipart upload concurrency so `max_concurrency` actually bounds in-flight work
- replace the async multipart auth-header property with a normal async method
- use Python 3.8-compatible dependency floors for aiofiles and asyncstdlib
- add focused unit coverage for async upload file reads, async auth behavior, multipart concurrency limits, hashability, and async handle creation

## Scope
- no blocking filesystem reads or writes remain inside async `fal_client` method bodies
- remaining thread fallback in async auth is limited to the optional `portalocker` lock enter/exit path
- remaining sync filesystem operations are limited to sync-only APIs and the existing synchronous auth code path

## Testing
- python3 -m pre_commit run --all-files
- python3 -m pytest projects/fal_client/tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34d814d7-bd48-4863-959d-e54934ffb488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34d814d7-bd48-4863-959d-e54934ffb488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

