### PR TITLE
fix(e2e): reduce rollout_application flakiness with polling

### DIFF
--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -1529,6 +1529,14 @@ def test_kill_runner(host: api.FalServerlessHost, test_sleep_app: str):
 
 
 def test_rollout_application(host: api.FalServerlessHost, test_sleep_app: str):
+    def wait_until(condition: Callable[[], bool], timeout: float, interval: float = 1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if condition():
+                return
+            time.sleep(interval)
+        assert condition()
+
     handle = apps.submit(test_sleep_app, arguments={"wait_time": 30})
 
     while True:
@@ -1547,20 +1555,28 @@ def test_rollout_application(host: api.FalServerlessHost, test_sleep_app: str):
         runner_id_before = runners_before[0].runner_id
 
         client.rollout_application(app_alias, force=True)
+        runner_ids_after: set[str] = set()
 
-        time.sleep(15)
+        def runner_replaced() -> bool:
+            nonlocal runner_ids_after
+            runners_after = client.list_alias_runners(app_alias)
+            runner_ids_after = {r.runner_id for r in runners_after}
+            return runner_id_before not in runner_ids_after
 
-        runners_after = client.list_alias_runners(app_alias)
-        runner_ids_after = {r.runner_id for r in runners_after}
+        wait_until(runner_replaced, timeout=30)
 
         assert runner_id_before not in runner_ids_after
 
         client.rollout_application(app_alias, force=True)
+        runner_ids_final: set[str] = set()
 
-        time.sleep(3)
+        def rollout_completed() -> bool:
+            nonlocal runner_ids_final
+            runners_final = client.list_alias_runners(app_alias)
+            runner_ids_final = {r.runner_id for r in runners_final}
+            return not runner_ids_after.intersection(runner_ids_final)
 
-        runners_final = client.list_alias_runners(app_alias)
-        runner_ids_final = {r.runner_id for r in runners_final}
+        wait_until(rollout_completed, timeout=30)
 
         assert not runner_ids_after.intersection(runner_ids_final)
 


### PR DESCRIPTION
### Motivation
- `test_rollout_application` used fixed `time.sleep` calls which made the test flaky against variable rollout timings, causing intermittent failures when runner rotations took longer than expected.

### Description
- Add a generic `wait_until(condition, timeout, interval)` helper that polls using `time.monotonic()` instead of sleeping for fixed durations.
- Replace the first `time.sleep(15)` with a `runner_replaced` polling function that waits until the original `runner_id_before` is no longer returned by `list_alias_runners`.
- Replace the second `time.sleep(3)` with a `rollout_completed` polling function that waits until there is no intersection between `runner_ids_after` and the final runner IDs, with both polls using a 30s timeout.

### Testing
- Ran `python -m pip install -e 'projects/fal[dev]'` to install the package and test dependencies which completed successfully.
- Attempted `pre-commit run --all-files` but it could not be executed in this environment because the `pre-commit` tool is not installed, so hooks were not run here.
- Ran `python -m pytest -n auto -v projects/fal/tests/e2e/test_apps.py -k rollout_application` which exercised the updated test but the run errored during test setup due to missing authentication and therefore the e2e test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9bebcce50832ead5f1721b8891b35)