### PR TITLE
fix(fal): unpin cloudpickle to support Python 3.14

### DIFF
--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -35,10 +35,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
+        deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
-          - deps: "pydantic==2.11.7"
+          - deps: "pydantic==2.13.3"
             python: "3.8"
           - deps: "pydantic==1.10.18"
             python: "3.9"

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -50,6 +50,8 @@ jobs:
             python: "3.12"
           - deps: "pydantic==1.10.18"
             python: "3.13"
+          - deps: "pydantic==1.10.18"
+            python: "3.14"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -33,10 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
+        deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
-          - deps: "pydantic==2.11.7"
+          - deps: "pydantic==2.13.3"
             python: "3.8"
           - deps: "pydantic==1.10.18"
             python: "3.9"

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -48,6 +48,8 @@ jobs:
             python: "3.12"
           - deps: "pydantic==1.10.18"
             python: "3.13"
+          - deps: "pydantic==1.10.18"
+            python: "3.14"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fal-unit-tests.yml
+++ b/.github/workflows/fal-unit-tests.yml
@@ -33,10 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
+        deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
-          - deps: "pydantic==2.11.7"
+          - deps: "pydantic==2.13.3"
             python: "3.8"
           - deps: "pydantic==1.10.18"
             python: "3.9"

--- a/.github/workflows/fal-unit-tests.yml
+++ b/.github/workflows/fal-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         deps: ["pydantic==1.10.18", "pydantic==2.11.7"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - deps: "pydantic==2.11.7"
             python: "3.8"
@@ -48,6 +48,8 @@ jobs:
             python: "3.12"
           - deps: "pydantic==1.10.18"
             python: "3.13"
+          - deps: "pydantic==1.10.18"
+            python: "3.14"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests-fal-client.yml
+++ b/.github/workflows/tests-fal-client.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests-isolate-proto.yml
+++ b/.github/workflows/tests-isolate-proto.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "isolate-proto>=0.31.2,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
-    "cloudpickle==3.0.0",
+    "cloudpickle>=3.1.0,<4",
     "typing-extensions>=4.7.1,<5",
     "structlog>=22.3.0,<26",
     "opentelemetry-api>=1.15.0,<2",

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "isolate-proto>=0.31.2,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
-    "cloudpickle==3.1.2",
+    "cloudpickle>=3.0.0,<3.2",
     "typing-extensions>=4.7.1,<5",
     "structlog>=22.3.0,<26",
     "opentelemetry-api>=1.15.0,<2",

--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "isolate-proto>=0.31.2,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
-    "cloudpickle>=3.1.0,<4",
+    "cloudpickle==3.1.2",
     "typing-extensions>=4.7.1,<5",
     "structlog>=22.3.0,<26",
     "opentelemetry-api>=1.15.0,<2",


### PR DESCRIPTION
## Summary
- cloudpickle 3.0.0 hits infinite recursion in `_extract_code_globals` on Python 3.14, so `fal run` fails with a stack overflow when serializing any function (`RecursionError: Stack overflow (used 16352 kB) in comparison`).
- Relaxes the strict `cloudpickle==3.0.0` pin in `projects/fal/pyproject.toml` to `>=3.1.0,<4`, which picks up the upstream Python 3.14 fixes.
- Verified the cloudpickle internals fal patches in `_serialization.py` (`_PICKLE_BY_VALUE_MODULES`, `_extract_class_dict`, `_dynamic_class_reduce`, `_class_setstate`, `Pickler.dispatch`) all still exist in 3.1.x, so the existing monkey-patches keep working.

## Test plan
- [x] On Python 3.14, `fal run ~/test_simple_function.py` fails on cloudpickle 3.0.0 with the recursion error reproduced from SERV-524
- [x] After upgrading to cloudpickle 3.1.2 in the same venv, `fal run ~/test_simple_function.py` runs end-to-end and prints `OLOLO` from the remote machine
- [x] CI green on Python 3.8–3.13 (no behavior change expected for those — cloudpickle 3.1.x is backwards compatible with 3.0.0 for the fal use cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)