### PR TITLE
feat(run): configure local exposed ports

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -1204,10 +1204,13 @@ class Options:
             pip_requirements.extend(requirements)
 
     def get_exposed_port(self) -> int | None:
-        if self.gateway.get("serve"):
+        exposed_port = self.gateway.get("exposed_port")
+        if exposed_port is not None:
+            return exposed_port
+        elif self.gateway.get("serve"):
             return _SERVE_PORT
         else:
-            return self.gateway.get("exposed_port")
+            return None
 
 
 _SERVE_PORT = 8080
@@ -2152,13 +2155,25 @@ class ServeWrapper(BaseServable):
             RouteSignature("/"): self._func,
         }
 
-    async def __call__(self, *args, **kwargs) -> None:
+    async def __call__(
+        self,
+        *args,
+        exposed_port: int | None = None,
+        exposed_metrics_port: int | None = None,
+        **kwargs,
+    ) -> None:
         if len(args) != 0 or len(kwargs) != 0:
             print(
                 f"[warning] {self._func.__name__} function is served with no arguments."
             )
 
-        await self.serve()
+        serve_kwargs: dict[str, Any] = {}
+        if exposed_port is not None:
+            serve_kwargs["port"] = exposed_port
+        if exposed_metrics_port is not None:
+            serve_kwargs["metrics_port"] = exposed_metrics_port
+
+        await self.serve(**serve_kwargs)
 
 
 @dataclass
@@ -2288,16 +2303,51 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         return ["/"]
 
     def run_local(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
+        return self._run_local(args=args, kwargs=kwargs)
+
+    def _run_local(
+        self,
+        *,
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+        exposed_port: int | None = None,
+        exposed_metrics_port: int | None = None,
+    ) -> ReturnT:
         import asyncio  # noqa: PLC0415
         import inspect  # noqa: PLC0415
         import os  # noqa: PLC0415
         from typing import Awaitable, cast  # noqa: PLC0415
 
+        if kwargs is None:
+            kwargs = {}
+
         func = self._resolve_local_func()
+        call_kwargs = dict(kwargs)
+        supports_local_serve_options = self._supports_local_serve_options()
+        local_serve_options_requested = (
+            exposed_port is not None or exposed_metrics_port is not None
+        )
+        if local_serve_options_requested and not supports_local_serve_options:
+            raise FalServerlessError(
+                "Local exposed port options are only supported when running "
+                "a fal.App or serve=True function locally."
+            )
+
+        if supports_local_serve_options:
+            effective_exposed_port = (
+                exposed_port
+                if exposed_port is not None
+                else self.options.get_exposed_port()
+            )
+            if effective_exposed_port is not None:
+                call_kwargs["exposed_port"] = effective_exposed_port
+            if exposed_metrics_port is not None:
+                call_kwargs["exposed_metrics_port"] = exposed_metrics_port
+
         previous_isolate_env = os.environ.get("IS_ISOLATE_AGENT")
         os.environ["IS_ISOLATE_AGENT"] = "1"
         try:
-            result = func(*args, **kwargs)
+            result = func(*args, **call_kwargs)
             if inspect.isawaitable(result):
                 awaited = cast(Awaitable[ReturnT], result)
 
@@ -2312,14 +2362,23 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             else:
                 os.environ["IS_ISOLATE_AGENT"] = previous_isolate_env
 
+    def _resolve_entrypoint_target(self) -> Any:
+        if self.entrypoint is None:
+            raise FalServerlessError(
+                "IsolatedFunction has no local callable to invoke."
+            )
+
+        import importlib  # noqa: PLC0415
+
+        module_name, _, attr = self.entrypoint.partition(":")
+        target: Any = importlib.import_module(module_name)
+        for part in attr.split("."):
+            target = getattr(target, part)
+        return target
+
     def _resolve_local_func(self) -> Callable[ArgsT, ReturnT]:
         if self.entrypoint is not None and self.raw_func is None:
-            import importlib  # noqa: PLC0415
-
-            module_name, _, attr = self.entrypoint.partition(":")
-            target: Any = importlib.import_module(module_name)
-            for part in attr.split("."):
-                target = getattr(target, part)
+            target = self._resolve_entrypoint_target()
             try:
                 return target.run_local
             except AttributeError:
@@ -2332,6 +2391,20 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
                 "IsolatedFunction has no local callable to invoke."
             )
         return self.func  # type: ignore[return-value]
+
+    def _supports_local_serve_options(self) -> bool:
+        if self.raw_func is not None:
+            return bool(
+                getattr(self.raw_func, "_fal_local_app", False)
+                or self.options.gateway.get("serve")
+            )
+        if self.entrypoint is None:
+            return False
+
+        from fal.app import App  # noqa: PLC0415
+
+        target = self._resolve_entrypoint_target()
+        return isinstance(target, type) and issubclass(target, App)
 
     @overload
     def on(

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -2186,6 +2186,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     app_name: str | None = None
     app_auth: AuthModeLiteral | None = None
     entrypoint: str | None = None
+    _entrypoint_exposed_port_defaulted: bool = False
 
     def __post_init__(self) -> None:
         if self.raw_func is None and self.entrypoint is None:
@@ -2203,6 +2204,8 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         self.__dict__.update(state)
         if not hasattr(self, "executor"):
             self.executor = ThreadPoolExecutor()
+        if not hasattr(self, "_entrypoint_exposed_port_defaulted"):
+            self._entrypoint_exposed_port_defaulted = False
 
     @property
     def run_entrypoint(self) -> str | None:
@@ -2351,7 +2354,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             entrypoint_target_keeps_own_port = (
                 self.raw_func is None
                 and isinstance(local_serve_options_target, IsolatedFunction)
-                and self.options.gateway.get("exposed_port") == _SERVE_PORT
+                and self._entrypoint_exposed_port_defaulted
             )
             effective_exposed_port = exposed_port
             if effective_exposed_port is None and not entrypoint_target_keeps_own_port:

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -2303,7 +2303,20 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         return ["/"]
 
     def run_local(self, *args: ArgsT.args, **kwargs: ArgsT.kwargs) -> ReturnT:
-        return self._run_local(args=args, kwargs=kwargs)
+        call_kwargs = dict(kwargs)
+        exposed_port: int | None = None
+        exposed_metrics_port: int | None = None
+        if self._supports_local_serve_options():
+            exposed_port = cast(Optional[int], call_kwargs.pop("exposed_port", None))
+            exposed_metrics_port = cast(
+                Optional[int], call_kwargs.pop("exposed_metrics_port", None)
+            )
+        return self._run_local(
+            args=args,
+            kwargs=call_kwargs,
+            exposed_port=exposed_port,
+            exposed_metrics_port=exposed_metrics_port,
+        )
 
     def _run_local(
         self,
@@ -2323,7 +2336,8 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
 
         func = self._resolve_local_func()
         call_kwargs = dict(kwargs)
-        supports_local_serve_options = self._supports_local_serve_options()
+        local_serve_options_target = self._local_serve_options_target()
+        supports_local_serve_options = local_serve_options_target is not None
         local_serve_options_requested = (
             exposed_port is not None or exposed_metrics_port is not None
         )
@@ -2334,11 +2348,14 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             )
 
         if supports_local_serve_options:
-            effective_exposed_port = (
-                exposed_port
-                if exposed_port is not None
-                else self.options.get_exposed_port()
+            entrypoint_target_keeps_own_port = (
+                self.raw_func is None
+                and isinstance(local_serve_options_target, IsolatedFunction)
+                and self.options.gateway.get("exposed_port") == _SERVE_PORT
             )
+            effective_exposed_port = exposed_port
+            if effective_exposed_port is None and not entrypoint_target_keeps_own_port:
+                effective_exposed_port = self.options.get_exposed_port()
             if effective_exposed_port is not None:
                 call_kwargs["exposed_port"] = effective_exposed_port
             if exposed_metrics_port is not None:
@@ -2392,19 +2409,31 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             )
         return self.func  # type: ignore[return-value]
 
-    def _supports_local_serve_options(self) -> bool:
+    def _local_serve_options_target(self) -> Any | None:
         if self.raw_func is not None:
-            return bool(
-                getattr(self.raw_func, "_fal_local_app", False)
-                or self.options.gateway.get("serve")
-            )
+            if getattr(
+                self.raw_func, "_fal_local_app", False
+            ) or self.options.gateway.get("serve"):
+                return self
+            return None
         if self.entrypoint is None:
-            return False
+            return None
 
         from fal.app import App  # noqa: PLC0415
 
         target = self._resolve_entrypoint_target()
-        return isinstance(target, type) and issubclass(target, App)
+        if isinstance(target, type) and issubclass(target, App):
+            return target
+        if (
+            isinstance(target, IsolatedFunction)
+            and target.raw_func is not None
+            and target._supports_local_serve_options()
+        ):
+            return target
+        return None
+
+    def _supports_local_serve_options(self) -> bool:
+        return self._local_serve_options_target() is not None
 
     @overload
     def on(

--- a/projects/fal/src/fal/api/run.py
+++ b/projects/fal/src/fal/api/run.py
@@ -19,14 +19,17 @@ def run(
     args: tuple[Any, ...] = (),
     kwargs: dict[str, Any] | None = None,
     local: bool = False,
+    exposed_port: int | None = None,
+    exposed_metrics_port: int | None = None,
     result_handler: ResultHandler | None = None,
     reraise: bool = True,
 ) -> Any:
     """Run an ``IsolatedFunction`` locally or on its host with friendly errors.
 
-    When ``local=True``, defers to ``isolated_function.run_local`` (which
-    invokes the function in the current Python process). ``result_handler``
-    has no effect in that mode.
+    When ``local=True``, invokes the function in the current Python process.
+    ``exposed_port`` and ``exposed_metrics_port`` configure the local app
+    server ports for ``fal.App`` and ``serve=True`` runs. ``result_handler``
+    has no effect in local mode.
 
     Otherwise the call is dispatched through ``host.run`` and:
 
@@ -40,7 +43,12 @@ def run(
         kwargs = {}
 
     if local:
-        return isolated_function.run_local(*args, **kwargs)
+        return isolated_function._run_local(
+            args=args,
+            kwargs=kwargs,
+            exposed_port=exposed_port,
+            exposed_metrics_port=exposed_metrics_port,
+        )
 
     func = isolated_function.func
     options = isolated_function.options

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -141,22 +141,33 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
     if host:
         cls.local_file_path = host.local_file_path
 
-    def initialize_and_serve():
+    def initialize_and_serve(
+        *,
+        exposed_port: int | None = None,
+        exposed_metrics_port: int | None = None,
+    ):
         import threading  # noqa: PLC0415
 
         app = cls()
         set_current_app(app)
 
+        serve_kwargs: dict[str, Any] = {"limit_max_requests": limit_max_requests}
+        if exposed_port is not None:
+            serve_kwargs["port"] = exposed_port
+        if exposed_metrics_port is not None:
+            serve_kwargs["metrics_port"] = exposed_metrics_port
+
         if threading.current_thread() == threading.main_thread():
-            return app.serve(limit_max_requests=limit_max_requests)
+            return app.serve(**serve_kwargs)
         else:
             asyncio.set_event_loop(asyncio.new_event_loop())
-            asyncio.run(app.serve(limit_max_requests=limit_max_requests))
+            asyncio.run(app.serve(**serve_kwargs))
 
     # if the function is not marked with _run_on_main_thread, it runs on a thread pool
     # however in thread pool, the function cannot receive SIGTERM
     # we run the function on main thread so SIGTERM can be propagated to the app
     initialize_and_serve._run_on_main_thread = True  # type: ignore[attr-defined]
+    initialize_and_serve._fal_local_app = True  # type: ignore[attr-defined]
 
     metadata = cls.build_metadata()
 
@@ -739,11 +750,22 @@ class App(BaseServable):
         return {"openapi": cls(_allow_init=True).openapi()}
 
     @classmethod
-    def run_local(cls, *args, **kwargs):
+    def run_local(
+        cls,
+        *args,
+        exposed_port: int | None = None,
+        exposed_metrics_port: int | None = None,
+        **kwargs,
+    ):
         # import wrap_app explicitly to avoid reference to wrap_app during pickling
         from fal.app import wrap_app  # noqa: PLC0415
 
-        return wrap_app(cls).run_local(*args, **kwargs)
+        return wrap_app(cls)._run_local(
+            args=args,
+            kwargs=kwargs,
+            exposed_port=exposed_port,
+            exposed_metrics_port=exposed_metrics_port,
+        )
 
     @classmethod
     def spawn(cls) -> AppSpawnInfo:

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -121,6 +121,7 @@ def get_app_data_from_toml(
     app_files = app_data.pop("app_files", None)
     app_files_ignore = app_data.pop("app_files_ignore", None)
     app_files_context_dir = app_data.pop("app_files_context_dir", None)
+    exposed_port = app_data.pop("exposed_port", None)
 
     image_config = app_data.pop("image", None)
 
@@ -136,6 +137,8 @@ def get_app_data_from_toml(
         raise ValueError(
             "app_files_context_dir is only supported when app_files is provided."
         )
+    if exposed_port is not None:
+        _validate_port("exposed_port", exposed_port)
     if image_config is not None and app_files:
         raise ValueError("app_files is not supported for container apps.")
 
@@ -163,6 +166,8 @@ def get_app_data_from_toml(
         options.host["app_files_ignore"] = app_files_ignore
     if app_files_context_dir is not None:
         options.host["app_files_context_dir"] = app_files_context_dir
+    if exposed_port is not None:
+        options.gateway["exposed_port"] = exposed_port
     if requirements is not None:
         options.environment["requirements"] = requirements
     if python_version is not None:
@@ -232,6 +237,13 @@ def _validate_requirements(requirements: Any) -> None:
 def _validate_str_list(field_name: str, value: Any) -> None:
     if not (isinstance(value, list) and all(isinstance(item, str) for item in value)):
         raise ValueError(f"{field_name} must be a list of strings.")
+
+
+def _validate_port(field_name: str, value: Any) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer.")
+    if value < 0 or value > 65535:
+        raise ValueError(f"{field_name} must be between 0 and 65535.")
 
 
 _IMAGE_PASSTHROUGH_KEYS = (

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -2,13 +2,22 @@ import argparse
 from dataclasses import replace
 from pathlib import Path
 
-from ._utils import AppData, get_app_data_from_toml, is_app_name
+from ._utils import AppData, _validate_port, get_app_data_from_toml, is_app_name
 from .parser import FalClientParser, RefAction, add_env_argument
 
 
 def _run(args):
     from fal.api.client import SyncServerlessClient
     from fal.utils import load_function_from
+
+    exposed_port = args.exposed_port
+    exposed_metrics_port = args.exposed_metrics_port
+    if not args.local and (
+        exposed_port is not None or exposed_metrics_port is not None
+    ):
+        raise ValueError(
+            "--exposed-port and --exposed-metrics-port can only be used with --local."
+        )
 
     # Handle deprecated --force-env-build flag
     if args.force_env_build:
@@ -85,6 +94,8 @@ def _run(args):
     run_api(
         isolated_function,
         local=args.local,
+        exposed_port=exposed_port,
+        exposed_metrics_port=exposed_metrics_port,
         result_handler=CliRunResultHandler(
             console=args.console,
             auth_mode=loaded.app_auth or "public",
@@ -101,6 +112,18 @@ def add_parser(main_subparsers, parents):
         if option not in ALIAS_AUTH_MODES:
             raise argparse.ArgumentTypeError(f"{option} is not a auth option")
         return option
+
+    def valid_port_option(option):
+        try:
+            port = int(option)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"{option} is not a valid port") from None
+
+        try:
+            _validate_port("port", port)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(str(exc)) from None
+        return port
 
     run_help = "Run fal function."
     epilog = "Examples:\n  fal run path/to/myfile.py::myfunc\n  fal run my-app\n"
@@ -147,6 +170,18 @@ def add_parser(main_subparsers, parents):
         "--local",
         action="store_true",
         help="Run locally without serverless.",
+    )
+    parser.add_argument(
+        "--exposed-port",
+        type=valid_port_option,
+        metavar="PORT",
+        help="Port for the --local app server (default: 8080).",
+    )
+    parser.add_argument(
+        "--exposed-metrics-port",
+        type=valid_port_option,
+        metavar="PORT",
+        help="Port for the --local metrics server (default: 9090).",
     )
     parser.add_argument(
         "--machine-type",

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -161,6 +161,7 @@ def load_function_from(
     with open(file_path) as f:
         source_code = f.read()
 
+    wrapped_app = False
     if isinstance(target, type) and issubclass(target, App):
         # ``App.__init_subclass__`` enforces ``image``/``app_files`` exclusivity
         # at class-definition time, but ``image`` can also arrive from
@@ -179,6 +180,7 @@ def load_function_from(
             force_env_build=force_env_build,
             limit_max_requests=limit_max_requests,
         )
+        wrapped_app = True
 
     if not isinstance(target, IsolatedFunction):
         raise FalServerlessError(
@@ -186,6 +188,8 @@ def load_function_from(
         )
     if options is not None:
         _merge_options(target.options, options)
+        if wrapped_app and options.gateway.get("exposed_port") is not None:
+            target.options.gateway["exposed_port"] = options.gateway["exposed_port"]
 
     # Override the host so CLI-provided context (e.g. team) is applied.
     # For @fal.function, the host was set at import time without CLI context.
@@ -236,6 +240,7 @@ def _load_from_python_entry_point(
     _parse_python_entry_point(python_entry_point)
 
     merged_options = deepcopy(options) if options is not None else ApiOptions()
+    exposed_port_defaulted = "exposed_port" not in merged_options.gateway
     merged_options.gateway.setdefault("exposed_port", 8080)
     # The entry-point path bypasses Host.parse_options (which is where ``kind``
     # would normally be defaulted for ``@fal.function``/``wrap_app``), so set
@@ -249,6 +254,7 @@ def _load_from_python_entry_point(
         app_name=app_name,
         app_auth=app_auth,
         entrypoint=python_entry_point,
+        _entrypoint_exposed_port_defaulted=exposed_port_defaulted,
     )
 
     return LoadedFunction(

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -15,6 +15,8 @@ def test_run():
     assert args.func_ref == ("/my/path.py", "myfunc")
     assert args.machine_type is None
     assert args.limit_max_requests is None
+    assert args.exposed_port is None
+    assert args.exposed_metrics_port is None
 
 
 def test_run_with_env():
@@ -49,6 +51,25 @@ def test_run_with_limit_max_requests():
     assert args.func == _run
     assert args.func_ref == ("/my/path.py", "myfunc")
     assert args.limit_max_requests == 1
+
+
+def test_run_with_exposed_port_options():
+    args = parse_args(
+        [
+            "run",
+            "/my/path.py::myfunc",
+            "--local",
+            "--exposed-port",
+            "3000",
+            "--exposed-metrics-port",
+            "3001",
+        ]
+    )
+    assert args.func == _run
+    assert args.func_ref == ("/my/path.py", "myfunc")
+    assert args.local is True
+    assert args.exposed_port == 3000
+    assert args.exposed_metrics_port == 3001
 
 
 @patch("fal.api.client.SyncServerlessClient._create_host")
@@ -105,6 +126,7 @@ def mock_parse_pyproject_toml():
                 "python_entry_point": "simple.app:SimpleApp",
                 "python_version": "3.12",
                 "requirements": ["fal"],
+                "exposed_port": 9000,
             },
         }
     }
@@ -124,6 +146,9 @@ def mock_args(
     auth: Optional[str] = "public",
     machine_type: Optional[str] = None,
     limit_max_requests: Optional[int] = None,
+    local: bool = False,
+    exposed_port: Optional[int] = None,
+    exposed_metrics_port: Optional[int] = None,
 ):
     args = MagicMock()
     args.host = host
@@ -137,7 +162,9 @@ def mock_args(
     args.env = None
     args.machine_type = machine_type
     args.limit_max_requests = limit_max_requests
-    args.local = False
+    args.local = local
+    args.exposed_port = exposed_port
+    args.exposed_metrics_port = exposed_metrics_port
     return args
 
 
@@ -180,6 +207,7 @@ def test_run_forwards_python_entry_point_to_loader(
     assert call_kwargs["python_entry_point"] == "simple.app:SimpleApp"
     assert call_kwargs["options"].environment["python_version"] == "3.12"
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
+    assert call_kwargs["options"].gateway["exposed_port"] == 9000
 
 
 @patch("fal.api.client.SyncServerlessClient._create_host")
@@ -207,6 +235,61 @@ def test_run_forwards_limit_max_requests_to_load_function_from(
 
     _, call_kwargs = mock_load_function_from.call_args
     assert call_kwargs["limit_max_requests"] == 1
+
+
+@patch("fal.api.run.run")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_forwards_exposed_port_options_to_run_api(
+    mock_load_function_from,
+    mock_create_host,
+    mock_run_api,
+):
+    host = mocked_fal_serverless_host("my-host")
+    mock_create_host.return_value = host
+
+    isolated_function = MagicMock()
+    loaded = MagicMock()
+    loaded.function = isolated_function
+    loaded.app_name = None
+    loaded.app_auth = "private"
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(
+        func_ref=("/my/path.py", "myfunc"),
+        host="my-host",
+        local=True,
+        exposed_port=3000,
+        exposed_metrics_port=3001,
+    )
+
+    _run(args)
+
+    _, call_kwargs = mock_run_api.call_args
+    assert call_kwargs["local"] is True
+    assert call_kwargs["exposed_port"] == 3000
+    assert call_kwargs["exposed_metrics_port"] == 3001
+
+
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_rejects_exposed_port_options_without_local(
+    mock_load_function_from, mock_create_host
+):
+    args = mock_args(
+        func_ref=("/my/path.py", "myfunc"),
+        host="my-host",
+        exposed_port=3000,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="--exposed-port and --exposed-metrics-port can only be used with --local",
+    ):
+        _run(args)
+
+    mock_create_host.assert_not_called()
+    mock_load_function_from.assert_not_called()
 
 
 @patch("fal.api.client.SyncServerlessClient._create_host")

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -145,6 +145,94 @@ def test_run_local_forwards_exposed_ports_to_served_function(monkeypatch):
     assert called_metrics_port == 3001
 
 
+def test_run_local_forwards_exposed_ports_to_entrypoint_served_function(monkeypatch):
+    from fal.api.api import ServeWrapper
+
+    called_port: int | None = None
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_port, called_metrics_port
+        called_port = port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(gateway={"serve": True}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True, exposed_port=3000, exposed_metrics_port=3001)
+
+    assert called_port == 3000
+    assert called_metrics_port == 3001
+
+
+def test_run_local_entrypoint_served_function_keeps_configured_port(monkeypatch):
+    from fal.api.api import ServeWrapper
+
+    called_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_ports.append(port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(gateway={"serve": True, "exposed_port": 9000}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True)
+
+    assert called_ports == [9000]
+
+
 def test_run_local_exposed_port_override_does_not_mutate_options(monkeypatch):
     from fal.api.api import ServeWrapper
 

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -1,11 +1,20 @@
 from unittest.mock import MagicMock
 
-from fal.api import IsolatedFunction, Options
+import pytest
+
+from fal import App, endpoint
+from fal.api import FalServerlessError, IsolatedFunction, Options
 from fal.api.run import run as run_api
 
 
 class _FakeHost:
     pass
+
+
+def test_options_get_exposed_port_prefers_configured_port_for_serve_true():
+    options = Options(gateway={"serve": True, "exposed_port": 3000})
+
+    assert options.get_exposed_port() == 3000
 
 
 def test_run_local_with_entrypoint_resolves_user_symbol(monkeypatch):
@@ -47,3 +56,118 @@ def test_run_local_without_entrypoint_uses_raw_func():
         (1,),
         {"x": 2},
     )
+
+
+def test_run_local_forwards_exposed_ports_to_entrypoint_app(monkeypatch):
+    sentinel = MagicMock(name="user_module.UserApp.run_local")
+    sentinel.return_value = "ran"
+
+    class UserApp(App):
+        @endpoint("/")
+        def run(self):
+            return "ok"
+
+    UserApp.run_local = sentinel
+
+    fake_module = MagicMock()
+    fake_module.UserApp = UserApp
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(),
+        entrypoint="user_module:UserApp",
+    )
+
+    result = run_api(
+        iso,
+        args=("a",),
+        kwargs={"k": 1},
+        local=True,
+        exposed_port=3000,
+        exposed_metrics_port=3001,
+    )
+
+    assert result == "ran"
+    sentinel.assert_called_once_with(
+        "a",
+        k=1,
+        exposed_port=3000,
+        exposed_metrics_port=3001,
+    )
+
+
+def test_run_local_rejects_exposed_ports_for_plain_function():
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(),
+    )
+
+    with pytest.raises(FalServerlessError, match="Local exposed port options"):
+        run_api(iso, local=True, exposed_port=3000)
+
+
+def test_run_local_forwards_exposed_ports_to_served_function(monkeypatch):
+    from fal.api.api import ServeWrapper
+
+    called_port: int | None = None
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_port, called_metrics_port
+        called_port = port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(gateway={"serve": True}),
+    )
+
+    run_api(iso, local=True, exposed_port=3000, exposed_metrics_port=3001)
+
+    assert called_port == 3000
+    assert called_metrics_port == 3001
+
+
+def test_run_local_exposed_port_override_does_not_mutate_options(monkeypatch):
+    from fal.api.api import ServeWrapper
+
+    called_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_ports.append(port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(gateway={"serve": True}),
+    )
+
+    run_api(iso, local=True, exposed_port=3000)
+    run_api(iso, local=True)
+
+    assert called_ports == [3000, 8080]
+    assert iso.options.gateway == {"serve": True}

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -226,11 +226,56 @@ def test_run_local_entrypoint_served_function_keeps_configured_port(monkeypatch)
         host=_FakeHost(),
         options=Options(gateway={"exposed_port": 8080}),
         entrypoint="user_module:served_function",
+        _entrypoint_exposed_port_defaulted=True,
     )
 
     run_api(iso, local=True)
 
     assert called_ports == [9000]
+
+
+def test_run_local_entrypoint_served_function_honors_explicit_default_port(
+    monkeypatch,
+):
+    from fal.api.api import ServeWrapper
+
+    called_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_ports.append(port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(gateway={"serve": True, "exposed_port": 9000}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True)
+
+    assert called_ports == [8080]
 
 
 def test_run_local_exposed_port_override_does_not_mutate_options(monkeypatch):

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -235,6 +235,43 @@ def test_wrap_app_limit_max_requests_propagates_to_serve(
     assert called_limit_max_requests == 1
 
 
+def test_wrap_app_exposed_ports_propagate_to_serve(
+    isolate_agent_env, monkeypatch: pytest.MonkeyPatch
+):
+    from fal import ref
+    from fal.api.run import run as run_api
+    from fal.app import wrap_app
+
+    class LocalPortApp(App):
+        @endpoint("/")
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    called_port: int | None = None
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        limit_max_requests: int | None = None,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_port, called_metrics_port
+        called_port = port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(LocalPortApp, "serve", fake_serve)
+    monkeypatch.setattr(ref, "current_app", None)
+
+    fn = wrap_app(LocalPortApp)
+    fn.options.gateway["exposed_port"] = 3000
+    run_api(fn, local=True, exposed_metrics_port=3001)
+
+    assert called_port == 3000
+    assert called_metrics_port == 3001
+
+
 def test_wrap_app_raises_for_virtualenv_only_keys_with_conda_kind():
     from fal.app import wrap_app
 
@@ -1039,6 +1076,55 @@ def test_openapi_does_not_duplicate_ws_paths_on_multiple_calls(isolate_agent_env
     ]
     assert [p for p in first["x-fal-order-paths"] if p != "/health"] == expected_order
     assert [p for p in second["x-fal-order-paths"] if p != "/health"] == expected_order
+
+
+@pytest.mark.asyncio
+async def test_serve_binds_app_and_metrics_to_custom_ports(
+    isolate_agent_env, monkeypatch: pytest.MonkeyPatch
+):
+    import prometheus_client
+
+    from fal.api import api
+
+    configs = []
+
+    class FakeGauge:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def labels(self, *args, **kwargs):
+            return self
+
+        def set(self, value):
+            pass
+
+    class FakeServer:
+        def __init__(self, config):
+            self.config = config
+            configs.append(config)
+
+        def set_handle_exit(self, handle_exit):
+            self._handle_exit = handle_exit
+
+        async def serve(self) -> None:
+            return None
+
+    monkeypatch.setattr(api, "FalServer", FakeServer)
+    monkeypatch.setattr(api.uvicorn, "Server", FakeServer)
+    monkeypatch.setattr(prometheus_client, "Gauge", FakeGauge)
+
+    class CustomPortApp(App):
+        @endpoint("/")
+        def run(self):
+            return {"status": "ok"}
+
+    app = CustomPortApp()
+    await app.serve(port=3000, metrics_port=3001)
+
+    assert configs[0].host == "0.0.0.0"
+    assert configs[0].port == 3000
+    assert configs[1].host == "0.0.0.0"
+    assert configs[1].port == 3001
 
 
 @pytest.mark.asyncio

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -169,6 +169,26 @@ def test_load_function_from_applies_toml_app_files_for_fal_app(tmp_path):
     assert wrapped_cls.app_files_context_dir == "."
 
 
+def test_load_function_from_applies_toml_exposed_port_for_fal_app(tmp_path):
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(gateway={"exposed_port": 9000})
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.gateway["exposed_port"] == 9000
+
+
 def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
     app_file = tmp_path / "app.py"
     app_file.write_text(


### PR DESCRIPTION
## Summary
  - add `fal run --local --exposed-port` to
  override the local app port
  - add `--exposed-metrics-port` for the local
  metrics server
  - support `exposed_port` from pyproject app
  config

when I try to run two apps at the same time, both of the apps tried to bind the same host:port, therefore, Ruslan suggested to make this PR. 