### PR TITLE
feat(run): introduce python_entry_point

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -384,26 +384,28 @@ class Host(Generic[ArgsT, ReturnT]):
 
     def run(
         self,
-        func: Callable[ArgsT, ReturnT],
+        func: Callable[ArgsT, ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> ReturnT:
         """Run the given function in the isolated environment."""
         raise NotImplementedError
 
     def spawn(
         self,
-        func: Callable[ArgsT, ReturnT],
+        func: Callable[ArgsT, ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> SpawnInfo:
         raise NotImplementedError
 
@@ -497,17 +499,23 @@ class LocalHost(Host):
 
     def run(
         self,
-        func: Callable[..., ReturnT],
+        func: Callable[..., ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> ReturnT:
         import isolate  # noqa: PLC0415
         from isolate.backends.settings import DEFAULT_SETTINGS  # noqa: PLC0415
         from isolate.connections import PythonIPC  # noqa: PLC0415
+
+        if entrypoint is not None or func is None:
+            raise NotImplementedError(
+                "LocalHost does not support entrypoint-based execution."
+            )
 
         settings = replace(
             DEFAULT_SETTINGS,
@@ -799,7 +807,7 @@ class FalServerlessHost(Host):
     @_handle_grpc_error()
     def register(
         self,
-        func: Callable[ArgsT, ReturnT],
+        func: Callable[ArgsT, ReturnT] | None,
         options: Options,
         *,
         application_name: Optional[str] = None,
@@ -810,6 +818,7 @@ class FalServerlessHost(Host):
         scale: bool = True,
         environment_name: Optional[str] = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> Optional[RegisterApplicationResult]:
         from isolate.backends.common import active_python  # noqa: PLC0415
 
@@ -864,7 +873,18 @@ class FalServerlessHost(Host):
 
         files = self.files_sync(FileSyncOptions.from_options(options))
 
-        partial_func = _prepare_partial_func(func)
+        if func is None and entrypoint is None:
+            raise FalServerlessError(
+                "register requires either a func or an entrypoint."
+            )
+        if func is not None and entrypoint is not None:
+            raise FalServerlessError(
+                "only one of a func or an entrypoint can be provided."
+            )
+
+        partial_func = None
+        if func is not None:
+            partial_func = _prepare_partial_func(func)
 
         if metadata is None:
             metadata = {}
@@ -896,6 +916,7 @@ class FalServerlessHost(Host):
             termination_grace_period_seconds=termination_grace_period_seconds,
             secrets=secrets,
             data_mounts=data_mounts,
+            entrypoint=entrypoint,
         ):
             result_handler(partial_result)
 
@@ -907,13 +928,14 @@ class FalServerlessHost(Host):
     @_handle_grpc_error()
     def _run(
         self,
-        func: Callable[..., ReturnT],
+        func: Callable[..., ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         result_handler: ResultHandler,
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
+        entrypoint: str | None = None,
     ) -> ReturnT:
         from isolate.backends.common import active_python  # noqa: PLC0415
 
@@ -965,8 +987,19 @@ class FalServerlessHost(Host):
         return_value = _UNSET
         # Allow isolate provided arguments (such as setup function) to take
         # precedence over the ones provided by the user.
-        partial_func = _prepare_partial_func(func, *args, **kwargs)
-        effective_app_name = application_name or getattr(func, "__name__", None)
+        if func is None and entrypoint is None:
+            raise FalServerlessError("_run requires either a func or an entrypoint.")
+        if func is not None and entrypoint is not None:
+            raise FalServerlessError(
+                "only one of a func or an entrypoint can be provided."
+            )
+
+        partial_func = None
+        if func is not None:
+            partial_func = _prepare_partial_func(func, *args, **kwargs)
+        effective_app_name = (
+            application_name or getattr(func, "__name__", None) or entrypoint
+        )
         effective_auth_mode = application_auth_mode or "public"
 
         for partial_result in self._connection.run(
@@ -980,6 +1013,7 @@ class FalServerlessHost(Host):
             environment_name=self.environment_name,
             secrets=secrets,
             data_mounts=data_mounts,
+            entrypoint=entrypoint,
         ):
             result_handler(partial_result)
 
@@ -1003,13 +1037,14 @@ class FalServerlessHost(Host):
 
     def run(
         self,
-        func: Callable[..., ReturnT],
+        func: Callable[..., ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> ReturnT:
         effective_auth_mode = application_auth_mode or "public"
 
@@ -1027,17 +1062,19 @@ class FalServerlessHost(Host):
             result_handler=result_handler,
             application_name=application_name,
             application_auth_mode=application_auth_mode,
+            entrypoint=entrypoint,
         )
 
     def spawn(
         self,
-        func: Callable[..., ReturnT],
+        func: Callable[..., ReturnT] | None,
         options: Options,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
+        entrypoint: str | None = None,
     ) -> SpawnInfo:
         ret = SpawnInfo()
         default_handler = SpawnResultHandler(ret)
@@ -1065,6 +1102,7 @@ class FalServerlessHost(Host):
             result_handler=composed,
             application_name=application_name,
             application_auth_mode=application_auth_mode,
+            entrypoint=entrypoint,
         )
 
         return ret
@@ -2066,12 +2104,19 @@ class ServeWrapper(BaseServable):
 @dataclass
 class IsolatedFunction(Generic[ArgsT, ReturnT]):
     host: Host[ArgsT, ReturnT]
-    raw_func: Callable[ArgsT, ReturnT]
-    options: Options
+    raw_func: Callable[ArgsT, ReturnT] | None = None
+    options: Options = field(default_factory=Options)
     executor: ThreadPoolExecutor = field(default_factory=ThreadPoolExecutor)
     reraise: bool = True
     app_name: str | None = None
     app_auth: AuthModeLiteral | None = None
+    entrypoint: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.raw_func is None and self.entrypoint is None:
+            raise FalServerlessError(
+                "IsolatedFunction requires either raw_func or entrypoint."
+            )
 
     def __getstate__(self) -> dict[str, Any]:
         # Ensure that the executor is not pickled.
@@ -2083,6 +2128,23 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         self.__dict__.update(state)
         if not hasattr(self, "executor"):
             self.executor = ThreadPoolExecutor()
+
+    @property
+    def run_entrypoint(self) -> str | None:
+        """gRPC entrypoint string for remote dispatch (``<symbol>.run_local``)."""
+        if self.entrypoint is None:
+            return None
+        return f"{self.entrypoint}.run_local"
+
+    @property
+    def metadata_entrypoint(self) -> str | None:
+        """gRPC entrypoint string for the metadata probe.
+
+        Resolves to ``<symbol>.build_metadata`` on the worker.
+        """
+        if self.entrypoint is None:
+            return None
+        return f"{self.entrypoint}.build_metadata"
 
     def submit(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs):
         # TODO: This should probably live inside each host since they can
@@ -2097,6 +2159,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             kwargs=kwargs,
             application_name=self.app_name,
             application_auth_mode=self.app_auth,
+            entrypoint=self.run_entrypoint,
         )
         return future
 
@@ -2108,6 +2171,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             kwargs,
             application_name=self.app_name,
             application_auth_mode=self.app_auth,
+            entrypoint=self.run_entrypoint,
         )
 
     def __call__(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
@@ -2118,13 +2182,58 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     def build_metadata(self) -> dict[str, Any]:
         return self.options.host.get("metadata") or {}
 
+    def fetch_metadata(self) -> dict[str, Any]:
+        """Probe ``<entrypoint>.build_metadata`` on the worker and cache the
+        result into ``options.host["metadata"]``.
+
+        No-op when there's no ``entrypoint`` set — the regular flow already
+        populates metadata via ``wrap_app``/registration paths, and this
+        method just returns that cached value.
+        """
+        if self.metadata_entrypoint is None:
+            return self.build_metadata()
+
+        from fal.api import ResultHandler  # noqa: PLC0415
+
+        payload: object = self.host.run(
+            None,
+            self.options,
+            args=(),
+            kwargs={},
+            entrypoint=self.metadata_entrypoint,
+            result_handler=ResultHandler(),
+        )
+        if not isinstance(payload, dict):
+            raise FalServerlessError(
+                "fetch_metadata: entrypoint probe returned a non-dict payload."
+            )
+        self.options.host["metadata"] = payload
+        return payload
+
+    @property
+    def endpoints(self) -> list[str]:
+        """Endpoint paths for this function.
+
+        Derived from the openapi spec in ``build_metadata()`` when present;
+        falls back to ``raw_func._routes`` and finally ``["/"]``. In
+        entrypoint mode call ``fetch_metadata()`` first to populate the
+        openapi spec — without it the property returns ``["/"]``.
+        """
+        openapi = self.build_metadata().get("openapi") or {}
+        paths = openapi.get("paths")
+        if isinstance(paths, dict) and paths:
+            return list(paths.keys())
+        if self.raw_func is not None:
+            return getattr(self.raw_func, "_routes", ["/"])
+        return ["/"]
+
     def run_local(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
         import asyncio  # noqa: PLC0415
         import inspect  # noqa: PLC0415
         import os  # noqa: PLC0415
         from typing import Awaitable, cast  # noqa: PLC0415
 
-        func = self.func
+        func = self._resolve_local_func()
         previous_isolate_env = os.environ.get("IS_ISOLATE_AGENT")
         os.environ["IS_ISOLATE_AGENT"] = "1"
         try:
@@ -2142,6 +2251,27 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
                 del os.environ["IS_ISOLATE_AGENT"]
             else:
                 os.environ["IS_ISOLATE_AGENT"] = previous_isolate_env
+
+    def _resolve_local_func(self) -> Callable[ArgsT, ReturnT]:
+        if self.entrypoint is not None and self.raw_func is None:
+            import importlib  # noqa: PLC0415
+
+            module_name, _, attr = self.entrypoint.partition(":")
+            target: Any = importlib.import_module(module_name)
+            for part in attr.split("."):
+                target = getattr(target, part)
+            try:
+                return target.run_local
+            except AttributeError:
+                raise FalServerlessError(
+                    f"{self.entrypoint!r} has no run_local method — "
+                    "is it a fal.App subclass or a fal.function?"
+                ) from None
+        if self.raw_func is None:
+            raise FalServerlessError(
+                "IsolatedFunction has no local callable to invoke."
+            )
+        return self.func  # type: ignore[return-value]
 
     @overload
     def on(
@@ -2180,7 +2310,9 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         )
 
     @property
-    def func(self) -> Callable[ArgsT, ReturnT]:
+    def func(self) -> Callable[ArgsT, ReturnT] | None:
+        if self.raw_func is None:
+            return None
         serve_mode = self.options.gateway.get("serve")
         if serve_mode:
             # This type can be safely ignored because this case only happens when it

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -138,6 +138,8 @@ def _resolve_deployment_reference(
         assert resolved_app_name is not None
 
         app_data = get_app_data_from_toml(resolved_app_name)
+        if app_data.python_entry_point is not None:
+            return (None, None), app_data
         assert app_data.ref is not None
         file_path, func_name = RefAction.split_ref(app_data.ref)
         return (file_path, func_name), app_data
@@ -161,7 +163,7 @@ def _prepare_deployment_from_reference(
     from fal.utils import load_function_from
 
     file_path, func_name = app_ref
-    if file_path is None:
+    if app_data.python_entry_point is None and file_path is None:
         # Try to find a python file in the current directory
         options = list(Path(".").glob("*.py"))
         if len(options) == 0:
@@ -175,19 +177,20 @@ def _prepare_deployment_from_reference(
         [resolved_file_path] = options
         file_path = str(resolved_file_path)
 
-    local_file_path = str(file_path)
+    local_file_path = str(file_path) if file_path is not None else ""
     host = client._create_host(
         local_file_path=local_file_path,
         environment_name=environment_name,
     )
     loaded = load_function_from(
         host,
-        local_file_path,
+        local_file_path or None,
         func_name,
         force_env_build=force_env_build,
         options=app_data.options,
         app_name=app_data.name,
         app_auth=app_data.auth,
+        python_entry_point=app_data.python_entry_point,
     )
 
     return PreparedDeployment(
@@ -231,6 +234,8 @@ def _execute_loaded_deployment(
     isolated_function = loaded.function
     strategy = app_data.deployment_strategy or "rolling"
 
+    isolated_function.fetch_metadata()
+
     result = host.register(
         func=isolated_function.func,
         options=isolated_function.options,
@@ -242,6 +247,7 @@ def _execute_loaded_deployment(
         scale=app_data.reset_scale,
         environment_name=environment_name,
         result_handler=result_handler,
+        entrypoint=isolated_function.run_entrypoint,
     )
 
     if not result or not result.result:
@@ -262,7 +268,7 @@ def _execute_loaded_deployment(
         "sync": {},
         "async": {},
     }
-    for endpoint in loaded.endpoints:
+    for endpoint in isolated_function.endpoints:
         urls["playground"][endpoint] = f"{result.service_urls.playground}{endpoint}"
         urls["sync"][endpoint] = f"{result.service_urls.run}{endpoint}"
         urls["async"][endpoint] = f"{result.service_urls.queue}{endpoint}"

--- a/projects/fal/src/fal/api/run.py
+++ b/projects/fal/src/fal/api/run.py
@@ -53,8 +53,14 @@ def run(
             application_name=isolated_function.app_name,
             application_auth_mode=isolated_function.app_auth,
             result_handler=result_handler,
+            entrypoint=isolated_function.run_entrypoint,
         )
     except FalMissingDependencyError as e:
+        if func is None:
+            # Entrypoint mode never serializes a callable on the client side,
+            # so there is nothing to inspect for missing-deps hints — just
+            # propagate the original error.
+            raise
         pairs = list(find_missing_dependencies(func, options.environment))
         if not pairs:
             raise e

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -20,6 +20,7 @@ VALID_REGIONS = {
 @dataclass(frozen=True)
 class AppData:
     ref: Optional[str] = None
+    python_entry_point: Optional[str] = None
     auth: Optional[AuthModeLiteral] = None
     deployment_strategy: Optional[DeploymentStrategyLiteral] = None
     reset_scale: bool = False
@@ -58,14 +59,30 @@ def get_app_data_from_toml(
     except KeyError:
         raise ValueError(f"App {app_name} not found in pyproject.toml")
 
-    try:
-        app_ref: str = app_data.pop("ref")
-    except KeyError:
-        raise ValueError(f"App {app_name} does not have a ref key in pyproject.toml")
-
-    # Convert the app_ref to a path relative to the project root
-    project_root, _ = find_project_root(None)
-    app_ref = str(project_root / app_ref)
+    python_entry_point: str | None = app_data.pop("python_entry_point", None)
+    if python_entry_point is not None:
+        if not isinstance(python_entry_point, str):
+            raise ValueError(
+                f"App {app_name} python_entry_point must be a string in pyproject.toml"
+            )
+        app_ref: str | None = app_data.pop("ref", None)
+        if app_ref is not None:
+            raise ValueError(
+                f"App {app_name} cannot have both ref "
+                "and python_entry_point keys in pyproject.toml"
+            )
+    else:
+        try:
+            app_ref = app_data.pop("ref")
+        except KeyError:
+            raise ValueError(
+                f"App {app_name} does not have a ref key in pyproject.toml"
+            )
+        if not isinstance(app_ref, str):
+            raise ValueError(f"App {app_name} ref must be a string in pyproject.toml")
+        # Convert the app_ref to a path relative to the project root
+        project_root, _ = find_project_root(None)
+        app_ref = str(project_root / app_ref)
 
     app_auth: Optional[AuthModeLiteral] = app_data.pop("auth", None)
     app_deployment_strategy: Optional[DeploymentStrategyLiteral] = app_data.pop(
@@ -148,6 +165,7 @@ def get_app_data_from_toml(
 
     return AppData(
         ref=app_ref,
+        python_entry_point=python_entry_point,
         auth=app_auth,
         deployment_strategy=app_deployment_strategy,
         reset_scale=app_reset_scale,

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -38,7 +38,10 @@ def _run(args):
             name=app_data.name,
         )
         team = team or app_data.team
-        file_path, func_name = RefAction.split_ref(app_data.ref)
+        if app_data.ref is not None:
+            file_path, func_name = RefAction.split_ref(app_data.ref)
+        else:
+            file_path, func_name = None, None
     else:
         file_path, func_name = func_ref
         # Turn relative path into absolute path for files
@@ -48,7 +51,10 @@ def _run(args):
 
     no_cache = args.no_cache or args.force_env_build
     client = SyncServerlessClient(host=args.host, team=team)
-    host = client._create_host(local_file_path=file_path, environment_name=args.env)
+    host = client._create_host(
+        local_file_path=file_path or "",
+        environment_name=args.env,
+    )
 
     loaded = load_function_from(
         host,
@@ -59,11 +65,17 @@ def _run(args):
         app_name=app_data.name,
         app_auth=app_data.auth,
         limit_max_requests=args.limit_max_requests,
+        python_entry_point=app_data.python_entry_point,
     )
 
     isolated_function = loaded.function
     if args.machine_type is not None:
         isolated_function.options.host["machine_type"] = args.machine_type
+
+    if not args.local:
+        # Endpoints/openapi for the result handler aren't available locally
+        # in entrypoint mode; this fetches them from the worker.
+        isolated_function.fetch_metadata()
 
     from fal.api.run import run as run_api
 
@@ -75,7 +87,7 @@ def _run(args):
         result_handler=CliRunResultHandler(
             console=args.console,
             auth_mode=loaded.app_auth or "public",
-            endpoints=loaded.endpoints,
+            endpoints=isolated_function.endpoints,
         ),
         reraise=False,
     )

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -793,7 +793,7 @@ class FalServerlessConnection:
 
     def register(
         self,
-        function: Callable[..., ResultT],
+        function: Callable[..., ResultT] | None,
         environments: list[isolate_proto.EnvironmentDefinition],
         application_name: str | None = None,
         auth_mode: Optional[AuthModeLiteral] = None,
@@ -812,8 +812,18 @@ class FalServerlessConnection:
         termination_grace_period_seconds: int | None = None,
         secrets: list[str] | None = None,
         data_mounts: list[str] | None = None,
+        entrypoint: str | None = None,
     ) -> Iterator[RegisterApplicationResult]:
-        wrapped_function = to_serialized_object(function, serialization_method)
+        if function is None and entrypoint is None:
+            raise ValueError("either function or entrypoint must be provided.")
+        if function is not None and entrypoint is not None:
+            raise ValueError("only one of function or entrypoint can be provided.")
+
+        wrapped_function = (
+            to_serialized_object(function, serialization_method)
+            if function is not None
+            else None
+        )
         if machine_requirements:
             wrapped_requirements = isolate_proto.MachineRequirements(
                 # NOTE: backwards compatibility with old API
@@ -883,7 +893,6 @@ class FalServerlessConnection:
         )
 
         request = isolate_proto.RegisterApplicationRequest(
-            function=wrapped_function,
             environments=environments,
             machine_requirements=wrapped_requirements,
             application_name=full_application_name,
@@ -904,6 +913,11 @@ class FalServerlessConnection:
             ),
             data_mounts=data_mounts or [],
         )
+        if entrypoint is not None:
+            request.entrypoint = entrypoint
+        else:
+            assert wrapped_function is not None  # validated at the top
+            request.function.MergeFrom(wrapped_function)
         if private_logs is not None:
             request.private_logs = private_logs
         for partial_result in self.stub.RegisterApplication(request):
@@ -995,7 +1009,7 @@ class FalServerlessConnection:
 
     def run(
         self,
-        function: Callable[..., ResultT],
+        function: Callable[..., ResultT] | None,
         environments: list[isolate_proto.EnvironmentDefinition],
         *,
         serialization_method: str = _DEFAULT_SERIALIZATION_METHOD,
@@ -1007,8 +1021,18 @@ class FalServerlessConnection:
         environment_name: str | None = None,
         secrets: list[str] | None = None,
         data_mounts: list[str] | None = None,
+        entrypoint: str | None = None,
     ) -> Iterator[HostedRunResult[ResultT]]:
-        wrapped_function = to_serialized_object(function, serialization_method)
+        if function is None and entrypoint is None:
+            raise ValueError("either function or entrypoint must be provided.")
+        if function is not None and entrypoint is not None:
+            raise ValueError("only one of function or entrypoint can be provided.")
+
+        wrapped_function = (
+            to_serialized_object(function, serialization_method)
+            if function is not None
+            else None
+        )
         if machine_requirements:
             wrapped_requirements = isolate_proto.MachineRequirements(
                 # NOTE: backwards compatibility with old API
@@ -1047,7 +1071,6 @@ class FalServerlessConnection:
             else None
         )
         request = isolate_proto.HostedRun(
-            function=wrapped_function,
             environments=environments,
             machine_requirements=wrapped_requirements,
             files=files,
@@ -1061,6 +1084,11 @@ class FalServerlessConnection:
             ),
             data_mounts=data_mounts or [],
         )
+        if entrypoint is not None:
+            request.entrypoint = entrypoint
+        else:
+            assert wrapped_function is not None  # validated at the top
+            request.function.MergeFrom(wrapped_function)
         if setup_function:
             request.setup_func.MergeFrom(
                 to_serialized_object(setup_function, serialization_method)

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 @dataclass
 class LoadedFunction:
     function: IsolatedFunction
-    endpoints: list[str]
     app_name: str | None
     app_auth: AuthModeLiteral | None
     source_code: str | None
@@ -116,7 +115,7 @@ def _apply_toml_app_file_options(
 
 def load_function_from(
     host: FalServerlessHost,
-    file_path: str,
+    file_path: str | None,
     function_name: str | None = None,
     *,
     force_env_build: bool = False,
@@ -124,6 +123,7 @@ def load_function_from(
     app_name: str | None = None,
     app_auth: AuthModeLiteral | None = None,
     limit_max_requests: int | None = None,
+    python_entry_point: str | None = None,
 ) -> LoadedFunction:
     import os
     import runpy
@@ -133,6 +133,18 @@ def load_function_from(
     from fal import App, wrap_app
 
     from .api import FalServerlessError, IsolatedFunction
+
+    if python_entry_point is not None:
+        return _load_from_python_entry_point(
+            host,
+            python_entry_point,
+            options=options,
+            app_name=app_name,
+            app_auth=app_auth,
+        )
+
+    if file_path is None:
+        raise FalServerlessError("App ref must resolve to a file path.")
 
     sys.path.append(os.getcwd())
     module = runpy.run_path(file_path)
@@ -149,10 +161,8 @@ def load_function_from(
     with open(file_path) as f:
         source_code = f.read()
 
-    endpoints = ["/"]
     if isinstance(target, type) and issubclass(target, App):
         _apply_toml_app_file_options(target, options)
-        endpoints = target.get_endpoints() or ["/"]
         target = wrap_app(
             target,
             host=host,
@@ -175,11 +185,63 @@ def load_function_from(
     target.app_auth = app_auth
     return LoadedFunction(
         target,
-        endpoints,
         app_name=app_name,
         app_auth=app_auth,
         source_code=source_code,
         class_name=class_name,
+    )
+
+
+def _parse_python_entry_point(python_entry_point: str) -> tuple[str, str]:
+    from fal.api import FalServerlessError
+
+    if ":" not in python_entry_point:
+        raise FalServerlessError(
+            "python_entry_point must be in '<module>:<symbol>' format."
+        )
+    module_name, symbol_name = python_entry_point.split(":", 1)
+    if not module_name or not symbol_name:
+        raise FalServerlessError(
+            "python_entry_point must be in '<module>:<symbol>' format."
+        )
+    return module_name, symbol_name
+
+
+def _load_from_python_entry_point(
+    host: FalServerlessHost,
+    python_entry_point: str,
+    *,
+    options: Optional[Options] = None,
+    app_name: str | None = None,
+    app_auth: AuthModeLiteral | None = None,
+) -> LoadedFunction:
+    from copy import deepcopy
+
+    from fal.api import IsolatedFunction
+    from fal.api import Options as ApiOptions
+
+    # Validate the format up-front; the return value is unused but the call
+    # raises FalServerlessError on a malformed entrypoint string so we fail
+    # fast instead of leaking an obscure error at dispatch time.
+    _parse_python_entry_point(python_entry_point)
+
+    merged_options = deepcopy(options) if options is not None else ApiOptions()
+    merged_options.gateway.setdefault("exposed_port", 8080)
+
+    isolated_function: IsolatedFunction = IsolatedFunction(
+        host=host,
+        options=merged_options,
+        app_name=app_name,
+        app_auth=app_auth,
+        entrypoint=python_entry_point,
+    )
+
+    return LoadedFunction(
+        isolated_function,
+        app_name=app_name,
+        app_auth=app_auth,
+        source_code=None,
+        class_name=python_entry_point,
     )
 
 

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -123,6 +123,10 @@ def mock_parse_pyproject_toml():
                 "team": "my-team",
                 "no_scale": True,
             },
+            "entrypoint-app": {
+                "python_entry_point": "simple.app:SimpleApp",
+                "requirements": ["fal"],
+            },
         }
     }
 
@@ -187,6 +191,83 @@ def test_deploy_with_toml_success(
             reset_scale=False,
             team=None,
             name="my-app",
+        ),
+        force_env_build=False,
+        environment_name=None,
+    )
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_deploy_python_entry_point_forwards_to_loader(
+    mock_load_function_from,
+    mock_create_host,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
+):
+    """End-to-end: deploying a python_entry_point app passes the entrypoint
+    through to ``load_function_from`` and skips the cwd ``*.py`` glob.
+    """
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+    mock_create_host.return_value = MagicMock()
+    loaded = MagicMock()
+    loaded.app_name = "entrypoint-app"
+    loaded.app_auth = "public"
+    loaded.class_name = "SimpleApp"
+    loaded.function = MagicMock(spec=["entrypoint"])
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(app_ref=("entrypoint-app", None))
+    _deploy(args)
+
+    mock_create_host.assert_called_once()
+    _, host_kwargs = mock_create_host.call_args
+    assert host_kwargs["local_file_path"] == ""
+
+    mock_load_function_from.assert_called_once()
+    _, call_kwargs = mock_load_function_from.call_args
+    assert call_kwargs["python_entry_point"] == "simple.app:SimpleApp"
+    assert call_kwargs["options"].environment["requirements"] == ["fal"]
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy._prepare_deployment_from_reference")
+def test_deploy_with_toml_python_entry_point(
+    mock_prepare_ref,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
+):
+    """``fal deploy <app>`` with python_entry_point in pyproject.toml resolves
+    cleanly without crashing on the absent ``ref``.
+    """
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+    options = Options(environment={"requirements": ["fal"]})
+
+    args = mock_args(app_ref=("entrypoint-app", None))
+
+    _deploy(args)
+
+    mock_prepare_ref.assert_called_once_with(
+        mock_prepare_ref.call_args[0][0],
+        (None, None),
+        AppData(
+            ref=None,
+            python_entry_point="simple.app:SimpleApp",
+            auth=None,
+            deployment_strategy=None,
+            reset_scale=False,
+            team=None,
+            name="entrypoint-app",
+            options=options,
         ),
         force_env_build=False,
         environment_name=None,

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -100,6 +100,10 @@ def mock_parse_pyproject_toml():
                 "team": "my-team",
                 "auth": "shared",
             },
+            "entrypoint-app": {
+                "python_entry_point": "simple.app:SimpleApp",
+                "requirements": ["fal"],
+            },
         }
     }
 
@@ -131,7 +135,44 @@ def mock_args(
     args.env = None
     args.machine_type = machine_type
     args.limit_max_requests = limit_max_requests
+    args.local = False
     return args
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_forwards_python_entry_point_to_loader(
+    mock_load_function_from,
+    mock_create_host,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_parse_pyproject_toml,
+):
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+
+    host = mocked_fal_serverless_host("my-host")
+    mock_create_host.return_value = host
+
+    isolated_function = MagicMock()
+    isolated_function.options = MagicMock()
+    isolated_function.options.host = {}
+    loaded = MagicMock()
+    loaded.function = isolated_function
+    loaded.app_name = None
+    loaded.app_auth = None
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(func_ref=("entrypoint-app", None), host="my-host")
+
+    _run(args)
+
+    mock_create_host.assert_called_once_with(local_file_path="", environment_name=None)
+    mock_load_function_from.assert_called_once()
+    _, call_kwargs = mock_load_function_from.call_args
+    assert call_kwargs["python_entry_point"] == "simple.app:SimpleApp"
+    assert call_kwargs["options"].environment["requirements"] == ["fal"]
 
 
 @patch("fal.api.client.SyncServerlessClient._create_host")

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+from fal.api import IsolatedFunction, Options
+from fal.api.run import run as run_api
+
+
+class _FakeHost:
+    pass
+
+
+def test_run_local_with_entrypoint_resolves_user_symbol(monkeypatch):
+    sentinel = MagicMock(name="user_module.UserApp.run_local")
+    sentinel.return_value = "ran"
+
+    fake_module = MagicMock()
+    fake_module.UserApp.run_local = sentinel
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(),
+        entrypoint="user_module:UserApp",
+    )
+
+    result = run_api(iso, args=("a",), kwargs={"k": 1}, local=True)
+
+    assert result == "ran"
+    sentinel.assert_called_once_with("a", k=1)
+
+
+def test_run_local_without_entrypoint_uses_raw_func():
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda *a, **k: ("local", a, k),
+        options=Options(),
+    )
+
+    assert run_api(iso, args=(1,), kwargs={"x": 2}, local=True) == (
+        "local",
+        (1,),
+        {"x": 2},
+    )

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -1,10 +1,16 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 import fal
 from fal.api import IsolatedFunction, Options
 from fal.api.api import merge_basic_config
 from fal.api.client import SyncServerlessClient
-from fal.utils import _find_target, load_function_from
+from fal.utils import (
+    _find_target,
+    _parse_python_entry_point,
+    load_function_from,
+)
 
 
 class DummyHost:
@@ -197,3 +203,119 @@ def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
     assert wrapped_cls.app_files == ["class-files"]
     assert wrapped_cls.app_files_ignore == ["class-ignore"]
     assert wrapped_cls.app_files_context_dir == "class-context"
+
+
+def test_parse_python_entry_point():
+    module_name, symbol_name = _parse_python_entry_point("pkg.mod:MyApp")
+    assert module_name == "pkg.mod"
+    assert symbol_name == "MyApp"
+
+
+def test_parse_python_entry_point_invalid_format():
+    with pytest.raises(Exception) as exc:
+        _parse_python_entry_point("pkg.mod")
+    assert "python_entry_point must be in '<module>:<symbol>' format." in str(exc.value)
+
+
+def test_load_from_python_entry_point_is_passive():
+    """``load_function_from(python_entry_point=...)`` must not hit the worker;
+    metadata is fetched explicitly later via ``IsolatedFunction.fetch_metadata``.
+    """
+    from fal.utils import _load_from_python_entry_point
+
+    host = MagicMock(spec=["run"])  # no .run() attribute access expected
+    options = Options(environment={"requirements": ["fal", "torch"]})
+
+    loaded = _load_from_python_entry_point(
+        host,
+        "simple.app:SimpleApp",
+        options=options,
+    )
+
+    host.run.assert_not_called()
+    assert loaded.function.entrypoint == "simple.app:SimpleApp"
+    assert loaded.function.run_entrypoint == "simple.app:SimpleApp.run_local"
+    assert loaded.function.raw_func is None
+    assert loaded.function.options.gateway["exposed_port"] == 8080
+    assert loaded.function.options.environment["requirements"] == ["fal", "torch"]
+    assert loaded.function.endpoints == ["/"]
+    assert loaded.function.build_metadata() == {}
+
+
+def test_load_from_python_entry_point_keeps_pyproject_exposed_port():
+    from fal.utils import _load_from_python_entry_point
+
+    host = MagicMock(spec=["run"])
+    options = Options(gateway={"exposed_port": 9000})
+    loaded = _load_from_python_entry_point(
+        host,
+        "simple.app:SimpleApp",
+        options=options,
+    )
+
+    assert loaded.function.options.gateway["exposed_port"] == 9000
+
+
+def test_isolated_function_endpoints_from_metadata():
+    iso = IsolatedFunction(
+        host=DummyHost(),
+        entrypoint="pkg:Sym",
+    )
+    iso.options.host["metadata"] = {"openapi": {"paths": {"/predict": {}, "/info": {}}}}
+
+    assert sorted(iso.endpoints) == ["/info", "/predict"]
+
+
+def test_isolated_function_endpoints_fallback_to_routes():
+    func = lambda: None  # noqa: E731
+    func._routes = ["/custom"]  # type: ignore[attr-defined]
+    iso = IsolatedFunction(host=DummyHost(), raw_func=func, options=Options())
+
+    assert iso.endpoints == ["/custom"]
+
+
+def test_isolated_function_endpoints_default():
+    iso = IsolatedFunction(host=DummyHost(), entrypoint="pkg:Sym")
+    assert iso.endpoints == ["/"]
+
+
+def test_isolated_function_fetch_metadata_no_op_without_entrypoint():
+    iso = IsolatedFunction(
+        host=DummyHost(),
+        raw_func=lambda: None,
+        options=Options(),
+    )
+    iso.options.host["metadata"] = {"openapi": {"paths": {"/x": {}}}}
+
+    assert iso.fetch_metadata() == {"openapi": {"paths": {"/x": {}}}}
+
+
+def test_isolated_function_fetch_metadata_probes_worker():
+    host = MagicMock()
+    host.run.return_value = {"openapi": {"paths": {"/predict": {}}}}
+
+    iso = IsolatedFunction(host=host, entrypoint="pkg.mod:MyApp")
+    metadata = iso.fetch_metadata()
+
+    host.run.assert_called_once()
+    _, call_kwargs = host.run.call_args
+    assert call_kwargs["entrypoint"] == "pkg.mod:MyApp.build_metadata"
+    assert metadata == {"openapi": {"paths": {"/predict": {}}}}
+    assert iso.options.host["metadata"] == metadata
+    assert iso.endpoints == ["/predict"]
+
+
+def test_isolated_function_fetch_metadata_rejects_non_dict_payload():
+    from fal.api import FalServerlessError
+
+    host = MagicMock()
+    host.run.return_value = "not a dict"
+
+    iso = IsolatedFunction(host=host, entrypoint="pkg.mod:MyApp")
+    with pytest.raises(FalServerlessError, match="non-dict payload"):
+        iso.fetch_metadata()
+
+
+def test_isolated_function_requires_func_or_entrypoint():
+    with pytest.raises(Exception, match="raw_func or entrypoint"):
+        IsolatedFunction(host=DummyHost())


### PR DESCRIPTION
## Summary
- Plumb an `entrypoint: str | None` end-to-end (`Host`/`LocalHost`/`FalServerlessHost`, `IsolatedFunction`, `api/run.py`, `api/deploy.py`, `sdk.py`) so the gRPC `RegisterApplicationRequest` / `HostedRun` `oneof callable` can carry a `module:symbol` string instead of a pickled callable.
- Add `python_entry_point` (mutually exclusive with `ref`) to `[tool.fal.apps.<name>]`, captured on `AppData`.
- `IsolatedFunction` makes `entrypoint` (bare `module:symbol`) a first-class field; `raw_func` is now optional. Two derived properties feed the gRPC dispatch sites: `run_entrypoint` → `<symbol>.run_local`, `metadata_entrypoint` → `<symbol>.build_metadata`. `IsolatedFunction.endpoints` derives from `build_metadata()["openapi"]["paths"]` with sensible fallbacks.
- `IsolatedFunction.fetch_metadata()` is the explicit, active step that probes `<symbol>.build_metadata` on the worker and caches the result into `options.host["metadata"]` — called from `_execute_loaded_deployment` (right before `host.register`) and from `cli/run.py` (before `run_api`, only when not `--local`). `load_function_from(python_entry_point=...)` itself is purely passive.
- `--local` resolves the user's symbol with `importlib` and invokes `target.run_local` directly; the worker side never enters the picture.

This relies on the new `build_metadata`/`run_local` methods on `fal.App` (#1010) and `IsolatedFunction` (#1011), so no helper file injection or sdist build is needed — the user is responsible for getting their package onto the worker via their pyproject `requirements`.

## Test plan
- [x] `pytest tests/unit/test_utils.py tests/unit/test_api_run.py tests/unit/cli/test_run.py` (43 passed)
- [x] Pre-existing `tests/unit/cli/test_deploy.py::test_deploy_with_cli_*` failures (CWD-sensitive, unrelated) confirmed to also fail on `main`.
- [x] Pre-existing E2E (`test_rollout_application`) and Integration (`test_regular_function_in_a_container_with_custom_image`) flakes confirmed to also fail on `main`.