### PR TITLE
ci(release): use GitHub App token to create releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,9 +27,19 @@ jobs:
     environment:
       name: create-github-release
     steps:
+      - name: Mint GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.REGEN_APP_ID }}
+          private-key: ${{ secrets.REGEN_APP_PRIVATE_KEY }}
+          owner: fal-ai
+          repositories: fal
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - uses: actions/setup-python@v2
         with:
@@ -39,7 +49,7 @@ jobs:
         env:
           PROJECT_NAME: ${{ github.event.inputs.project_name }}
           BUMP_VERSION: ${{ github.event.inputs.bump_version }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -xeo pipefail
           last_tag=$(git describe --tags --abbrev=0 --match "${PROJECT_NAME}_v*")


### PR DESCRIPTION
## Summary
- Mint a short-lived installation token via the existing GitHub App (already used by `regen-grpc.yml`) and use it for `gh release create` in `create-release.yaml`.
- Replaces reliance on `secrets.GH_TOKEN` (a long-lived PAT).
- Also passes the app token to `actions/checkout` so the tag push originates from the app, ensuring downstream workflows (PyPI publish, container build in `release.yaml`) are triggered on the resulting `release: published` event.

## Why
The default `GITHUB_TOKEN` does not trigger downstream workflows, which is why this workflow used a PAT in the first place. A GitHub App token has the same property as a PAT here (triggers downstream workflows) but is short-lived, not tied to a person, and easier to rotate.

The `REGEN_APP` already has `contents: write` on this repo (it's used to push regen commits in [regen-grpc.yml](.github/workflows/regen-grpc.yml)), which is the same permission `gh release create` needs.

## Test plan
- [ ] Run the `Create Github release` workflow manually (`workflow_dispatch`) against one of the projects (e.g. `fal_client`, patch bump) and confirm:
  - [ ] The tag and release are created successfully.
  - [ ] The downstream `PyPI release` workflow (`release.yaml`) fires on the `release: published` event.