### PR TITLE
feat(api): add build_metadata method to IsolatedFunction

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -2115,6 +2115,9 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
 
         return _run_with_handling(self, args=args, kwargs=kwargs, reraise=self.reraise)
 
+    def build_metadata(self) -> dict[str, Any]:
+        return self.options.host.get("metadata") or {}
+
     def run_local(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
         import asyncio  # noqa: PLC0415
         import inspect  # noqa: PLC0415

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -237,7 +237,7 @@ def _execute_loaded_deployment(
         application_name=loaded.app_name,
         application_auth_mode=loaded.app_auth,  # type: ignore
         source_code=loaded.source_code,
-        metadata=isolated_function.options.host.get("metadata", {}),
+        metadata=isolated_function.build_metadata(),
         deployment_strategy=strategy,
         scale=app_data.reset_scale,
         environment_name=environment_name,


### PR DESCRIPTION
## Summary
- Adds `build_metadata()` to `IsolatedFunction`, mirroring the `App.build_metadata` classmethod added in #1010.
- It returns the metadata dict stashed in `options.host` (which is what `wrap_app` populates via `cls.build_metadata()`).
- Updates `_execute_loaded_deployment` in [deploy.py](projects/fal/src/fal/api/deploy.py) to use the new method instead of poking `options.host.get("metadata", {})` directly.

## Test plan
- [x] CI passes