### PR TITLE
feat(api): make result_handler pluggable

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -161,6 +161,127 @@ class SpawnInfo:
         return urlparse(self.url).path.strip("/")
 
 
+class ResultHandler:
+    """Base class for handling streamed partial results from run/spawn/register.
+
+    Subclass and override the on_* hooks; ``__call__`` dispatches a partial
+    result to the appropriate hook(s). The base class itself is a no-op, so
+    ``ResultHandler()`` is a valid silent handler.
+    """
+
+    def __call__(self, partial_result: Any) -> None:
+        for log in getattr(partial_result, "logs", None) or ():
+            self.on_log(log)
+        service_urls = getattr(partial_result, "service_urls", None)
+        if service_urls is not None:
+            self.on_service_urls(service_urls)
+
+    def on_log(self, log: Any) -> None:
+        """Called once per Log entry in a partial result."""
+
+    def on_service_urls(self, urls: Any) -> None:
+        """Called when a partial result carries service URLs."""
+
+
+class SpawnResultHandler(ResultHandler):
+    """Default handler for FalServerlessHost.spawn: populates a SpawnInfo from
+    streamed partial results.
+
+    The host always runs this (since the SpawnInfo it fills is spawn's return
+    value); a caller-supplied result_handler is composed on top of it.
+    """
+
+    def __init__(self, info: SpawnInfo) -> None:
+        self.info = info
+
+    def __call__(self, partial_result: Any) -> None:
+        # Stream handle is spawn-specific (callers use it for cancellation),
+        # so it lives here rather than on the base class.
+        stream = getattr(partial_result, "stream", None)
+        if stream is not None:
+            self.info.stream = stream
+        super().__call__(partial_result)
+
+    def on_log(self, log: Any) -> None:
+        if self.info._url is None and "And API access through" in log.message:
+            self.info.url = log.message.rsplit()[-1].replace("queue.", "")
+        self.info.logs.put(log)
+
+    def on_service_urls(self, urls: Any) -> None:
+        self.info.url = urls.run
+
+
+class RegisterResultHandler(ResultHandler):
+    """Default handler for FalServerlessHost.register: forwards logs to the printer."""
+
+    def __init__(self) -> None:
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+
+    def on_log(self, log: Any) -> None:
+        self.log_printer.print(log)
+
+
+class RunResultHandler(ResultHandler):
+    """Default handler for FalServerlessHost.run: prints the URL banner + logs."""
+
+    def __init__(
+        self,
+        *,
+        auth_mode: str,
+        endpoints: list[str],
+    ) -> None:
+        self.auth_mode = auth_mode
+        self.endpoints = endpoints
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+
+    def on_service_urls(self, urls: Any) -> None:
+        from rich.rule import Rule  # noqa: PLC0415
+        from rich.text import Text  # noqa: PLC0415
+
+        from fal.flags import URL_OUTPUT  # noqa: PLC0415
+
+        print("")
+
+        lines = Text()
+        AUTH_EXPLANATIONS = {
+            "public": "no authentication required",
+            "private": "only you/team can access",
+            "shared": "any authenticated user can access",
+        }
+        auth_desc = AUTH_EXPLANATIONS.get(self.auth_mode, self.auth_mode)
+        lines.append(f"▸ Auth: {self.auth_mode} ", style="bold")
+        lines.append(f"({auth_desc})\n\n", style="dim")
+
+        if URL_OUTPUT != "none":
+            lines.append("▸ Playground ", style="bold")
+            lines.append("(open in browser)\n", style="dim")
+            for endpoint in self.endpoints:
+                lines.append(f"  {urls.playground}{endpoint}\n", style="cyan")
+
+        if URL_OUTPUT == "all":
+            lines.append("\n")
+            lines.append("▸ API Endpoints ", style="bold")
+            lines.append("(use in code)\n", style="dim")
+            for endpoint in self.endpoints:
+                lines.append(f"  Sync   {urls.run}{endpoint}\n", style="cyan")
+                lines.append(f"  Async  {urls.queue}{endpoint}\n", style="cyan")
+
+        title = Text(f"Ephemeral App ({self.auth_mode})", style="bold")
+        subtitle = Text("Deleted when process exits", style="dim")
+        console.print(Rule(title, style="green"))
+        console.print(lines)
+        console.print(Rule(subtitle, style="green"))
+
+    def on_log(self, log: Any) -> None:
+        # Obsolete messages from before service_urls were added.
+        if (
+            "Access the playground at" in log.message
+            or "And API access through" in log.message
+        ):
+            return
+        self.log_printer.print(log)
+
+
 @dataclass
 class Host(Generic[ArgsT, ReturnT]):
     """The physical environment where the isolated code
@@ -265,6 +386,7 @@ class Host(Generic[ArgsT, ReturnT]):
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        result_handler: ResultHandler | None = None,
     ) -> ReturnT:
         """Run the given function in the isolated environment."""
         raise NotImplementedError
@@ -277,6 +399,7 @@ class Host(Generic[ArgsT, ReturnT]):
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        result_handler: ResultHandler | None = None,
     ) -> SpawnInfo:
         raise NotImplementedError
 
@@ -367,7 +490,6 @@ class LocalHost(Host):
     # The environment which provides the default set of
     # packages for isolate agent to run.
     _AGENT_ENVIRONMENT: BaseEnvironment = field(default_factory=_prepare_environment)
-    _log_printer = IsolateLogPrinter(debug=flags.DEBUG)
 
     def run(
         self,
@@ -377,6 +499,7 @@ class LocalHost(Host):
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        result_handler: ResultHandler | None = None,
     ) -> ReturnT:
         import isolate  # noqa: PLC0415
         from isolate.backends.settings import DEFAULT_SETTINGS  # noqa: PLC0415
@@ -385,7 +508,7 @@ class LocalHost(Host):
         settings = replace(
             DEFAULT_SETTINGS,
             serialization_method="cloudpickle",
-            log_hook=self._log_printer.print,
+            log_hook=IsolateLogPrinter(debug=flags.DEBUG).print,
         )
         environment = isolate.prepare_environment(
             **options.environment,
@@ -614,10 +737,6 @@ class FalServerlessHost(Host):
 
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
-    _log_printer: IsolateLogPrinter = field(
-        default_factory=lambda: IsolateLogPrinter(debug=flags.DEBUG), init=False
-    )
-
     _thread_pool: ThreadPoolExecutor = field(
         default_factory=ThreadPoolExecutor, init=False
     )
@@ -686,6 +805,7 @@ class FalServerlessHost(Host):
         deployment_strategy: DeploymentStrategyLiteral,
         scale: bool = True,
         environment_name: Optional[str] = None,
+        result_handler: ResultHandler | None = None,
     ) -> Optional[RegisterApplicationResult]:
         from isolate.backends.common import active_python  # noqa: PLC0415
 
@@ -751,6 +871,9 @@ class FalServerlessHost(Host):
             # to add more metadata in the future
             metadata["openapi"] = func.openapi()
 
+        if result_handler is None:
+            result_handler = RegisterResultHandler()
+
         for partial_result in self._connection.register(
             partial_func,
             environments,
@@ -770,8 +893,7 @@ class FalServerlessHost(Host):
             secrets=secrets,
             data_mounts=data_mounts,
         ):
-            for log in partial_result.logs:
-                self._log_printer.print(log)
+            result_handler(partial_result)
 
             if partial_result.result:
                 return partial_result
@@ -785,7 +907,7 @@ class FalServerlessHost(Host):
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
-        result_handler: Callable[..., None],
+        result_handler: ResultHandler,
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
     ) -> ReturnT:
@@ -883,69 +1005,15 @@ class FalServerlessHost(Host):
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        result_handler: ResultHandler | None = None,
     ) -> ReturnT:
         effective_auth_mode = application_auth_mode or "public"
 
-        def result_handler(partial_result):
-            if service_urls := partial_result.service_urls:
-                from rich.rule import Rule  # noqa: PLC0415
-                from rich.text import Text  # noqa: PLC0415
-
-                from fal.flags import URL_OUTPUT  # noqa: PLC0415
-
-                print("")
-
-                # Build panel content with grouped sections
-                lines = Text()
-                endpoints = getattr(func, "_routes", ["/"])  # type: ignore[attr-defined]
-
-                AUTH_EXPLANATIONS = {
-                    "public": "no authentication required",
-                    "private": "only you/team can access",
-                    "shared": "any authenticated user can access",
-                }
-                auth_desc = AUTH_EXPLANATIONS.get(
-                    effective_auth_mode, effective_auth_mode
-                )
-                lines.append(f"▸ Auth: {effective_auth_mode} ", style="bold")
-                lines.append(f"({auth_desc})\n\n", style="dim")
-
-                # Playground section
-                if URL_OUTPUT != "none":
-                    lines.append("▸ Playground ", style="bold")
-                    lines.append("(open in browser)\n", style="dim")
-                    for endpoint in endpoints:
-                        lines.append(
-                            f"  {service_urls.playground}{endpoint}\n", style="cyan"
-                        )
-
-                # API Endpoints section
-                if URL_OUTPUT == "all":
-                    lines.append("\n")
-                    lines.append("▸ API Endpoints ", style="bold")
-                    lines.append("(use in code)\n", style="dim")
-                    for endpoint in endpoints:
-                        lines.append(
-                            f"  Sync   {service_urls.run}{endpoint}\n", style="cyan"
-                        )
-                        lines.append(
-                            f"  Async  {service_urls.queue}{endpoint}\n", style="cyan"
-                        )
-
-                title = Text(f"Ephemeral App ({effective_auth_mode})", style="bold")
-                subtitle = Text("Deleted when process exits", style="dim")
-                console.print(Rule(title, style="green"))
-                console.print(lines)
-                console.print(Rule(subtitle, style="green"))
-
-            for log in partial_result.logs:
-                if (
-                    "Access the playground at" in log.message
-                    or "And API access through" in log.message
-                ):
-                    # Obsolete messages from before service_urls were added.
-                    continue
-                self._log_printer.print(log)
+        if result_handler is None:
+            result_handler = RunResultHandler(
+                auth_mode=effective_auth_mode,
+                endpoints=getattr(func, "_routes", ["/"]),  # type: ignore[attr-defined]
+            )
 
         return self._run(
             func,
@@ -965,17 +1033,24 @@ class FalServerlessHost(Host):
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        result_handler: ResultHandler | None = None,
     ) -> SpawnInfo:
         ret = SpawnInfo()
+        default_handler = SpawnResultHandler(ret)
 
-        def result_handler(partial_result):
-            ret.stream = partial_result.stream
-            if service_urls := partial_result.service_urls:
-                ret.url = service_urls.run
-            for log in partial_result.logs:
-                if ret._url is None and "And API access through" in log.message:
-                    ret.url = log.message.rsplit()[-1].replace("queue.", "")
-                ret.logs.put(log)
+        # SpawnInfo is the spawn() return value, so the default handler always
+        # runs. A caller-supplied result_handler is composed on top of it.
+        composed: Callable[[Any], None]
+        if result_handler is None:
+            composed = default_handler
+        else:
+            # Bind to a local so the closure below sees a non-None Callable
+            # (mypy can't narrow `result_handler` through the enclosing scope).
+            user_handler = result_handler
+
+            def composed(partial_result):
+                default_handler(partial_result)
+                user_handler(partial_result)
 
         self._thread_pool.submit(
             self._run,
@@ -983,7 +1058,7 @@ class FalServerlessHost(Host):
             options,
             args,
             kwargs,
-            result_handler=result_handler,
+            result_handler=composed,
             application_name=application_name,
             application_auth_mode=application_auth_mode,
         )
@@ -1972,40 +2047,9 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         )
 
     def __call__(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
-        try:
-            return self.host.run(
-                self.func,
-                self.options,
-                args=args,
-                kwargs=kwargs,
-                application_name=self.app_name,
-                application_auth_mode=self.app_auth,
-            )
-        except FalMissingDependencyError as e:
-            pairs = list(find_missing_dependencies(self.func, self.options.environment))
-            if not pairs:
-                raise e
-            else:
-                lines = []
-                for used_modules, references in pairs:
-                    lines.append(
-                        f"\t- {used_modules!r} "
-                        f"(accessed through {', '.join(map(repr, references))})"
-                    )
+        from .run import run as _run_with_handling  # noqa: PLC0415
 
-                function_name = self.func.__name__
-                raise FalServerlessError(
-                    f"Couldn't deserialize your function on the remote server. \n\n"
-                    f"[Hint] {function_name!r} function uses the following modules "
-                    "which weren't present in the environment definition:\n"
-                    + "\n".join(lines)
-                ) from None
-        except Exception as exc:
-            cause = exc.__cause__
-            if self.reraise and isinstance(exc, UserFunctionException) and cause:
-                # re-raise original exception without our wrappers
-                raise cause
-            raise
+        return _run_with_handling(self, args=args, kwargs=kwargs, reraise=self.reraise)
 
     def run_local(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
         import asyncio  # noqa: PLC0415

--- a/projects/fal/src/fal/api/client.py
+++ b/projects/fal/src/fal/api/client.py
@@ -372,6 +372,9 @@ class SyncServerlessClient:
             auth: Authentication mode ("private" | "public").
             strategy: Deployment strategy ("recreate" | "rolling").
             reset_scale: If False, use previous scaling settings.
+            result_handler: Optional ``ResultHandler`` to observe streamed
+                build/deploy events. Defaults to the ``fal.api`` register
+                default (forwards logs to stdout).
 
         Example:
             # Auto-discover from pyproject.toml

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from fal.cli._utils import AppData
     from fal.utils import LoadedFunction
 
-    from .api import FalServerlessHost
+    from .api import FalServerlessHost, ResultHandler
     from .client import SyncServerlessClient
 
 import json
@@ -129,7 +129,7 @@ def _resolve_deployment_reference(
         name=app_name,
     )
 
-    app_ref_candidate = cast(tuple[str, str | None], app_ref_tuple)
+    app_ref_candidate = cast("tuple[str, str | None]", app_ref_tuple)
     if is_app_name(app_ref_candidate):
         if app_name or auth:
             raise ValueError("Cannot use --app-name or --auth with app name reference.")
@@ -205,6 +205,7 @@ def _deploy_from_reference(
     app_data: AppData,
     force_env_build: bool,
     environment_name: Optional[str] = None,
+    result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     prepared = _prepare_deployment_from_reference(
         client,
@@ -213,7 +214,7 @@ def _deploy_from_reference(
         force_env_build=force_env_build,
         environment_name=environment_name,
     )
-    return execute_prepared_deployment(prepared)
+    return execute_prepared_deployment(prepared, result_handler=result_handler)
 
 
 def _execute_loaded_deployment(
@@ -223,22 +224,12 @@ def _execute_loaded_deployment(
     app_data: AppData,
     display_name: str | None,
     environment_name: str | None = None,
+    result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     from fal.api import FalServerlessError
 
     isolated_function = loaded.function
     strategy = app_data.deployment_strategy or "rolling"
-
-    from fal.console import console
-
-    resolved_display_name = _deployment_display_name(display_name, loaded)
-
-    # Show what app name will be used
-    console.print(
-        f"Deploying '{resolved_display_name}' as app '{loaded.app_name}'",
-        style="bold",
-    )
-    console.print("")
 
     result = host.register(
         func=isolated_function.func,
@@ -250,6 +241,7 @@ def _execute_loaded_deployment(
         deployment_strategy=strategy,
         scale=app_data.reset_scale,
         environment_name=environment_name,
+        result_handler=result_handler,
     )
 
     if not result or not result.result:
@@ -312,13 +304,18 @@ def prepare_deployment(
     )
 
 
-def execute_prepared_deployment(prepared: PreparedDeployment) -> DeploymentResult:
+def execute_prepared_deployment(
+    prepared: PreparedDeployment,
+    *,
+    result_handler: ResultHandler | None = None,
+) -> DeploymentResult:
     return _execute_loaded_deployment(
         host=prepared.host,
         loaded=prepared.loaded,
         app_data=prepared.app_data,
         display_name=prepared.display_name,
         environment_name=prepared.environment_name,
+        result_handler=result_handler,
     )
 
 
@@ -332,6 +329,7 @@ def deploy(
     reset_scale: bool = False,
     force_env_build: bool = False,
     environment_name: str | None = None,
+    result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     resolved_app_ref, app_data = _resolve_deployment_reference(
         app_ref,
@@ -346,4 +344,5 @@ def deploy(
         app_data,
         force_env_build=force_env_build,
         environment_name=environment_name,
+        result_handler=result_handler,
     )

--- a/projects/fal/src/fal/api/run.py
+++ b/projects/fal/src/fal/api/run.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .api import (
+    FalMissingDependencyError,
+    FalServerlessError,
+    UserFunctionException,
+    find_missing_dependencies,
+)
+
+if TYPE_CHECKING:
+    from .api import IsolatedFunction, ResultHandler
+
+
+def run(
+    isolated_function: IsolatedFunction,
+    *,
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+    local: bool = False,
+    result_handler: ResultHandler | None = None,
+    reraise: bool = True,
+) -> Any:
+    """Run an ``IsolatedFunction`` locally or on its host with friendly errors.
+
+    When ``local=True``, defers to ``isolated_function.run_local`` (which
+    invokes the function in the current Python process). ``result_handler``
+    has no effect in that mode.
+
+    Otherwise the call is dispatched through ``host.run`` and:
+
+    * ``FalMissingDependencyError`` is translated into ``FalServerlessError``
+      with a hint listing modules accessed by the function but missing from
+      the environment definition.
+    * ``UserFunctionException`` is unwrapped to its underlying cause when
+      ``reraise=True`` (default), so callers see the original exception.
+    """
+    if kwargs is None:
+        kwargs = {}
+
+    if local:
+        return isolated_function.run_local(*args, **kwargs)
+
+    func = isolated_function.func
+    options = isolated_function.options
+    try:
+        return isolated_function.host.run(
+            func,
+            options,
+            args=args,
+            kwargs=kwargs,
+            application_name=isolated_function.app_name,
+            application_auth_mode=isolated_function.app_auth,
+            result_handler=result_handler,
+        )
+    except FalMissingDependencyError as e:
+        pairs = list(find_missing_dependencies(func, options.environment))
+        if not pairs:
+            raise e
+        lines = [
+            f"\t- {used_modules!r} "
+            f"(accessed through {', '.join(map(repr, references))})"
+            for used_modules, references in pairs
+        ]
+        raise FalServerlessError(
+            f"Couldn't deserialize your function on the remote server. \n\n"
+            f"[Hint] {func.__name__!r} function uses the following modules "
+            "which weren't present in the environment definition:\n" + "\n".join(lines)
+        ) from None
+    except Exception as exc:
+        cause = exc.__cause__
+        if reraise and isinstance(exc, UserFunctionException) and cause:
+            # re-raise original exception without our wrappers
+            raise cause
+        raise

--- a/projects/fal/src/fal/cli/_result_handlers.py
+++ b/projects/fal/src/fal/cli/_result_handlers.py
@@ -1,0 +1,90 @@
+"""CLI-specific ResultHandler subclasses.
+
+Built directly on the ``ResultHandler`` base so the CLI's presentation evolves
+independently of whatever default handlers the ``fal.api`` layer happens to ship.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fal import flags
+from fal.api.api import ResultHandler
+from fal.logging.isolate import IsolateLogPrinter
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+class CliRunResultHandler(ResultHandler):
+    """Renders an ephemeral-app banner + streams logs for ``fal run``."""
+
+    def __init__(
+        self,
+        *,
+        console: Console,
+        auth_mode: str,
+        endpoints: list[str],
+    ) -> None:
+        self.console = console
+        self.auth_mode = auth_mode
+        self.endpoints = endpoints
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+
+    def on_service_urls(self, urls: Any) -> None:
+        from rich.rule import Rule  # noqa: PLC0415
+        from rich.text import Text  # noqa: PLC0415
+
+        from fal.flags import URL_OUTPUT  # noqa: PLC0415
+
+        self.console.print("")
+
+        lines = Text()
+        AUTH_EXPLANATIONS = {
+            "public": "no authentication required",
+            "private": "only you/team can access",
+            "shared": "any authenticated user can access",
+        }
+        auth_desc = AUTH_EXPLANATIONS.get(self.auth_mode, self.auth_mode)
+        lines.append(f"▸ Auth: {self.auth_mode} ", style="bold")
+        lines.append(f"({auth_desc})\n\n", style="dim")
+
+        if URL_OUTPUT != "none":
+            lines.append("▸ Playground ", style="bold")
+            lines.append("(open in browser)\n", style="dim")
+            for endpoint in self.endpoints:
+                lines.append(f"  {urls.playground}{endpoint}\n", style="cyan")
+
+        if URL_OUTPUT == "all":
+            lines.append("\n")
+            lines.append("▸ API Endpoints ", style="bold")
+            lines.append("(use in code)\n", style="dim")
+            for endpoint in self.endpoints:
+                lines.append(f"  Sync   {urls.run}{endpoint}\n", style="cyan")
+                lines.append(f"  Async  {urls.queue}{endpoint}\n", style="cyan")
+
+        title = Text(f"Ephemeral App ({self.auth_mode})", style="bold")
+        subtitle = Text("Deleted when process exits", style="dim")
+        self.console.print(Rule(title, style="green"))
+        self.console.print(lines)
+        self.console.print(Rule(subtitle, style="green"))
+
+    def on_log(self, log: Any) -> None:
+        # Obsolete messages from before service_urls were added.
+        if (
+            "Access the playground at" in log.message
+            or "And API access through" in log.message
+        ):
+            return
+        self.log_printer.print(log)
+
+
+class CliRegisterResultHandler(ResultHandler):
+    """Streams build/deploy logs for ``fal deploy``."""
+
+    def __init__(self, *, console: Console) -> None:
+        self.console = console
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+
+    def on_log(self, log: Any) -> None:
+        self.log_printer.print(log)

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -10,6 +10,8 @@ from .parser import FalClientParser, RefAction, add_env_argument, get_output_par
 
 
 def _deploy(args):
+    from ._result_handlers import CliRegisterResultHandler
+
     team, app_ref = _resolve_team_and_app_ref(args)
 
     # Handle deprecated --force-env-build flag
@@ -21,18 +23,24 @@ def _deploy(args):
 
     no_cache = args.no_cache or args.force_env_build
     client = SyncServerlessClient(host=args.host, team=team)
+    result_handler = CliRegisterResultHandler(console=args.console)
 
     deploy_check_source = _resolve_deploy_check_source(args, client)
     if deploy_check_source is not None:
+        # The pre-deploy summary already shows the resolved app name.
         res = deploy_with_check(
             args,
             client,
             app_ref,
             force_env_build=no_cache,
             source=deploy_check_source,
+            result_handler=result_handler,
         )
     else:
-        res = client.deploy(
+        from fal.api import deploy as deploy_api
+
+        prepared = deploy_api.prepare_deployment(
+            client,
             app_ref,
             app_name=args.app_name,
             auth=args.auth,
@@ -40,6 +48,14 @@ def _deploy(args):
             reset_scale=args.app_scale_settings,
             force_env_build=no_cache,
             environment_name=args.env,
+        )
+        args.console.print(
+            f"Deploying '{prepared.display_name}' as app '{prepared.loaded.app_name}'",
+            style="bold",
+        )
+        args.console.print("")
+        res = deploy_api.execute_prepared_deployment(
+            prepared, result_handler=result_handler
         )
 
     _render_deploy_result(args, res)

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -11,6 +11,7 @@ from fal.sdk import construct_alias
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from fal.api.api import ResultHandler
     from fal.api.client import SyncServerlessClient
     from fal.api.deploy import DeploymentResult, PreparedDeployment
     from fal.sdk import AliasInfo
@@ -105,6 +106,7 @@ def deploy_with_check(
     *,
     force_env_build: bool,
     source: DeployCheckSource,
+    result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     from fal.api import deploy as deploy_api
 
@@ -135,7 +137,9 @@ def deploy_with_check(
         console=args.console,
         assume_yes=args.yes,
     )
-    return deploy_api.execute_prepared_deployment(prepared)
+    return deploy_api.execute_prepared_deployment(
+        prepared, result_handler=result_handler
+    )
 
 
 def _resolve_deploy_check_source(

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -64,12 +64,21 @@ def _run(args):
     isolated_function = loaded.function
     if args.machine_type is not None:
         isolated_function.options.host["machine_type"] = args.machine_type
-    # let our exc handlers handle UserFunctionException
-    isolated_function.reraise = False
-    if args.local:
-        isolated_function.run_local()
-    else:
-        isolated_function()
+
+    from fal.api.run import run as run_api
+
+    from ._result_handlers import CliRunResultHandler
+
+    run_api(
+        isolated_function,
+        local=args.local,
+        result_handler=CliRunResultHandler(
+            console=args.console,
+            auth_mode=loaded.app_auth or "public",
+            endpoints=loaded.endpoints,
+        ),
+        reraise=False,
+    )
 
 
 def add_parser(main_subparsers, parents):

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -158,9 +158,14 @@ def mock_args(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_success(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     # Mocking the parse_pyproject_toml function to return a predefined dict
     mock_parse_toml.return_value = mock_parse_pyproject_toml
@@ -172,8 +177,8 @@ def test_deploy_with_toml_success(
     project_root, _ = find_project_root(None)
 
     # Ensure the correct app is deployed
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -190,9 +195,14 @@ def test_deploy_with_toml_success(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_no_auth(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     # Mocking the parse_pyproject_toml function to return a predefined dict
     mock_parse_toml.return_value = mock_parse_pyproject_toml
@@ -204,8 +214,8 @@ def test_deploy_with_toml_no_auth(
     project_root, _ = find_project_root(None)
 
     # Since auth is not provided for "another-app", it should default to "private"
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/another_app/inference.py'}", "AnotherApp"),
         AppData(
             ref=f"{project_root / 'src/another_app/inference.py'}::AnotherApp",
@@ -222,9 +232,14 @@ def test_deploy_with_toml_no_auth(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_overrides_applied(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -233,8 +248,8 @@ def test_deploy_with_toml_overrides_applied(
     _deploy(args)
 
     project_root, _ = find_project_root(None)
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/override_app/inference.py'}", "OverrideApp"),
         AppData(
             ref=f"{project_root / 'src/override_app/inference.py'}::OverrideApp",
@@ -255,9 +270,14 @@ def test_deploy_with_toml_overrides_applied(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_app_not_found(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     # Mocking the parse_pyproject_toml function to return a predefined dict
     mock_parse_toml.return_value = mock_parse_pyproject_toml
@@ -273,9 +293,10 @@ def test_deploy_with_toml_app_not_found(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_missing_ref_key(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml
+    mock_prepare_ref, mock_execute, mock_parse_toml, mock_find_toml
 ):
     # Mocking a toml structure without a "ref" key for a certain app
     mock_parse_toml.return_value = {
@@ -297,9 +318,14 @@ def test_deploy_with_toml_missing_ref_key(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_extra_keys_in_toml(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -342,9 +368,14 @@ def test_deploy_with_toml_only_app_name_is_provided(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_deployment_strategy(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -354,8 +385,8 @@ def test_deploy_with_toml_deployment_strategy(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -372,9 +403,14 @@ def test_deploy_with_toml_deployment_strategy(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_toml_default_deployment_strategy(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -384,8 +420,8 @@ def test_deploy_with_toml_default_deployment_strategy(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/another_app/inference.py'}", "AnotherApp"),
         AppData(
             ref=f"{project_root / 'src/another_app/inference.py'}::AnotherApp",
@@ -402,9 +438,14 @@ def test_deploy_with_toml_default_deployment_strategy(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_auth(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -414,8 +455,8 @@ def test_deploy_with_cli_auth(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -432,9 +473,14 @@ def test_deploy_with_cli_auth(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_app_name(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -447,8 +493,8 @@ def test_deploy_with_cli_app_name(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -465,9 +511,14 @@ def test_deploy_with_cli_app_name(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_deployment_strategy(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -477,8 +528,8 @@ def test_deploy_with_cli_deployment_strategy(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -495,9 +546,14 @@ def test_deploy_with_cli_deployment_strategy(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_reset_scale(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -507,8 +563,8 @@ def test_deploy_with_cli_reset_scale(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -525,9 +581,14 @@ def test_deploy_with_cli_reset_scale(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_scale(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -537,8 +598,8 @@ def test_deploy_with_cli_scale(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -555,9 +616,14 @@ def test_deploy_with_cli_scale(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-@patch("fal.api.deploy._deploy_from_reference")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
 def test_deploy_with_cli_no_cache(
-    mock_deploy_ref, mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
 ):
     mock_parse_toml.return_value = mock_parse_pyproject_toml
 
@@ -567,8 +633,8 @@ def test_deploy_with_cli_no_cache(
 
     project_root, _ = find_project_root(None)
 
-    mock_deploy_ref.assert_called_once_with(
-        mock_deploy_ref.call_args[0][0],
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
         (f"{project_root / 'src/my_app/inference.py'}", "MyApp"),
         AppData(
             ref=f"{project_root / 'src/my_app/inference.py'}::MyApp",
@@ -585,9 +651,13 @@ def test_deploy_with_cli_no_cache(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
 @patch("fal.cli.deploy.SyncServerlessClient")
 def test_deploy_with_team_from_toml(
     mock_client,
+    mock_prepare,
+    mock_execute,
     mock_parse_toml,
     mock_find_toml,
     mock_parse_pyproject_toml,
@@ -598,11 +668,6 @@ def test_deploy_with_team_from_toml(
     # Mock the client instance
     mock_client_instance = MagicMock()
     mock_client.return_value = mock_client_instance
-    mock_client_instance.deploy.return_value = MagicMock(
-        revision="rev-123",
-        app_name="team-app",
-        urls={"playground": {}, "sync": {}, "async": {}},
-    )
 
     args = mock_args(app_ref=("team-app", None))
     args.host = "my-host"
@@ -615,9 +680,13 @@ def test_deploy_with_team_from_toml(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
 @patch("fal.cli.deploy.SyncServerlessClient")
 def test_deploy_with_team_from_toml_cli_team_override(
     mock_client,
+    mock_prepare,
+    mock_execute,
     mock_parse_toml,
     mock_find_toml,
     mock_parse_pyproject_toml,
@@ -628,11 +697,6 @@ def test_deploy_with_team_from_toml_cli_team_override(
     # Mock the client instance
     mock_client_instance = MagicMock()
     mock_client.return_value = mock_client_instance
-    mock_client_instance.deploy.return_value = MagicMock(
-        revision="rev-123",
-        app_name="team-app",
-        urls={"playground": {}, "sync": {}, "async": {}},
-    )
 
     args = mock_args(app_ref=("team-app", None), team="my-cli-team")
     args.host = "my-host"
@@ -645,9 +709,13 @@ def test_deploy_with_team_from_toml_cli_team_override(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
 @patch("fal.cli.deploy.SyncServerlessClient")
 def test_deploy_without_team_in_toml(
     mock_client,
+    mock_prepare,
+    mock_execute,
     mock_parse_toml,
     mock_find_toml,
     mock_parse_pyproject_toml,
@@ -658,11 +726,6 @@ def test_deploy_without_team_in_toml(
     # Mock the client instance
     mock_client_instance = MagicMock()
     mock_client.return_value = mock_client_instance
-    mock_client_instance.deploy.return_value = MagicMock(
-        revision="rev-123",
-        app_name="my-app",
-        urls={"playground": {}, "sync": {}, "async": {}},
-    )
 
     args = mock_args(app_ref=("my-app", None))
     args.host = "my-host"
@@ -784,20 +847,17 @@ def test_get_app_data_from_toml_no_scale_warning_can_be_suppressed(
 
 
 @patch("fal.cli._utils.get_app_data_from_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
 @patch("fal.cli.deploy.SyncServerlessClient")
-def test_deploy_team_lookup_uses_silent_toml_read(mock_client, mock_get_app_data):
+def test_deploy_team_lookup_uses_silent_toml_read(
+    mock_client, mock_prepare, mock_execute, mock_get_app_data
+):
     mock_get_app_data.return_value = AppData(team="my-team")
 
     # Mock the client instance
     mock_client_instance = MagicMock()
     mock_client.return_value = mock_client_instance
-    mock_client_instance.deploy.return_value = MagicMock(
-        revision="rev-123",
-        app_name="no-scale-app",
-        auth_mode="private",
-        urls={"playground": {}, "sync": {}, "async": {}},
-        log_url="https://fal.ai/logs/123",
-    )
 
     args = mock_args(app_ref=("no-scale-app", None))
     args.host = "my-host"

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -93,7 +93,7 @@ def test_app_regions_propagate_to_function_options():
 
 
 def test_run_forwards_regions_to_machine_requirements():
-    from fal.api.api import FalServerlessHost, Options
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
     from fal.sdk import HostedRunState
 
     host = FalServerlessHost()
@@ -116,7 +116,7 @@ def test_run_forwards_regions_to_machine_requirements():
             options,
             args=(),
             kwargs={},
-            result_handler=lambda _: None,
+            result_handler=ResultHandler(),
         )
 
     assert result == "ok"
@@ -535,7 +535,7 @@ def test_data_mounts_register_sends_to_connection():
 
 
 def test_data_mounts_run_sends_to_connection():
-    from fal.api.api import FalServerlessHost, Options
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
     from fal.sdk import HostedRunState
 
     host = FalServerlessHost()
@@ -558,7 +558,7 @@ def test_data_mounts_run_sends_to_connection():
             options,
             args=(),
             kwargs={},
-            result_handler=lambda _: None,
+            result_handler=ResultHandler(),
         )
 
     _, call_kwargs = connection.run.call_args
@@ -626,7 +626,7 @@ def test_secrets_register_sends_to_connection():
 
 
 def test_secrets_run_sends_to_connection():
-    from fal.api.api import FalServerlessHost, Options
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
     from fal.sdk import HostedRunState
 
     host = FalServerlessHost()
@@ -649,7 +649,7 @@ def test_secrets_run_sends_to_connection():
             options,
             args=(),
             kwargs={},
-            result_handler=lambda _: None,
+            result_handler=ResultHandler(),
         )
 
     _, call_kwargs = connection.run.call_args


### PR DESCRIPTION
## Summary

Pulls presentation out of `fal.api` and gives callers a real seam to plug in. The api layer used to print URL banners, build logs, and a "Deploying X as Y" line directly to a module-global console — fine for the CLI, awkward for SDK callers and tests. Now:

- `host.run` / `host.spawn` / `host.register` accept a `result_handler: ResultHandler | None`.
- `ResultHandler` is a small base class with `__call__` dispatch + `on_log` / `on_service_urls` hooks.
- Three default subclasses preserve today's behavior when no handler is passed: `RunResultHandler`, `RegisterResultHandler`, `SpawnResultHandler`. Each owns its own `IsolateLogPrinter` — Host classes no longer carry one.
- `fal run` / `fal deploy` now build their own `CliRunResultHandler` / `CliRegisterResultHandler` (extending `ResultHandler` directly, not the api defaults) and pass them in. They take `args.console` so the api layer no longer reaches for `fal.console.console` at runtime.
- The `"Deploying 'X' as app 'Y'"` print moves out of `api/deploy.py` and into `cli/deploy.py` (one more api-layer print site removed from the original audit).
- `result_handler` plumbs through `client.deploy()` → `deploy()` → `execute_prepared_deployment()` → `_execute_loaded_deployment()` → `host.register()`, so SDK callers benefit too.

## Why

`fal.api` was both the API layer and the view layer — every `host.run`/`host.register` call printed unconditionally to a module-global console with no way for a programmatic caller to silence, redirect, or restructure the output. The pluggable handler is the seam; making the CLI use it intentionally proves out the contract.

## Notable design choices

- **Raw callable param, not Observer.** `result_handler` is `ResultHandler | None`. `ResultHandler` is a class with `__call__` + `on_*` hooks, not a Protocol — subclass to extend, instantiate `ResultHandler()` for "be silent".
- **`SpawnResultHandler` runs unconditionally.** It populates `SpawnInfo`, which is `spawn()`'s return value. A caller-supplied `result_handler` is composed on top, not a replacement.
- **Stream handle is spawn-specific.** Pulled out of the base `__call__` dispatch — `SpawnResultHandler` overrides `__call__` to grab `partial_result.stream` itself, then delegates to `super().__call__` for log/url dispatch.
- **CLI handlers don't subclass api defaults.** Built directly on `ResultHandler` so CLI presentation evolves independently of whatever defaults `fal.api` ships.
- **`IsolatedFunction` signature unchanged.** We agreed not to push `result_handler` onto `__call__/.spawn/.submit` (would collide with user kwargs). The CLI bypasses `IsolatedFunction.__call__` and calls `host.run(...)` directly, with the same `FalMissingDependencyError` → friendly hint translation that `__call__` does.