### PR TITLE
feat(cli): support image=ContainerImage in pyproject.toml

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -237,11 +237,7 @@ def _validate_str_list(field_name: str, value: Any) -> None:
 _IMAGE_PASSTHROUGH_KEYS = (
     "build_args",
     "registries",
-    "builder",
-    "compression",
-    "force_compression",
     "secrets",
-    "dockerignore",
 )
 
 
@@ -254,64 +250,29 @@ def _build_container_image_from_toml(
     image_config = dict(image_config)
 
     dockerfile_path = image_config.pop("dockerfile", None)
-    dockerfile_str = image_config.pop("dockerfile_str", None)
-
-    if dockerfile_path is None and dockerfile_str is None:
+    if dockerfile_path is None:
         raise ValueError(
-            f"App {app_name} image must specify either 'dockerfile' (path) "
-            "or 'dockerfile_str' in pyproject.toml"
+            f"App {app_name} image must specify 'dockerfile' (path) in pyproject.toml"
         )
-    if dockerfile_path is not None and dockerfile_str is not None:
+    if not isinstance(dockerfile_path, str):
         raise ValueError(
-            f"App {app_name} image cannot specify both 'dockerfile' and "
-            "'dockerfile_str' in pyproject.toml"
+            f"App {app_name} image.dockerfile must be a string in pyproject.toml"
         )
 
-    if dockerfile_path is not None:
-        if not isinstance(dockerfile_path, str):
-            raise ValueError(
-                f"App {app_name} image.dockerfile must be a string in pyproject.toml"
-            )
-        resolved_path = Path(dockerfile_path)
-        if not resolved_path.is_absolute():
-            resolved_path = project_root / resolved_path
-        with open(resolved_path) as f:
-            dockerfile_str = f.read()
-    elif not isinstance(dockerfile_str, str):
-        raise ValueError(
-            f"App {app_name} image.dockerfile_str must be a string in pyproject.toml"
-        )
+    resolved_path = Path(dockerfile_path)
+    if not resolved_path.is_absolute():
+        resolved_path = project_root / resolved_path
+    with open(resolved_path) as f:
+        dockerfile_str = f.read()
 
-    kwargs: dict[str, Any] = {"dockerfile_str": dockerfile_str}
+    kwargs: dict[str, Any] = {
+        "dockerfile_str": dockerfile_str,
+        "context_dir": project_root,
+    }
 
     for key in _IMAGE_PASSTHROUGH_KEYS:
         if key in image_config:
             kwargs[key] = image_config.pop(key)
-
-    context_dir = image_config.pop("context_dir", None)
-    if context_dir is not None:
-        if not isinstance(context_dir, str):
-            raise ValueError(
-                f"App {app_name} image.context_dir must be a string in pyproject.toml"
-            )
-        context_path = Path(context_dir)
-        if not context_path.is_absolute():
-            context_path = project_root / context_path
-        kwargs["context_dir"] = context_path
-    else:
-        kwargs["context_dir"] = project_root
-
-    dockerignore_path = image_config.pop("dockerignore_path", None)
-    if dockerignore_path is not None:
-        if not isinstance(dockerignore_path, str):
-            raise ValueError(
-                f"App {app_name} image.dockerignore_path must be a string "
-                "in pyproject.toml"
-            )
-        dockerignore_resolved = Path(dockerignore_path)
-        if not dockerignore_resolved.is_absolute():
-            dockerignore_resolved = project_root / dockerignore_resolved
-        kwargs["dockerignore_path"] = dockerignore_resolved
 
     if image_config:
         raise ValueError(

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -136,7 +136,7 @@ def get_app_data_from_toml(
         raise ValueError(
             "app_files_context_dir is only supported when app_files is provided."
         )
-    if image_config is not None and app_files is not None:
+    if image_config is not None and app_files:
         raise ValueError("app_files is not supported for container apps.")
 
     if min_concurrency is not None:
@@ -262,8 +262,11 @@ def _build_container_image_from_toml(
     resolved_path = Path(dockerfile_path)
     if not resolved_path.is_absolute():
         resolved_path = project_root / resolved_path
-    with open(resolved_path) as f:
-        dockerfile_str = f.read()
+    try:
+        with open(resolved_path) as f:
+            dockerfile_str = f.read()
+    except FileNotFoundError:
+        raise ValueError(f"App {app_name} image.dockerfile not found: {resolved_path}")
 
     kwargs: dict[str, Any] = {
         "dockerfile_str": dockerfile_str,

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from fal.api import Options
+from fal.container import ContainerImage
 from fal.project import find_project_root, find_pyproject_toml, parse_pyproject_toml
 from fal.sdk import AuthModeLiteral, DeploymentStrategyLiteral
 
@@ -121,6 +122,8 @@ def get_app_data_from_toml(
     app_files_ignore = app_data.pop("app_files_ignore", None)
     app_files_context_dir = app_data.pop("app_files_context_dir", None)
 
+    image_config = app_data.pop("image", None)
+
     if regions is not None:
         _validate_regions(regions)
     if app_files is not None:
@@ -133,6 +136,8 @@ def get_app_data_from_toml(
         raise ValueError(
             "app_files_context_dir is only supported when app_files is provided."
         )
+    if image_config is not None and app_files is not None:
+        raise ValueError("app_files is not supported for container apps.")
 
     if min_concurrency is not None:
         options.host["min_concurrency"] = min_concurrency
@@ -162,6 +167,12 @@ def get_app_data_from_toml(
         options.environment["requirements"] = requirements
     if python_version is not None:
         options.environment["python_version"] = python_version
+    if image_config is not None:
+        container_image = _build_container_image_from_toml(
+            app_name, image_config, Path(toml_path).parent
+        )
+        options.environment["kind"] = "container"
+        options.environment["image"] = container_image.to_dict()
 
     app_reset_scale: bool
     if "no_scale" in app_data:
@@ -221,3 +232,90 @@ def _validate_requirements(requirements: Any) -> None:
 def _validate_str_list(field_name: str, value: Any) -> None:
     if not (isinstance(value, list) and all(isinstance(item, str) for item in value)):
         raise ValueError(f"{field_name} must be a list of strings.")
+
+
+_IMAGE_PASSTHROUGH_KEYS = (
+    "build_args",
+    "registries",
+    "builder",
+    "compression",
+    "force_compression",
+    "secrets",
+    "dockerignore",
+)
+
+
+def _build_container_image_from_toml(
+    app_name: str, image_config: Any, project_root: Path
+) -> ContainerImage:
+    if not isinstance(image_config, dict):
+        raise ValueError(f"App {app_name} image must be a table in pyproject.toml")
+
+    image_config = dict(image_config)
+
+    dockerfile_path = image_config.pop("dockerfile", None)
+    dockerfile_str = image_config.pop("dockerfile_str", None)
+
+    if dockerfile_path is None and dockerfile_str is None:
+        raise ValueError(
+            f"App {app_name} image must specify either 'dockerfile' (path) "
+            "or 'dockerfile_str' in pyproject.toml"
+        )
+    if dockerfile_path is not None and dockerfile_str is not None:
+        raise ValueError(
+            f"App {app_name} image cannot specify both 'dockerfile' and "
+            "'dockerfile_str' in pyproject.toml"
+        )
+
+    if dockerfile_path is not None:
+        if not isinstance(dockerfile_path, str):
+            raise ValueError(
+                f"App {app_name} image.dockerfile must be a string in pyproject.toml"
+            )
+        resolved_path = Path(dockerfile_path)
+        if not resolved_path.is_absolute():
+            resolved_path = project_root / resolved_path
+        with open(resolved_path) as f:
+            dockerfile_str = f.read()
+    elif not isinstance(dockerfile_str, str):
+        raise ValueError(
+            f"App {app_name} image.dockerfile_str must be a string in pyproject.toml"
+        )
+
+    kwargs: dict[str, Any] = {"dockerfile_str": dockerfile_str}
+
+    for key in _IMAGE_PASSTHROUGH_KEYS:
+        if key in image_config:
+            kwargs[key] = image_config.pop(key)
+
+    context_dir = image_config.pop("context_dir", None)
+    if context_dir is not None:
+        if not isinstance(context_dir, str):
+            raise ValueError(
+                f"App {app_name} image.context_dir must be a string in pyproject.toml"
+            )
+        context_path = Path(context_dir)
+        if not context_path.is_absolute():
+            context_path = project_root / context_path
+        kwargs["context_dir"] = context_path
+    else:
+        kwargs["context_dir"] = project_root
+
+    dockerignore_path = image_config.pop("dockerignore_path", None)
+    if dockerignore_path is not None:
+        if not isinstance(dockerignore_path, str):
+            raise ValueError(
+                f"App {app_name} image.dockerignore_path must be a string "
+                "in pyproject.toml"
+            )
+        dockerignore_resolved = Path(dockerignore_path)
+        if not dockerignore_resolved.is_absolute():
+            dockerignore_resolved = project_root / dockerignore_resolved
+        kwargs["dockerignore_path"] = dockerignore_resolved
+
+    if image_config:
+        raise ValueError(
+            f"Found unexpected keys in app {app_name} image: {image_config}"
+        )
+
+    return ContainerImage(**kwargs)

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -162,6 +162,16 @@ def load_function_from(
         source_code = f.read()
 
     if isinstance(target, type) and issubclass(target, App):
+        # ``App.__init_subclass__`` enforces ``image``/``app_files`` exclusivity
+        # at class-definition time, but ``image`` can also arrive from
+        # pyproject.toml — in which case the class never saw it. Re-check here
+        # so class-level ``app_files`` can't sneak through with a TOML image.
+        if (
+            options is not None
+            and options.environment.get("kind") == "container"
+            and target.app_files
+        ):
+            raise FalServerlessError("app_files is not supported for container apps.")
         _apply_toml_app_file_options(target, options)
         target = wrap_app(
             target,

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -962,21 +962,25 @@ def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(
         get_app_data_from_toml("my-app")
 
 
-@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.find_pyproject_toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-def test_get_app_data_from_toml_with_image_dockerfile_str(
-    mock_parse_toml, mock_find_toml
-):
+def test_get_app_data_from_toml_with_image(mock_parse_toml, mock_find_toml, tmp_path):
     from fal.cli._utils import get_app_data_from_toml
 
     dockerfile = "FROM python:3.12-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
     mock_parse_toml.return_value = {
         "apps": {
             "container-app": {
                 "ref": "src/my_app/inference.py::MyApp",
                 "image": {
-                    "dockerfile_str": dockerfile,
+                    "dockerfile": "Dockerfile",
                     "build_args": {"FOO": "bar"},
+                    "registries": {
+                        "myregistry.com": {"username": "u", "password": "p"}
+                    },
+                    "secrets": {"TOKEN": "shh"},
                 },
             }
         }
@@ -988,32 +992,10 @@ def test_get_app_data_from_toml_with_image_dockerfile_str(
     assert env["kind"] == "container"
     assert env["image"]["dockerfile_str"] == dockerfile
     assert env["image"]["build_args"] == {"FOO": "bar"}
-
-
-@patch("fal.cli._utils.find_pyproject_toml")
-@patch("fal.cli._utils.parse_pyproject_toml")
-def test_get_app_data_from_toml_with_image_dockerfile_path(
-    mock_parse_toml, mock_find_toml, tmp_path
-):
-    from fal.cli._utils import get_app_data_from_toml
-
-    dockerfile = "FROM python:3.12-slim\n"
-    (tmp_path / "Dockerfile").write_text(dockerfile)
-    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
-    mock_parse_toml.return_value = {
-        "apps": {
-            "container-app": {
-                "ref": "src/my_app/inference.py::MyApp",
-                "image": {"dockerfile": "Dockerfile"},
-            }
-        }
+    assert env["image"]["registries"] == {
+        "myregistry.com": {"username": "u", "password": "p"}
     }
-
-    toml_data = get_app_data_from_toml("container-app")
-
-    env = toml_data.options.environment
-    assert env["kind"] == "container"
-    assert env["image"]["dockerfile_str"] == dockerfile
+    assert env["image"]["secrets"] == {"TOKEN": "shh"}
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
@@ -1035,55 +1017,28 @@ def test_get_app_data_from_toml_rejects_image_without_dockerfile(
     with pytest.raises(
         ValueError,
         match=(
-            "App container-app image must specify either 'dockerfile' "
-            r"\(path\) or 'dockerfile_str' in pyproject.toml"
+            "App container-app image must specify 'dockerfile' "
+            r"\(path\) in pyproject.toml"
         ),
     ):
         get_app_data_from_toml("container-app")
 
 
-@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.find_pyproject_toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
-def test_get_app_data_from_toml_rejects_image_with_both_dockerfile_keys(
-    mock_parse_toml, mock_find_toml
+def test_get_app_data_from_toml_rejects_unknown_image_keys(
+    mock_parse_toml, mock_find_toml, tmp_path
 ):
     from fal.cli._utils import get_app_data_from_toml
 
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
     mock_parse_toml.return_value = {
         "apps": {
             "container-app": {
                 "ref": "src/my_app/inference.py::MyApp",
                 "image": {
                     "dockerfile": "Dockerfile",
-                    "dockerfile_str": "FROM python:3.12-slim\n",
-                },
-            }
-        }
-    }
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "App container-app image cannot specify both 'dockerfile' "
-            "and 'dockerfile_str' in pyproject.toml"
-        ),
-    ):
-        get_app_data_from_toml("container-app")
-
-
-@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
-@patch("fal.cli._utils.parse_pyproject_toml")
-def test_get_app_data_from_toml_rejects_unknown_image_keys(
-    mock_parse_toml, mock_find_toml
-):
-    from fal.cli._utils import get_app_data_from_toml
-
-    mock_parse_toml.return_value = {
-        "apps": {
-            "container-app": {
-                "ref": "src/my_app/inference.py::MyApp",
-                "image": {
-                    "dockerfile_str": "FROM python:3.12-slim\n",
                     "bogus": "value",
                 },
             }
@@ -1097,18 +1052,20 @@ def test_get_app_data_from_toml_rejects_unknown_image_keys(
         get_app_data_from_toml("container-app")
 
 
-@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.find_pyproject_toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_rejects_image_with_app_files(
-    mock_parse_toml, mock_find_toml
+    mock_parse_toml, mock_find_toml, tmp_path
 ):
     from fal.cli._utils import get_app_data_from_toml
 
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
     mock_parse_toml.return_value = {
         "apps": {
             "container-app": {
                 "ref": "src/my_app/inference.py::MyApp",
-                "image": {"dockerfile_str": "FROM python:3.12-slim\n"},
+                "image": {"dockerfile": "Dockerfile"},
                 "app_files": ["assets"],
             }
         }

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1078,6 +1078,53 @@ def test_get_app_data_from_toml_rejects_image_with_app_files(
         get_app_data_from_toml("container-app")
 
 
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_allows_image_with_empty_app_files(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {"dockerfile": "Dockerfile"},
+                "app_files": [],
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+    assert toml_data.options.environment["kind"] == "container"
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_missing_dockerfile(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {"dockerfile": "missing.Dockerfile"},
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"App container-app image.dockerfile not found:",
+    ):
+        get_app_data_from_toml("container-app")
+
+
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_no_scale_warning_can_be_suppressed(

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -964,6 +964,165 @@ def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_image_dockerfile_str(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    dockerfile = "FROM python:3.12-slim\n"
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {
+                    "dockerfile_str": dockerfile,
+                    "build_args": {"FOO": "bar"},
+                },
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+
+    env = toml_data.options.environment
+    assert env["kind"] == "container"
+    assert env["image"]["dockerfile_str"] == dockerfile
+    assert env["image"]["build_args"] == {"FOO": "bar"}
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_image_dockerfile_path(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    dockerfile = "FROM python:3.12-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {"dockerfile": "Dockerfile"},
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+
+    env = toml_data.options.environment
+    assert env["kind"] == "container"
+    assert env["image"]["dockerfile_str"] == dockerfile
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_without_dockerfile(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {"build_args": {"FOO": "bar"}},
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "App container-app image must specify either 'dockerfile' "
+            r"\(path\) or 'dockerfile_str' in pyproject.toml"
+        ),
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_with_both_dockerfile_keys(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {
+                    "dockerfile": "Dockerfile",
+                    "dockerfile_str": "FROM python:3.12-slim\n",
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "App container-app image cannot specify both 'dockerfile' "
+            "and 'dockerfile_str' in pyproject.toml"
+        ),
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_unknown_image_keys(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {
+                    "dockerfile_str": "FROM python:3.12-slim\n",
+                    "bogus": "value",
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"Found unexpected keys in app container-app image",
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_with_app_files(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {"dockerfile_str": "FROM python:3.12-slim\n"},
+                "app_files": ["assets"],
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="app_files is not supported for container apps.",
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_no_scale_warning_can_be_suppressed(
     mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml, capsys
 ):

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -205,6 +205,37 @@ def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
     assert wrapped_cls.app_files_context_dir == "class-context"
 
 
+def test_load_function_from_rejects_class_app_files_with_toml_image(tmp_path):
+    from fal.api import FalServerlessError
+
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    app_files = ['class-files']\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(
+        environment={
+            "kind": "container",
+            "image": {"dockerfile_str": "FROM python:3.12-slim\n"},
+        }
+    )
+
+    with pytest.raises(
+        FalServerlessError,
+        match="app_files is not supported for container apps.",
+    ):
+        load_function_from(host, str(app_file), "MyApp", options=options)
+
+
 def test_parse_python_entry_point():
     module_name, symbol_name = _parse_python_entry_point("pkg.mod:MyApp")
     assert module_name == "pkg.mod"


### PR DESCRIPTION
## Summary
- Adds `[tool.fal.apps.<name>.image]` support in pyproject.toml, mirroring the `image=ContainerImage(...)` argument already accepted by `fal.function` and `fal.App`.
- Supported keys: `dockerfile` (required, path resolved relative to the pyproject), `build_args`, `registries`, `secrets`. Sets `kind = "container"` automatically and pins `context_dir` to the project root.
- Rejects `image` + `app_files` both for TOML-declared and class-declared `app_files` (the latter via a post-class-load check, since `App.__init_subclass__` never sees a TOML-only image).