### PR TITLE
feat(cli): show `Building metadata...` banner during entrypoint probe

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -2246,12 +2246,17 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         """Probe ``<entrypoint>.build_metadata`` on the worker and cache the
         result into ``options.host["metadata"]``.
 
-        No-op when there's no ``entrypoint`` set — the regular flow already
-        populates metadata via ``wrap_app``/registration paths, and this
-        method just returns that cached value.
+        Idempotent: if metadata is already cached (either because the regular
+        ``wrap_app``/registration flow populated it, or because a previous
+        ``fetch_metadata()`` call did), returns the cached value without a
+        second round-trip.
         """
         if self.metadata_entrypoint is None:
             return self.build_metadata()
+
+        cached = self.build_metadata()
+        if cached:
+            return cached
 
         from fal.api import ResultHandler  # noqa: PLC0415
 

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -827,6 +827,20 @@ class FalServerlessHost(Host):
             requirements, self.local_project_root, on_progress=_on_progress
         )
 
+    def prepare_requirements(self, options: Options) -> None:
+        """Trigger local-path requirement materialization (sdist build +
+        upload) eagerly, so the noisy ``Packaging local project...``
+        output doesn't appear nested inside a later phase's rule frame
+        (e.g. ``IsolatedFunction.fetch_metadata()``).
+
+        The sdist URL cache is process-wide, so the subsequent dispatch
+        re-materializes silently. Pass a copy of the env options so the
+        in-place rewrite here doesn't escape — the real ``_run`` call
+        below will redo the rewrite (silently, from cache) on its own
+        copy when it actually dispatches.
+        """
+        self._materialize_local_requirements(options.environment.copy())
+
     def files_sync(self, options: FileSyncOptions) -> list[File]:
         """Sync files to the server."""
         # Auto-exclude the app file, it gets serialized separately
@@ -2241,6 +2255,20 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
 
     def build_metadata(self) -> dict[str, Any]:
         return self.options.host.get("metadata") or {}
+
+    def prepare_requirements(self) -> None:
+        """Trigger local-path requirement materialization eagerly so the
+        ``Packaging local project...`` output stands on its own instead
+        of being nested inside a later phase like ``fetch_metadata()``.
+
+        No-op on hosts that don't support the rewrite (e.g. ``LocalHost``).
+        Safe to call multiple times — the underlying sdist URL cache
+        keeps subsequent calls silent.
+        """
+        prepare = getattr(self.host, "prepare_requirements", None)
+        if prepare is None:
+            return
+        prepare(self.options)
 
     def fetch_metadata(
         self,

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -2242,7 +2242,11 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     def build_metadata(self) -> dict[str, Any]:
         return self.options.host.get("metadata") or {}
 
-    def fetch_metadata(self) -> dict[str, Any]:
+    def fetch_metadata(
+        self,
+        *,
+        result_handler: ResultHandler | None = None,
+    ) -> dict[str, Any]:
         """Probe ``<entrypoint>.build_metadata`` on the worker and cache the
         result into ``options.host["metadata"]``.
 
@@ -2250,6 +2254,10 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         ``wrap_app``/registration flow populated it, or because a previous
         ``fetch_metadata()`` call did), returns the cached value without a
         second round-trip.
+
+        ``result_handler`` is forwarded to the worker run so callers (the CLI)
+        can surface the env-build / runtime-setup / user-source logs that
+        stream while the worker is computing the metadata.
         """
         if self.metadata_entrypoint is None:
             return self.build_metadata()
@@ -2258,15 +2266,15 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         if cached:
             return cached
 
-        from fal.api import ResultHandler  # noqa: PLC0415
-
         payload: object = self.host.run(
             None,
             self.options,
             args=(),
             kwargs={},
             entrypoint=self.metadata_entrypoint,
-            result_handler=ResultHandler(),
+            result_handler=result_handler
+            if result_handler is not None
+            else ResultHandler(),
         )
         if not isinstance(payload, dict):
             raise FalServerlessError(

--- a/projects/fal/src/fal/cli/_result_handlers.py
+++ b/projects/fal/src/fal/cli/_result_handlers.py
@@ -29,7 +29,7 @@ class CliRunResultHandler(ResultHandler):
         self.console = console
         self.auth_mode = auth_mode
         self.endpoints = endpoints
-        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG, console=console)
 
     def on_service_urls(self, urls: Any) -> None:
         from rich.rule import Rule  # noqa: PLC0415
@@ -84,7 +84,7 @@ class CliRegisterResultHandler(ResultHandler):
 
     def __init__(self, *, console: Console) -> None:
         self.console = console
-        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG, console=console)
 
     def on_log(self, log: Any) -> None:
         self.log_printer.print(log)

--- a/projects/fal/src/fal/cli/_result_handlers.py
+++ b/projects/fal/src/fal/cli/_result_handlers.py
@@ -88,3 +88,21 @@ class CliRegisterResultHandler(ResultHandler):
 
     def on_log(self, log: Any) -> None:
         self.log_printer.print(log)
+
+
+class CliMetadataProbeResultHandler(CliRegisterResultHandler):
+    """Streams worker logs for ``IsolatedFunction.fetch_metadata()``.
+
+    Same as ``CliRegisterResultHandler`` but drops the legacy ``Access
+    the playground at`` / ``And API access through`` lines — those
+    advertise an ephemeral runner URL that's torn down as soon as the
+    metadata probe returns, so showing them just confuses users.
+    """
+
+    def on_log(self, log: Any) -> None:
+        if (
+            "Access the playground at" in log.message
+            or "And API access through" in log.message
+        ):
+            return
+        super().on_log(log)

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -36,13 +36,17 @@ def fetch_metadata_with_banner(
         isolated_function.fetch_metadata()
         return
 
+    from rich.rule import Rule  # noqa: PLC0415
+
     from fal.cli._result_handlers import CliRegisterResultHandler  # noqa: PLC0415
     from fal.console.icons import CHECK_ICON  # noqa: PLC0415
 
     console.print("Building metadata...", style="bold")
+    console.print(Rule(style="dim"))
     isolated_function.fetch_metadata(
         result_handler=CliRegisterResultHandler(console=console)
     )
+    console.print(Rule(style="dim"))
     console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")
     console.print("")
 

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -41,6 +41,11 @@ def fetch_metadata_with_banner(
     from fal.cli._result_handlers import CliRegisterResultHandler  # noqa: PLC0415
     from fal.console.icons import CHECK_ICON  # noqa: PLC0415
 
+    # Run sdist build/upload eagerly so its `Packaging local project...`
+    # section sits at top level instead of getting nested inside the
+    # metadata phase's rule frame below.
+    isolated_function.prepare_requirements()
+
     console.print("Building metadata...", style="bold")
     console.print(Rule(style="dim"))
     isolated_function.fetch_metadata(

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -124,7 +124,7 @@ def fetch_metadata_with_banner(
 
     from rich.rule import Rule  # noqa: PLC0415
 
-    from fal.cli._result_handlers import CliRegisterResultHandler  # noqa: PLC0415
+    from fal.cli._result_handlers import CliMetadataProbeResultHandler  # noqa: PLC0415
     from fal.console.icons import CHECK_ICON  # noqa: PLC0415
 
     # Run sdist build/upload eagerly so its `Packaging local project...`
@@ -136,7 +136,7 @@ def fetch_metadata_with_banner(
     console.print(Rule(style="dim"))
     with _indented_console_output():
         isolated_function.fetch_metadata(
-            result_handler=CliRegisterResultHandler(console=console)
+            result_handler=CliMetadataProbeResultHandler(console=console)
         )
     console.print(Rule(style="dim"))
     console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -3,11 +3,46 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from fal.api import Options
 from fal.project import find_project_root, find_pyproject_toml, parse_pyproject_toml
 from fal.sdk import AuthModeLiteral, DeploymentStrategyLiteral
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from fal.api import IsolatedFunction
+
+
+def fetch_metadata_with_banner(
+    console: Console,
+    isolated_function: IsolatedFunction,
+) -> None:
+    """Run ``isolated_function.fetch_metadata()`` with a ``Building
+    metadata...`` / ``✓ Metadata build complete`` section banner consistent
+    with the rest of the CLI (``Building environment...`` / ``Build
+    complete``, ``Packaging local project X...`` / ``Project packaged``).
+
+    The banner is only shown when an actual remote round-trip is needed
+    (entrypoint mode and no cached metadata yet). In every other case
+    this is a free no-op.
+    """
+    needs_remote_probe = (
+        isolated_function.metadata_entrypoint is not None
+        and not isolated_function.build_metadata()
+    )
+    if not needs_remote_probe:
+        isolated_function.fetch_metadata()
+        return
+
+    from fal.console.icons import CHECK_ICON  # noqa: PLC0415
+
+    console.print("Building metadata...", style="bold")
+    isolated_function.fetch_metadata()
+    console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")
+    console.print("")
+
 
 VALID_REGIONS = {
     "us-west",

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import contextlib
 import copy
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -58,47 +56,19 @@ class _IndentedStream:
         return getattr(self._underlying, name)
 
 
-@contextlib.contextmanager
-def _indented_console_output(prefix: str = "  "):
-    """Indent ``sys.stdout``/``sys.stderr`` and the ``fal.console`` module
-    global console for the duration of the block, so streamed worker
-    output reads as nested content under an enclosing section header.
+def _indented_console(parent: Console, prefix: str = "  ") -> Console:
+    """Build a rich Console that prefixes every output line with
+    ``prefix``. Width is narrowed by the prefix length so width-aware
+    renderables (e.g. ``Rule``) still align flush with the parent."""
+    import sys  # noqa: PLC0415
 
-    ``IsolateLogPrinter`` writes phase headers through
-    ``from fal.console import console`` (lazy local rebind, so swapping
-    the module attribute is enough) and writes log messages through raw
-    ``print()`` / ``sys.stdout`` / ``sys.stderr``. Wrapping all three
-    covers every code path it can take.
-    """
     from rich.console import Console  # noqa: PLC0415
 
-    import fal.console as _fc  # noqa: PLC0415
-
-    original_console = _fc.console
-    indented_stdout = _IndentedStream(sys.stdout, prefix)
-    indented_stderr = _IndentedStream(sys.stderr, prefix)
-    # Narrow the inner console so Rule() and any width-aware renderable
-    # render at (terminal_width - prefix) — once we add the prefix the
-    # total line width matches the outer console again.
-    indented_console = Console(
-        file=indented_stdout,
+    return Console(
+        file=_IndentedStream(sys.stdout, prefix),
         force_terminal=True,
-        width=max(1, original_console.size.width - len(prefix)),
+        width=max(1, parent.size.width - len(prefix)),
     )
-
-    saved_stdout = sys.stdout
-    saved_stderr = sys.stderr
-    try:
-        # _IndentedStream is a duck-typed file proxy, not a TextIO subclass —
-        # cast through Any for both replacement and restoration.
-        sys.stdout = indented_stdout  # type: ignore[assignment]
-        sys.stderr = indented_stderr  # type: ignore[assignment]
-        _fc.console = indented_console
-        yield
-    finally:
-        sys.stdout = saved_stdout
-        sys.stderr = saved_stderr
-        _fc.console = original_console
 
 
 def fetch_metadata_with_banner(
@@ -134,10 +104,9 @@ def fetch_metadata_with_banner(
 
     console.print("Building metadata...", style="bold")
     console.print(Rule(style="dim"))
-    with _indented_console_output():
-        isolated_function.fetch_metadata(
-            result_handler=CliMetadataProbeResultHandler(console=console)
-        )
+    isolated_function.fetch_metadata(
+        result_handler=CliMetadataProbeResultHandler(console=_indented_console(console))
+    )
     console.print(Rule(style="dim"))
     console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")
     console.print("")

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import copy
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -13,6 +15,90 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from fal.api import IsolatedFunction
+
+
+class _IndentedStream:
+    """File-like wrapper that prepends ``prefix`` to every line written.
+
+    Tracks whether the next byte starts a new line across writes so a
+    handler that produces a line in multiple ``write()`` calls still
+    only gets one prefix per visible line.
+    """
+
+    def __init__(self, underlying: Any, prefix: str) -> None:
+        self._underlying = underlying
+        self._prefix = prefix
+        self._at_line_start = True
+
+    def write(self, s: str) -> int:
+        if not s:
+            return 0
+        parts = s.split("\n")
+        out: list[str] = []
+        for i, part in enumerate(parts):
+            if i > 0:
+                out.append("\n")
+                self._at_line_start = True
+            if part:
+                if self._at_line_start:
+                    out.append(self._prefix)
+                    self._at_line_start = False
+                out.append(part)
+        self._underlying.write("".join(out))
+        return len(s)
+
+    def flush(self) -> None:
+        self._underlying.flush()
+
+    def isatty(self) -> bool:
+        check = getattr(self._underlying, "isatty", None)
+        return bool(check()) if callable(check) else False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._underlying, name)
+
+
+@contextlib.contextmanager
+def _indented_console_output(prefix: str = "  "):
+    """Indent ``sys.stdout``/``sys.stderr`` and the ``fal.console`` module
+    global console for the duration of the block, so streamed worker
+    output reads as nested content under an enclosing section header.
+
+    ``IsolateLogPrinter`` writes phase headers through
+    ``from fal.console import console`` (lazy local rebind, so swapping
+    the module attribute is enough) and writes log messages through raw
+    ``print()`` / ``sys.stdout`` / ``sys.stderr``. Wrapping all three
+    covers every code path it can take.
+    """
+    from rich.console import Console  # noqa: PLC0415
+
+    import fal.console as _fc  # noqa: PLC0415
+
+    original_console = _fc.console
+    indented_stdout = _IndentedStream(sys.stdout, prefix)
+    indented_stderr = _IndentedStream(sys.stderr, prefix)
+    # Narrow the inner console so Rule() and any width-aware renderable
+    # render at (terminal_width - prefix) — once we add the prefix the
+    # total line width matches the outer console again.
+    indented_console = Console(
+        file=indented_stdout,
+        force_terminal=True,
+        width=max(1, original_console.size.width - len(prefix)),
+    )
+
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    try:
+        # _IndentedStream is a duck-typed file proxy, not a TextIO subclass —
+        # cast through Any for both replacement and restoration.
+        sys.stdout = indented_stdout  # type: ignore[assignment]
+        sys.stderr = indented_stderr  # type: ignore[assignment]
+        _fc.console = indented_console
+        yield
+    finally:
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+        _fc.console = original_console
 
 
 def fetch_metadata_with_banner(
@@ -48,9 +134,10 @@ def fetch_metadata_with_banner(
 
     console.print("Building metadata...", style="bold")
     console.print(Rule(style="dim"))
-    isolated_function.fetch_metadata(
-        result_handler=CliRegisterResultHandler(console=console)
-    )
+    with _indented_console_output():
+        isolated_function.fetch_metadata(
+            result_handler=CliRegisterResultHandler(console=console)
+        )
     console.print(Rule(style="dim"))
     console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")
     console.print("")

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -36,10 +36,13 @@ def fetch_metadata_with_banner(
         isolated_function.fetch_metadata()
         return
 
+    from fal.cli._result_handlers import CliRegisterResultHandler  # noqa: PLC0415
     from fal.console.icons import CHECK_ICON  # noqa: PLC0415
 
     console.print("Building metadata...", style="bold")
-    isolated_function.fetch_metadata()
+    isolated_function.fetch_metadata(
+        result_handler=CliRegisterResultHandler(console=console)
+    )
     console.print(f"{CHECK_ICON} Metadata build complete", style="bold green")
     console.print("")
 

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -5,6 +5,7 @@ import json
 
 from fal.api.client import SyncServerlessClient
 
+from ._utils import fetch_metadata_with_banner
 from .deploy_check import _resolve_deploy_check_source, deploy_with_check
 from .parser import FalClientParser, RefAction, add_env_argument, get_output_parser
 
@@ -54,6 +55,7 @@ def _deploy(args):
             style="bold",
         )
         args.console.print("")
+        fetch_metadata_with_banner(args.console, prepared.loaded.function)
         res = deploy_api.execute_prepared_deployment(
             prepared, result_handler=result_handler
         )

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -110,6 +110,8 @@ def deploy_with_check(
 ) -> DeploymentResult:
     from fal.api import deploy as deploy_api
 
+    from ._utils import fetch_metadata_with_banner
+
     prepared = deploy_api.prepare_deployment(
         client,
         app_ref,
@@ -137,6 +139,7 @@ def deploy_with_check(
         console=args.console,
         assume_yes=args.yes,
     )
+    fetch_metadata_with_banner(args.console, prepared.loaded.function)
     return deploy_api.execute_prepared_deployment(
         prepared, result_handler=result_handler
     )

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -2,7 +2,12 @@ import argparse
 from dataclasses import replace
 from pathlib import Path
 
-from ._utils import AppData, get_app_data_from_toml, is_app_name
+from ._utils import (
+    AppData,
+    fetch_metadata_with_banner,
+    get_app_data_from_toml,
+    is_app_name,
+)
 from .parser import FalClientParser, RefAction, add_env_argument
 
 
@@ -76,7 +81,7 @@ def _run(args):
     if not args.local:
         # Endpoints/openapi for the result handler aren't available locally
         # in entrypoint mode; this fetches them from the worker.
-        isolated_function.fetch_metadata()
+        fetch_metadata_with_banner(args.console, isolated_function)
 
     from fal.api.run import run as run_api
 

--- a/projects/fal/src/fal/logging/isolate.py
+++ b/projects/fal/src/fal/logging/isolate.py
@@ -11,26 +11,64 @@ from .style import LEVEL_STYLES
 
 if TYPE_CHECKING:
     from isolate.logs import Log, LogSource
+    from rich.console import Console
 
 _renderer = ConsoleRenderer(level_styles=LEVEL_STYLES)
 
 
 class IsolateLogPrinter:
+    """Print streamed isolate logs with phase-header transitions.
+
+    When ``console`` is omitted, phase headers go through the
+    ``fal.console`` module-level console and raw log messages go
+    through ``sys.stdout``/``sys.stderr`` (preserving the source's
+    stdout/stderr split). When a ``console`` is provided, all output
+    is routed through it — useful for callers (e.g. the CLI's
+    metadata-probe phase) that wrap output with an indented or otherwise
+    decorated console so the whole stream stays inside the wrap.
+    """
+
     debug: bool
 
-    def __init__(self, debug: bool = False) -> None:
+    def __init__(
+        self,
+        debug: bool = False,
+        *,
+        console: Console | None = None,
+    ) -> None:
         self.debug = debug
         self._current_source: LogSource | None = None
+        self._console_override = console
+
+    def _resolve_console(self) -> Console:
+        if self._console_override is not None:
+            return self._console_override
+        from fal.console import console as _global_console
+
+        return _global_console
+
+    def _emit_message(self, message: str, *, stderr: bool = False) -> None:
+        if self._console_override is None:
+            stream = sys.stderr if stderr else sys.stdout
+            print(message, file=stream)
+            return
+        # Write to the console's underlying file so any wrapper around
+        # it (e.g. an indented stream) sees the bytes — but skip rich's
+        # rendering pipeline since the structlog renderer already baked
+        # in ANSI escapes for the destination terminal.
+        self._console_override.file.write(message + "\n")
+        self._console_override.file.flush()
 
     def _maybe_print_header(self, source: LogSource):
         from isolate.logs import LogSource
         from rich.rule import Rule
 
-        from fal.console import console
         from fal.console.icons import CHECK_ICON
 
         if source == self._current_source:
             return
+
+        console = self._resolve_console()
 
         # Print build completion when transitioning out of BUILDER phase
         if self._current_source == LogSource.BUILDER:
@@ -62,8 +100,10 @@ class IsolateLogPrinter:
         self._maybe_print_header(log.source)
 
         if log.source == LogSource.USER:
-            stream = sys.stderr if log.level == LogLevel.STDERR else sys.stdout
-            print(log.message, file=stream)
+            self._emit_message(
+                log.message,
+                stderr=log.level == LogLevel.STDERR,
+            )
             return
 
         level = str(log.level)
@@ -88,4 +128,4 @@ class IsolateLogPrinter:
 
         # Use structlog processors to get consistent output with local logs
         message = _renderer.__call__(logger={}, name=level, event_dict=event)
-        print(message)
+        self._emit_message(message)

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -221,7 +221,10 @@ def test_deploy_python_entry_point_forwards_to_loader(
     loaded.app_name = "entrypoint-app"
     loaded.app_auth = "public"
     loaded.class_name = "SimpleApp"
-    loaded.function = MagicMock(spec=["entrypoint"])
+    loaded.function = MagicMock(
+        spec=["entrypoint", "metadata_entrypoint", "build_metadata", "fetch_metadata"]
+    )
+    loaded.function.metadata_entrypoint = None
     mock_load_function_from.return_value = loaded
 
     args = mock_args(app_ref=("entrypoint-app", None))
@@ -1030,7 +1033,10 @@ def _prepared_deployment(
                         "regions": ["us-east"],
                     },
                     environment={},
-                )
+                ),
+                metadata_entrypoint=None,
+                build_metadata=lambda: {},
+                fetch_metadata=lambda: {},
             ),
         ),
         display_name="MyApp",

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -305,6 +305,20 @@ def test_isolated_function_fetch_metadata_probes_worker():
     assert iso.endpoints == ["/predict"]
 
 
+def test_isolated_function_fetch_metadata_forwards_result_handler():
+    from fal.api import ResultHandler
+
+    host = MagicMock()
+    host.run.return_value = {"openapi": {"paths": {}}}
+
+    iso = IsolatedFunction(host=host, entrypoint="pkg.mod:MyApp")
+    custom_handler = ResultHandler()
+    iso.fetch_metadata(result_handler=custom_handler)
+
+    _, call_kwargs = host.run.call_args
+    assert call_kwargs["result_handler"] is custom_handler
+
+
 def test_isolated_function_fetch_metadata_is_idempotent():
     host = MagicMock()
     host.run.return_value = {"openapi": {"paths": {"/predict": {}}}}

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -305,6 +305,18 @@ def test_isolated_function_fetch_metadata_probes_worker():
     assert iso.endpoints == ["/predict"]
 
 
+def test_isolated_function_fetch_metadata_is_idempotent():
+    host = MagicMock()
+    host.run.return_value = {"openapi": {"paths": {"/predict": {}}}}
+
+    iso = IsolatedFunction(host=host, entrypoint="pkg.mod:MyApp")
+    first = iso.fetch_metadata()
+    second = iso.fetch_metadata()
+
+    host.run.assert_called_once()
+    assert first == second == {"openapi": {"paths": {"/predict": {}}}}
+
+
 def test_isolated_function_fetch_metadata_rejects_non_dict_payload():
     from fal.api import FalServerlessError
 


### PR DESCRIPTION
## Summary

In entrypoint mode (`python_entry_point` in `pyproject.toml`), `fal run` / `fal deploy` silently do a full worker round-trip to fetch openapi metadata before the actual run/register phase kicks in. With no UI output and a potentially cold env build happening underneath, it looks like the CLI is hanging.

This PR:

- **Hoists `isolated_function.fetch_metadata()` to the CLI layer in deploy**, mirroring what `fal run` already does. The API-level call in `_execute_loaded_deployment` is kept so programmatic `deploy_api.deploy(...)` callers still work.
- **Wraps the call in a `Building metadata...` / `✓ Metadata build complete` banner** matching the existing CLI convention (`Building environment...` / `✓ Build complete`, `Packaging local project X...` / `✓ Project packaged`).
- **Makes `IsolatedFunction.fetch_metadata()` idempotent** — if metadata is already in `options.host["metadata"]`, it returns the cached value without a second round-trip. This matches the docstring's "cache" claim and means the API-layer call after the CLI's call is a free no-op.

Banner shows only when an actual remote probe is needed (entrypoint mode + cache empty), so non-entrypoint flows are unaffected.