### PR TITLE
feat(cli): add `fal runners gpus` and `fal apps gpus`

### DIFF
--- a/projects/fal/src/fal/api/_metrics.py
+++ b/projects/fal/src/fal/api/_metrics.py
@@ -1,0 +1,101 @@
+"""Internal helpers shared by `apps.app_gpus` and `runners.runners_gpus`.
+
+Both rely on the same `/applications/metrics` payload and the same GPU name
+normalization. Living in their own module avoids a private cross-import
+between sibling modules.
+"""
+
+from __future__ import annotations
+
+import re
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import httpx
+
+import fal.flags as flags
+
+if TYPE_CHECKING:
+    from .client import SyncServerlessClient
+
+
+# Ports the dashboard's GPU name normalization. SKU rules collapse driver
+# variants (PCIE/SXM/MIG, etc.) into a single short name, e.g.
+# "NVIDIA H100 80GB HBM3" and "NVIDIA H100 80GB HBM3 MIG 3g.40gb" → "H100".
+_CPU_MACHINE_TYPES = {"M", "L", "S", "XS", "XL"}
+
+_GPU_NAME_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\b(RTX.?5090|GPU-RTX5090)\b", re.IGNORECASE), "5090"),
+    (re.compile(r"\b(A100|GPU-A100)\b", re.IGNORECASE), "A100"),
+    # L40S is a distinct GPU but the frontend collapses it into "L40"; keep
+    # parity until the dashboard distinguishes them.
+    (re.compile(r"\b(L40S?|GPU-L40)\b", re.IGNORECASE), "L40"),
+    (re.compile(r"\b(H100|GPU-H100)\b", re.IGNORECASE), "H100"),
+    (re.compile(r"\b(H200|GPU-H200)\b", re.IGNORECASE), "H200"),
+    (re.compile(r"\b(B200|GPU-B200)\b", re.IGNORECASE), "B200"),
+]
+
+_RTX_RE = re.compile(r"RTX\s*(?:PRO\s*)?([A-Z]?\d{4}(?:\s+(?:Ti|Super|SUPER|Ada|XT))?)")
+_MIG_RE = re.compile(r"\b([A-Z]\d{3,4})\b.*\bMIG\b")
+_MODEL_RE = re.compile(r"\b([A-Z]\d{2,4}\w?)\b")
+# Ordered after _MODEL_RE: AMD MI\d names like "MI300X" can't satisfy the
+# generic [A-Z]\d{2,4} model pattern (no \b between M and I), so it's safe to
+# fall through to the MI matcher.
+_MI_RE = re.compile(r"\b(MI\d{3}\w*)\b")
+
+
+def _shorten_gpu_name(name: str) -> str:
+    if name in _CPU_MACHINE_TYPES:
+        return ""
+    m = _RTX_RE.search(name)
+    if m:
+        return f"RTX {m.group(1)}"
+    m = _MIG_RE.search(name)
+    if m:
+        return f"{m.group(1)} MIG"
+    m = _MODEL_RE.search(name)
+    if m:
+        return m.group(1)
+    m = _MI_RE.search(name)
+    if m:
+        return m.group(1)
+    return f"{name[:7]}…" if len(name) > 8 else name
+
+
+def _normalize_gpu_name(name: str) -> str:
+    for pattern, short in _GPU_NAME_PATTERNS:
+        if pattern.search(name):
+            return short
+    return _shorten_gpu_name(name)
+
+
+def _normalize_gpu_counts(by_type: dict | None) -> dict[str, int]:
+    """Filter out zero/CPU entries and collapse raw GPU names into short SKUs."""
+    out: dict[str, int] = {}
+    for raw_type, count in (by_type or {}).items():
+        if count <= 0 or raw_type in _CPU_MACHINE_TYPES:
+            continue
+        short = _normalize_gpu_name(raw_type)
+        if not short:
+            continue
+        out[short] = out.get(short, 0) + count
+    return out
+
+
+def _get_metrics(client: SyncServerlessClient) -> dict:
+    """Fetch the raw /applications/metrics payload."""
+    rest_client = client._create_rest_client()
+    with httpx.Client(
+        base_url=rest_client.base_url,
+        headers=rest_client.get_headers(),
+        timeout=30,
+        verify=not flags.TEST_MODE,
+        follow_redirects=True,
+    ) as http:
+        resp = http.get("/applications/metrics")
+    if resp.status_code != HTTPStatus.OK:
+        raise RuntimeError(f"Failed to fetch metrics: {resp.status_code} {resp.text}")
+    data = resp.json()
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Unexpected metrics response format: {resp.text}")
+    return data

--- a/projects/fal/src/fal/api/apps.py
+++ b/projects/fal/src/fal/api/apps.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, List, Optional
 
 from fal.sdk import AliasInfo, FalServerlessClient, RunnerInfo
 
+from ._metrics import _get_metrics, _normalize_gpu_counts
+
 if TYPE_CHECKING:
     from .client import SyncServerlessClient
 
@@ -97,3 +99,31 @@ def rollout_app(
             force=force,
             environment_name=environment_name,
         )
+
+
+def app_gpus(client: SyncServerlessClient, app_name: str) -> dict:
+    """Get GPU usage for a single application.
+
+    Accepts either a bare name ("flux") or a namespaced one ("fal-ai/flux").
+    The metrics endpoint keys apps as "<namespace>/<name>", but the rest of
+    `fal apps` accepts bare names, so we match by basename for parity.
+
+    Returns {"gpus": {<type>: <count>, ...}, "total": <int>} where `total`
+    equals the sum of values in `gpus`. GPU type names are normalized to
+    short SKUs (e.g. "H100"); the metrics endpoint includes every machine
+    type with non-GPU plans at count 0, which we filter out.
+    """
+    data = _get_metrics(client)
+    apps = data.get("apps") or {}
+    target = app_name.rsplit("/", 1)[-1]
+    matches = [info for key, info in apps.items() if key.rsplit("/", 1)[-1] == target]
+    if not matches:
+        raise RuntimeError(f"Application {app_name!r} not found in metrics.")
+    if len(matches) > 1:
+        candidates = sorted(key for key in apps if key.rsplit("/", 1)[-1] == target)
+        raise RuntimeError(
+            f"Application name {app_name!r} is ambiguous; matches: "
+            f"{', '.join(candidates)}"
+        )
+    gpu_by_type = _normalize_gpu_counts(matches[0].get("gpu_count_by_type"))
+    return {"gpus": gpu_by_type, "total": sum(gpu_by_type.values())}

--- a/projects/fal/src/fal/api/client.py
+++ b/projects/fal/src/fal/api/client.py
@@ -158,6 +158,19 @@ class AppsNamespace:
             self.client, app_name, force=force, environment_name=environment_name
         )
 
+    def gpus(self, app_name: str) -> dict:
+        """Get GPU usage for a single application.
+
+        Corresponds to `fal apps gpus <app>`. Returns
+        ``{"gpus": {<type>: <count>, ...}, "total": <int>}``.
+
+        Example:
+            usage = client.apps.gpus("fal-ai/flux")
+            print(usage["total"])  # e.g. 21
+            print(usage["gpus"])   # e.g. {"B200": 21}
+        """
+        return apps_api.app_gpus(self.client, app_name)
+
 
 class RunnersNamespace:
     """Namespace for runner management operations.
@@ -209,6 +222,19 @@ class RunnersNamespace:
             runner_id: The ID of the runner to kill.
         """
         return runners_api.kill_runner(self.client, runner_id)
+
+    def gpus(self) -> dict:
+        """Get team-wide GPU usage summary.
+
+        Corresponds to `fal runners gpus`. Returns
+        ``{"gpus": {<type>: <count>, ...}, "total": <int>}``.
+
+        Example:
+            usage = client.runners.gpus()
+            print(usage["total"])  # e.g. 1120
+            print(usage["gpus"])   # e.g. {"H100": 394, "B200": 353, ...}
+        """
+        return runners_api.runners_gpus(self.client)
 
 
 class KeysNamespace:

--- a/projects/fal/src/fal/api/runners.py
+++ b/projects/fal/src/fal/api/runners.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, List, Optional
 
 from fal.sdk import FalServerlessClient, RunnerInfo
 
+from ._metrics import _get_metrics, _normalize_gpu_counts
+
 if TYPE_CHECKING:
     from .client import SyncServerlessClient
 
@@ -26,3 +28,17 @@ def stop_runner(
 def kill_runner(client: SyncServerlessClient, runner_id: str) -> None:
     with FalServerlessClient(client._grpc_host, client._credentials).connect() as conn:
         conn.kill_runner(runner_id)
+
+
+def runners_gpus(client: SyncServerlessClient) -> dict:
+    """Get team-wide GPU usage summary.
+
+    Returns {"gpus": {<type>: <count>, ...}, "total": <int>} where `total`
+    equals the sum of values in `gpus`. GPU type names are normalized to
+    short SKUs (e.g. "H100"); the metrics endpoint includes every machine
+    type with non-GPU plans at count 0, which we filter out.
+    """
+    data = _get_metrics(client)
+    summary = data.get("summary") or {}
+    gpu_by_type = _normalize_gpu_counts(summary.get("total_gpu_by_type"))
+    return {"gpus": gpu_by_type, "total": sum(gpu_by_type.values())}

--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -477,6 +477,27 @@ def _add_runners_parser(subparsers, parents):
     parser.set_defaults(func=_runners)
 
 
+def _gpus(args):
+    client = SyncServerlessClient(host=args.host, team=args.team)
+    usage = client.apps.gpus(args.app_name)
+    runners.render_gpus(args, usage["gpus"], usage["total"])
+
+
+def _add_gpus_parser(subparsers, parents):
+    gpus_help = "Show GPU usage for an application."
+    parser = subparsers.add_parser(
+        "gpus",
+        description=gpus_help,
+        help=gpus_help,
+        parents=[*parents, get_output_parser()],
+    )
+    parser.add_argument(
+        "app_name",
+        help="Application name.",
+    )
+    parser.set_defaults(func=_gpus)
+
+
 def _delete(args):
     client = get_client(args.host, args.team)
     with client.connect() as connection:
@@ -548,5 +569,6 @@ def add_parser(main_subparsers, parents):
     _add_scale_parser(subparsers, parents)
     _add_rollout_parser(subparsers, parents)
     _add_runners_parser(subparsers, parents)
+    _add_gpus_parser(subparsers, parents)
     _add_delete_parser(subparsers, parents)
     _add_delete_rev_parser(subparsers, parents)

--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -273,6 +273,31 @@ def _kill(args):
     client.runners.kill(args.id)
 
 
+def render_gpus(args, gpu_by_type: dict[str, int], total: int):
+    sorted_types = sorted(gpu_by_type.items(), key=lambda kv: -kv[1])
+    if args.output == "pretty":
+        from rich.table import Table
+
+        table = Table()
+        table.add_column("Type")
+        table.add_column("Count", justify="right")
+        for gpu_type, gpus in sorted_types:
+            table.add_row(gpu_type, str(gpus))
+        args.console.print(table)
+        args.console.print(f"Total: {total}")
+    elif args.output == "json":
+        result = {"gpus": dict(sorted_types), "total": total}
+        args.console.print(json.dumps(result))
+    else:
+        raise AssertionError(f"Invalid output format: {args.output}")
+
+
+def _gpus(args):
+    client = SyncServerlessClient(host=args.host, team=args.team)
+    usage = client.runners.gpus()
+    render_gpus(args, usage["gpus"], usage["total"])
+
+
 def _list_json(args, runners: list[RunnerInfo]):
     json_runners = [
         {
@@ -725,6 +750,17 @@ def _logs(args):
             printer.print(log)
 
 
+def _add_gpus_parser(subparsers, parents):
+    gpus_help = "Show GPU usage summary across runners."
+    parser = subparsers.add_parser(
+        "gpus",
+        description=gpus_help,
+        help=gpus_help,
+        parents=[*parents, get_output_parser()],
+    )
+    parser.set_defaults(func=_gpus)
+
+
 def _add_logs_parser(subparsers, parents):
     logs_help = "Show logs for a runner."
     parser = subparsers.add_parser(
@@ -836,6 +872,7 @@ def add_parser(main_subparsers, parents):
     _add_stop_parser(subparsers, parents)
     _add_kill_parser(subparsers, parents)
     _add_list_parser(subparsers, parents)
+    _add_gpus_parser(subparsers, parents)
     _add_logs_parser(subparsers, parents)
     _add_shell_parser(subparsers, parents)
     _add_exec_parser(subparsers, parents)

--- a/projects/fal/tests/unit/cli/test_apps.py
+++ b/projects/fal/tests/unit/cli/test_apps.py
@@ -1,9 +1,13 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from fal.cli.apps import (
     _delete,
     _delete_rev,
+    _gpus,
     _list,
     _list_rev,
     _rollout,
@@ -186,3 +190,57 @@ def test_delete_rev():
     args = parse_args(["apps", "delete-rev", "myrev"])
     assert args.func == _delete_rev
     assert args.app_rev == "myrev"
+
+
+_GPUS_PAYLOAD = {"gpus": {"H100": 8, "B200": 3, "L40": 5}, "total": 16}
+
+
+def test_apps_gpus_parser():
+    args = parse_args(["apps", "gpus", "myapp"])
+    assert args.func == _gpus
+    assert args.app_name == "myapp"
+
+
+def _mock_gpus_client(payload):
+    client = MagicMock()
+    client.apps.gpus.return_value = payload
+    return client
+
+
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_apps_gpus_json(mock_client_cls):
+    mock_client_cls.return_value = _mock_gpus_client(_GPUS_PAYLOAD)
+    args = parse_args(["apps", "gpus", "fal-ai/flux", "--json"])
+    args.console = MagicMock()
+    args.func(args)
+
+    output = args.console.print.call_args[0][0]
+    result = json.loads(output)
+    assert result["total"] == 16
+    # Sorted by count desc by render_gpus
+    assert list(result["gpus"].items()) == [("H100", 8), ("L40", 5), ("B200", 3)]
+
+
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_apps_gpus_pretty_runs(mock_client_cls):
+    mock_client_cls.return_value = _mock_gpus_client(_GPUS_PAYLOAD)
+    args = parse_args(["apps", "gpus", "fal-ai/flux"])
+    args.console = MagicMock()
+    args.func(args)
+
+    printed = " ".join(str(call.args[0]) for call in args.console.print.call_args_list)
+    assert "Total: 16" in printed
+
+
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_apps_gpus_app_not_found(mock_client_cls):
+    client = MagicMock()
+    client.apps.gpus.side_effect = RuntimeError(
+        "Application 'fal-ai/missing' not found in metrics."
+    )
+    mock_client_cls.return_value = client
+    args = parse_args(["apps", "gpus", "fal-ai/missing"])
+    args.console = MagicMock()
+
+    with pytest.raises(RuntimeError, match="not found in metrics"):
+        args.func(args)

--- a/projects/fal/tests/unit/cli/test_runners.py
+++ b/projects/fal/tests/unit/cli/test_runners.py
@@ -1,0 +1,80 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fal.cli.main import parse_args
+from fal.cli.runners import _gpus
+
+_GPUS_PAYLOAD = {
+    "gpus": {"H100": 394, "B200": 353, "H200": 334},
+    "total": 1120,
+}
+
+
+def test_gpus_parser_registered():
+    args = parse_args(["runners", "gpus"])
+    assert args.func == _gpus
+
+
+def _mock_client(payload):
+    client = MagicMock()
+    client.runners.gpus.return_value = payload
+    return client
+
+
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_gpus_json(mock_client_cls):
+    mock_client_cls.return_value = _mock_client(_GPUS_PAYLOAD)
+
+    args = parse_args(["runners", "gpus", "--json"])
+    args.console = MagicMock()
+    args.func(args)
+
+    output = args.console.print.call_args[0][0]
+    result = json.loads(output)
+
+    assert result["total"] == 1120
+    # Sorted by gpus desc by render_gpus
+    assert list(result["gpus"].items()) == [
+        ("H100", 394),
+        ("B200", 353),
+        ("H200", 334),
+    ]
+
+
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_gpus_pretty_runs(mock_client_cls):
+    mock_client_cls.return_value = _mock_client(_GPUS_PAYLOAD)
+
+    args = parse_args(["runners", "gpus"])
+    args.console = MagicMock()
+    args.func(args)
+
+    printed = " ".join(str(call.args[0]) for call in args.console.print.call_args_list)
+    assert "Total: 1120" in printed
+
+
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_gpus_empty(mock_client_cls):
+    mock_client_cls.return_value = _mock_client({"gpus": {}, "total": 0})
+
+    args = parse_args(["runners", "gpus", "--json"])
+    args.console = MagicMock()
+    args.func(args)
+
+    output = args.console.print.call_args[0][0]
+    assert json.loads(output) == {"gpus": {}, "total": 0}
+
+
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_gpus_propagates_api_error(mock_client_cls):
+    client = MagicMock()
+    client.runners.gpus.side_effect = RuntimeError("Failed to fetch metrics: 500 boom")
+    mock_client_cls.return_value = client
+
+    args = parse_args(["runners", "gpus"])
+    args.console = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Failed to fetch metrics"):
+        args.func(args)

--- a/projects/fal/tests/unit/test_api_metrics.py
+++ b/projects/fal/tests/unit/test_api_metrics.py
@@ -1,0 +1,160 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fal.api._metrics import (
+    _normalize_gpu_counts,
+    _normalize_gpu_name,
+    _shorten_gpu_name,
+)
+from fal.api.apps import app_gpus
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # SKU rules collapse driver variants
+        ("NVIDIA H100 80GB HBM3", "H100"),
+        ("NVIDIA H100 80GB HBM3 MIG 3g.40gb", "H100"),
+        ("NVIDIA H200", "H200"),
+        ("NVIDIA B200", "B200"),
+        ("NVIDIA A100-SXM4-80GB", "A100"),
+        ("NVIDIA A100-SXM4-40GB", "A100"),
+        ("NVIDIA A100 PCIE 40GB", "A100"),
+        ("NVIDIA L40", "L40"),
+        ("NVIDIA L40S", "L40"),
+        ("NVIDIA RTX 5090", "5090"),
+        ("RTX-5090", "5090"),
+        ("GPU-H100", "H100"),
+        # Fallthrough to shortenGpuName
+        ("NVIDIA RTX A6000", "RTX A6000"),
+        ("NVIDIA RTX PRO 6000 Blackwell Server Edition", "RTX 6000"),
+    ],
+)
+def test_normalize_gpu_name(raw, expected):
+    assert _normalize_gpu_name(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # CPU plans return empty so they get filtered downstream
+        ("M", ""),
+        ("L", ""),
+        ("XS", ""),
+        # RTX matcher with optional PRO
+        ("NVIDIA RTX A6000", "RTX A6000"),
+        ("NVIDIA RTX PRO 6000 Blackwell Server Edition", "RTX 6000"),
+        # MIG matcher
+        ("NVIDIA H100 MIG 3g.40gb", "H100 MIG"),
+        # AMD MI series
+        ("AMD MI300X", "MI300X"),
+        # Generic model fallback (requires 2+ digits after the letter)
+        ("Tesla V100", "V100"),
+        # Truncation fallback for unmatched names longer than 8 chars
+        ("Unknown123Foo", "Unknown…"),
+    ],
+)
+def test_shorten_gpu_name(raw, expected):
+    assert _shorten_gpu_name(raw) == expected
+
+
+def test_normalize_gpu_counts_collapses_variants_and_drops_noise():
+    raw = {
+        "NVIDIA H100 80GB HBM3": 400,
+        "NVIDIA H100 80GB HBM3 MIG 3g.40gb": 30,  # collapses into H100
+        "NVIDIA H200": 280,
+        "NVIDIA A100-SXM4-80GB": 5,
+        "NVIDIA A100-SXM4-40GB": 3,  # collapses into A100
+        "M": 0,  # filtered (CPU + zero)
+        "L": 0,
+        "S": 0,
+        "XS": 0,
+        "XL": 0,
+    }
+    result = _normalize_gpu_counts(raw)
+    assert result == {"H100": 430, "H200": 280, "A100": 8}
+
+
+def test_normalize_gpu_counts_filters_cpu_types_with_nonzero_counts():
+    # Defensive: even if the endpoint accidentally reports a non-zero CPU
+    # plan in the GPU breakdown, we still filter it out.
+    raw = {"NVIDIA H100": 10, "M": 5, "L": 3}
+    assert _normalize_gpu_counts(raw) == {"H100": 10}
+
+
+def test_normalize_gpu_counts_handles_none_and_empty():
+    assert _normalize_gpu_counts(None) == {}
+    assert _normalize_gpu_counts({}) == {}
+
+
+@patch("fal.api.apps._get_metrics")
+def test_app_gpus_normalizes_per_app(mock_get_metrics):
+    mock_get_metrics.return_value = {
+        "apps": {
+            "fal-ai/flux": {
+                "runner_count": 3,
+                "gpu_count": 11,
+                "gpu_count_by_type": {
+                    "NVIDIA H100 80GB HBM3": 8,
+                    "NVIDIA H100 80GB HBM3 MIG 3g.40gb": 3,
+                    "M": 0,
+                },
+                "cpu_count": 0,
+                "cpu_count_by_type": {},
+                "queue_size": 0,
+            },
+        },
+        "summary": {},
+    }
+    result = app_gpus(MagicMock(), "fal-ai/flux")
+    assert result == {"gpus": {"H100": 11}, "total": 11}
+
+
+@patch("fal.api.apps._get_metrics")
+def test_app_gpus_raises_when_app_missing(mock_get_metrics):
+    mock_get_metrics.return_value = {"apps": {}, "summary": {}}
+    with pytest.raises(RuntimeError, match="not found in metrics"):
+        app_gpus(MagicMock(), "fal-ai/missing")
+
+
+_FLUX_APP = {
+    "runner_count": 1,
+    "gpu_count": 4,
+    "gpu_count_by_type": {"NVIDIA H100 80GB HBM3": 4},
+    "cpu_count": 0,
+    "cpu_count_by_type": {},
+    "queue_size": 0,
+}
+
+
+@patch("fal.api.apps._get_metrics")
+def test_app_gpus_accepts_bare_name(mock_get_metrics):
+    mock_get_metrics.return_value = {
+        "apps": {"fal-ai/flux": _FLUX_APP},
+        "summary": {},
+    }
+    # Bare name resolves to the namespaced key
+    assert app_gpus(MagicMock(), "flux") == {"gpus": {"H100": 4}, "total": 4}
+
+
+@patch("fal.api.apps._get_metrics")
+def test_app_gpus_accepts_namespaced_name(mock_get_metrics):
+    mock_get_metrics.return_value = {
+        "apps": {"fal-ai/flux": _FLUX_APP},
+        "summary": {},
+    }
+    assert app_gpus(MagicMock(), "fal-ai/flux") == {"gpus": {"H100": 4}, "total": 4}
+
+
+@patch("fal.api.apps._get_metrics")
+def test_app_gpus_ambiguous_bare_name(mock_get_metrics):
+    mock_get_metrics.return_value = {
+        "apps": {
+            "team-a/flux": _FLUX_APP,
+            "team-b/flux": _FLUX_APP,
+        },
+        "summary": {},
+    }
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        app_gpus(MagicMock(), "flux")


### PR DESCRIPTION
## Summary
- Adds **`fal runners gpus`** — team-wide GPU usage summary, grouped by GPU type with a total. Sourced from the platform's `/applications/metrics` REST endpoint.
- Adds **`fal apps gpus <alias>`** — same shape, scoped to a single application.
- Both commands share `_fetch_metrics` + `render_gpus` helpers in `runners.py` so output stays consistent.

Output shape:

```
$ fal runners gpus
┏━━━━━━┳━━━━━━━┓
┃ Type ┃ Count ┃
┡━━━━━━╇━━━━━━━┩
│ H100 │   394 │
│ B200 │   353 │
│ H200 │   334 │
└──────┴───────┘
Total: 1120

$ fal runners gpus --json
{"gpus": {"H100": 394, "B200": 353, "H200": 334}, "total": 1120}

$ fal apps gpus fal-ai/flux --json
{"gpus": {"B200": 21}, "total": 21}
```

The JSON shape is the primary surface for usage-tracking consumers (SERV-754) that want a cheap snapshot without paginating runners.

## Test plan
- [x] Unit tests for `fal runners gpus`: parser registration, JSON output, pretty output, empty summary, HTTP error
- [x] Unit tests for `fal apps gpus`: parser registration, JSON output, pretty output, app-not-found
- [x] `--help` renders for both commands
- [x] Manual smoke test against staging once deployed