### PR TITLE
feat: explicit BuildEnvironment step in fal deploy / fal run

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.23.1,<0.27.0",
-    "isolate-proto>=0.31.2,<1",
+    "isolate-proto>=0.31.3,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle>=3.0.0,<3.2",

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -395,8 +395,20 @@ class Host(Generic[ArgsT, ReturnT]):
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> ReturnT:
         """Run the given function in the isolated environment."""
+        raise NotImplementedError
+
+    def build_environment(
+        self,
+        options: Options,
+        *,
+        application_name: str | None = None,
+        environment_name: str | None = None,
+        result_handler: ResultHandler | None = None,
+    ) -> None:
+        """Pre-build the given function environment when supported by the host."""
         raise NotImplementedError
 
     def spawn(
@@ -554,7 +566,10 @@ class LocalHost(Host):
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> ReturnT:
+        # `build_environment` is a serverless concept; LocalHost ignores it.
+        del build_environment
         import isolate  # noqa: PLC0415
         from isolate.backends.settings import DEFAULT_SETTINGS  # noqa: PLC0415
         from isolate.connections import PythonIPC  # noqa: PLC0415
@@ -938,6 +953,7 @@ class FalServerlessHost(Host):
         environment_name: Optional[str] = None,
         result_handler: ResultHandler | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> Optional[RegisterApplicationResult]:
         from isolate.backends.common import active_python  # noqa: PLC0415
 
@@ -1038,6 +1054,7 @@ class FalServerlessHost(Host):
             secrets=secrets,
             data_mounts=data_mounts,
             entrypoint=entrypoint,
+            build_environment=build_environment,
         ):
             result_handler(partial_result)
 
@@ -1057,6 +1074,7 @@ class FalServerlessHost(Host):
         application_name: str | None = None,
         application_auth_mode: AuthModeLiteral | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> ReturnT:
         from isolate.backends.common import active_python  # noqa: PLC0415
 
@@ -1146,6 +1164,7 @@ class FalServerlessHost(Host):
             secrets=secrets,
             data_mounts=data_mounts,
             entrypoint=entrypoint,
+            build_environment=build_environment,
         ):
             result_handler(partial_result)
 
@@ -1158,7 +1177,7 @@ class FalServerlessHost(Host):
                 elif state is HostedRunState.SUCCESS:
                     return_value = partial_result.result
                 else:
-                    raise NotImplementedError("Unknown state: ", state)
+                    raise NotImplementedError(f"Unknown state: {state}")
 
         if return_value is _UNSET:
             raise InternalFalServerlessError(
@@ -1177,6 +1196,7 @@ class FalServerlessHost(Host):
         application_auth_mode: AuthModeLiteral | None = None,
         result_handler: ResultHandler | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> ReturnT:
         effective_auth_mode = application_auth_mode or "public"
 
@@ -1195,6 +1215,76 @@ class FalServerlessHost(Host):
             application_name=application_name,
             application_auth_mode=application_auth_mode,
             entrypoint=entrypoint,
+            build_environment=build_environment,
+        )
+
+    @_handle_grpc_error()
+    def build_environment(
+        self,
+        options: Options,
+        *,
+        application_name: str | None = None,
+        environment_name: str | None = None,
+        result_handler: ResultHandler | None = None,
+    ) -> None:
+        """Pre-build the environment defined by ``options`` so that a follow-up
+        ``register`` / ``run`` / ``fetch_metadata`` with ``build_environment=False``
+        hits the cache.
+
+        Streams build logs through ``result_handler`` (defaults to a no-op
+        handler if not provided).
+        """
+        from isolate.backends.common import active_python  # noqa: PLC0415
+
+        environment_options = options.environment.copy()
+        environment_options.setdefault("python_version", active_python())
+        self._materialize_local_requirements(environment_options)
+        environments = [self._connection.define_environment(**environment_options)]
+
+        machine_type: list[str] | str = options.host.get(
+            "machine_type", FAL_SERVERLESS_DEFAULT_MACHINE_TYPE
+        )
+        base_image = options.host.get("_base_image", None)
+        scheduler = options.host.get("_scheduler", None)
+        scheduler_options = options.host.get("_scheduler_options", None)
+        regions = options.host.get("regions")
+        secrets = options.host.get("secrets")
+        machine_requirements = MachineRequirements(
+            machine_types=machine_type,  # type: ignore
+            num_gpus=options.host.get("num_gpus"),
+            base_image=base_image,
+            scheduler=scheduler,
+            scheduler_options=scheduler_options,
+            valid_regions=regions,
+        )
+
+        files = self.files_sync(FileSyncOptions.from_options(options))
+
+        if result_handler is None:
+            result_handler = ResultHandler()
+
+        for partial_result in self._connection.build_environment(
+            environments,
+            machine_requirements=machine_requirements,
+            files=files,
+            application_name=application_name,
+            environment_name=environment_name,
+            secrets=secrets,
+        ):
+            result_handler(partial_result)
+            status = partial_result.status
+            if status is None or status.state is HostedRunState.IN_PROGRESS:
+                continue
+            if status.state is HostedRunState.SUCCESS:
+                return
+            if status.state is HostedRunState.INTERNAL_FAILURE:
+                raise InternalFalServerlessError(
+                    "An internal failure occurred while building the environment."
+                )
+            raise NotImplementedError(f"Unknown state: {status.state}")
+
+        raise InternalFalServerlessError(
+            "The build environment stream ended without a terminal status."
         )
 
     def spawn(
@@ -2332,13 +2422,19 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     def build_metadata(self) -> dict[str, Any]:
         return self.options.host.get("metadata") or {}
 
-    def fetch_metadata(self) -> dict[str, Any]:
+    def fetch_metadata(
+        self, *, build_environment: bool | None = None
+    ) -> dict[str, Any]:
         """Probe ``<entrypoint>.build_metadata`` on the worker and cache the
         result into ``options.host["metadata"]``.
 
         No-op when there's no ``entrypoint`` set — the regular flow already
         populates metadata via ``wrap_app``/registration paths, and this
         method just returns that cached value.
+
+        Pass ``build_environment=False`` to skip the inline env build inside
+        the metadata probe (e.g. when the caller has already pre-built the env
+        via ``Host.build_environment``).
         """
         if self.metadata_entrypoint is None:
             return self.build_metadata()
@@ -2350,8 +2446,10 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             self.options,
             args=(),
             kwargs={},
+            application_name=self.app_name,
             entrypoint=self.metadata_entrypoint,
             result_handler=ResultHandler(),
+            build_environment=build_environment,
         )
         if not isinstance(payload, dict):
             raise FalServerlessError(

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -210,6 +210,7 @@ def _deploy_from_reference(
     force_env_build: bool,
     environment_name: Optional[str] = None,
     result_handler: ResultHandler | None = None,
+    build_result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     prepared = _prepare_deployment_from_reference(
         client,
@@ -218,7 +219,11 @@ def _deploy_from_reference(
         force_env_build=force_env_build,
         environment_name=environment_name,
     )
-    return execute_prepared_deployment(prepared, result_handler=result_handler)
+    return execute_prepared_deployment(
+        prepared,
+        result_handler=result_handler,
+        build_result_handler=build_result_handler,
+    )
 
 
 def _execute_loaded_deployment(
@@ -229,13 +234,28 @@ def _execute_loaded_deployment(
     display_name: str | None,
     environment_name: str | None = None,
     result_handler: ResultHandler | None = None,
+    build_result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     from fal.api import FalServerlessError
 
     isolated_function = loaded.function
     strategy = app_data.deployment_strategy or "rolling"
+    build_result_handler = (
+        result_handler if build_result_handler is None else build_result_handler
+    )
 
-    isolated_function.fetch_metadata()
+    # Explicit build phase so the CLI / caller gets a clean "build → deploy"
+    # split instead of inferring it from the log stream's source field.
+    # Downstream steps then assert `build_environment=False` to skip re-doing
+    # the build in their own RPC.
+    host.build_environment(
+        isolated_function.options,
+        application_name=loaded.app_name,
+        environment_name=environment_name,
+        result_handler=build_result_handler,
+    )
+
+    isolated_function.fetch_metadata(build_environment=False)
 
     result = host.register(
         func=isolated_function.func,
@@ -249,6 +269,7 @@ def _execute_loaded_deployment(
         environment_name=environment_name,
         result_handler=result_handler,
         entrypoint=isolated_function.run_entrypoint,
+        build_environment=False,
     )
 
     if not result or not result.result:
@@ -315,6 +336,7 @@ def execute_prepared_deployment(
     prepared: PreparedDeployment,
     *,
     result_handler: ResultHandler | None = None,
+    build_result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     return _execute_loaded_deployment(
         host=prepared.host,
@@ -323,6 +345,7 @@ def execute_prepared_deployment(
         display_name=prepared.display_name,
         environment_name=prepared.environment_name,
         result_handler=result_handler,
+        build_result_handler=build_result_handler,
     )
 
 
@@ -337,6 +360,7 @@ def deploy(
     force_env_build: bool = False,
     environment_name: str | None = None,
     result_handler: ResultHandler | None = None,
+    build_result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     resolved_app_ref, app_data = _resolve_deployment_reference(
         app_ref,
@@ -352,4 +376,5 @@ def deploy(
         force_env_build=force_env_build,
         environment_name=environment_name,
         result_handler=result_handler,
+        build_result_handler=build_result_handler,
     )

--- a/projects/fal/src/fal/api/run.py
+++ b/projects/fal/src/fal/api/run.py
@@ -23,6 +23,7 @@ def run(
     exposed_metrics_port: int | None = None,
     result_handler: ResultHandler | None = None,
     reraise: bool = True,
+    build_environment: bool | None = None,
 ) -> Any:
     """Run an ``IsolatedFunction`` locally or on its host with friendly errors.
 
@@ -62,6 +63,7 @@ def run(
             application_auth_mode=isolated_function.app_auth,
             result_handler=result_handler,
             entrypoint=isolated_function.run_entrypoint,
+            build_environment=build_environment,
         )
     except FalMissingDependencyError as e:
         if func is None:

--- a/projects/fal/src/fal/cli/_result_handlers.py
+++ b/projects/fal/src/fal/cli/_result_handlers.py
@@ -72,11 +72,19 @@ class CliRunResultHandler(ResultHandler):
         print_rule(self.console, subtitle, style="green")
 
     def on_log(self, log: Any) -> None:
+        from isolate.logs import LogSource  # noqa: PLC0415
+
         # Obsolete messages from before service_urls were added.
         if (
             "Access the playground at" in log.message
             or "And API access through" in log.message
         ):
+            return
+        # The CLI orchestrates an explicit BuildEnvironment RPC before Run,
+        # so any BUILDER-source log that arrives here is either a cache-hit
+        # confirmation or a redundant rebuild we don't want to re-frame as
+        # its own "Building environment..." phase.
+        if log.source == LogSource.BUILDER:
             return
         self.log_printer.print(log)
 
@@ -89,4 +97,67 @@ class CliRegisterResultHandler(ResultHandler):
         self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
 
     def on_log(self, log: Any) -> None:
+        from isolate.logs import LogSource  # noqa: PLC0415
+
+        # Build phase is rendered by CliBuildEnvironmentResultHandler in the
+        # explicit pre-build step; the cache-hit confirmation the server
+        # streams here would be a redundant second header.
+        if log.source == LogSource.BUILDER:
+            return
+        self.log_printer.print(log)
+
+
+class CliBuildEnvironmentResultHandler(ResultHandler):
+    """Renders the build phase as a top-level CLI step, surrounded by a
+    ``Building environment...`` header and a ``✓ Build complete`` footer.
+
+    Used to drive an explicit ``BuildEnvironment`` RPC before
+    ``Run`` / ``RegisterApplication`` so the CLI doesn't have to infer the
+    build phase from the log stream's source field.
+    """
+
+    def __init__(self, *, console: Console) -> None:
+        from isolate.logs import LogSource  # noqa: PLC0415
+
+        self.console = console
+        self.log_printer = IsolateLogPrinter(debug=flags.DEBUG)
+        # IsolateLogPrinter tracks the current phase in _current_source. The CLI
+        # renders the build-phase header / footer itself, so keep the printer in
+        # BUILDER mode to avoid its own "Building environment..." transition.
+        self.log_printer._current_source = LogSource.BUILDER
+        self._header_printed = False
+
+    def __call__(self, partial_result: Any) -> None:
+        from fal.sdk import HostedRunState  # noqa: PLC0415
+
+        super().__call__(partial_result)
+        status = getattr(partial_result, "status", None)
+        if status is not None and status.state is HostedRunState.SUCCESS:
+            self._print_footer()
+
+    def _print_header_once(self) -> None:
+        if self._header_printed:
+            return
+
+        from fal.console.rules import print_rule  # noqa: PLC0415
+
+        self.console.print("Building environment...", style="bold")
+        print_rule(self.console, style="dim")
+        self._header_printed = True
+
+    def _print_footer(self) -> None:
+        from fal.console.icons import CHECK_ICON  # noqa: PLC0415
+        from fal.console.rules import print_rule  # noqa: PLC0415
+
+        if not self._header_printed:
+            self.console.print(f"{CHECK_ICON} Build complete", style="bold green")
+            self.console.print("")
+            return
+
+        print_rule(self.console, style="dim")
+        self.console.print(f"{CHECK_ICON} Build complete", style="bold green")
+        self.console.print("")
+
+    def on_log(self, log: Any) -> None:
+        self._print_header_once()
         self.log_printer.print(log)

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -10,7 +10,10 @@ from .parser import FalClientParser, RefAction, add_env_argument, get_output_par
 
 
 def _deploy(args):
-    from ._result_handlers import CliRegisterResultHandler
+    from ._result_handlers import (
+        CliBuildEnvironmentResultHandler,
+        CliRegisterResultHandler,
+    )
 
     team, app_ref = _resolve_team_and_app_ref(args)
 
@@ -24,6 +27,7 @@ def _deploy(args):
     no_cache = args.no_cache or args.force_env_build
     client = SyncServerlessClient(host=args.host, team=team)
     result_handler = CliRegisterResultHandler(console=args.console)
+    build_result_handler = CliBuildEnvironmentResultHandler(console=args.console)
 
     deploy_check_source = _resolve_deploy_check_source(args, client)
     if deploy_check_source is not None:
@@ -35,6 +39,7 @@ def _deploy(args):
             force_env_build=no_cache,
             source=deploy_check_source,
             result_handler=result_handler,
+            build_result_handler=build_result_handler,
         )
     else:
         from fal.api import deploy as deploy_api
@@ -55,7 +60,9 @@ def _deploy(args):
         )
         args.console.print("")
         res = deploy_api.execute_prepared_deployment(
-            prepared, result_handler=result_handler
+            prepared,
+            result_handler=result_handler,
+            build_result_handler=build_result_handler,
         )
 
     _render_deploy_result(args, res)

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -107,6 +107,7 @@ def deploy_with_check(
     force_env_build: bool,
     source: DeployCheckSource,
     result_handler: ResultHandler | None = None,
+    build_result_handler: ResultHandler | None = None,
 ) -> DeploymentResult:
     from fal.api import deploy as deploy_api
 
@@ -138,7 +139,9 @@ def deploy_with_check(
         assume_yes=args.yes,
     )
     return deploy_api.execute_prepared_deployment(
-        prepared, result_handler=result_handler
+        prepared,
+        result_handler=result_handler,
+        build_result_handler=build_result_handler,
     )
 
 

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -83,9 +83,19 @@ def _run(args):
         isolated_function.options.host["machine_type"] = args.machine_type
 
     if not args.local:
+        # Explicit build phase so the CLI gets a clean "build → run" split
+        # instead of inferring it from the log stream's source field.
+        from ._result_handlers import CliBuildEnvironmentResultHandler
+
+        host.build_environment(
+            isolated_function.options,
+            application_name=loaded.app_name,
+            environment_name=args.env,
+            result_handler=CliBuildEnvironmentResultHandler(console=args.console),
+        )
         # Endpoints/openapi for the result handler aren't available locally
         # in entrypoint mode; this fetches them from the worker.
-        isolated_function.fetch_metadata()
+        isolated_function.fetch_metadata(build_environment=False)
 
     from fal.api.run import run as run_api
 
@@ -102,6 +112,7 @@ def _run(args):
             endpoints=isolated_function.endpoints,
         ),
         reraise=False,
+        build_environment=None if args.local else False,
     )
 
 

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -410,6 +410,12 @@ class RegisterApplicationResultType:
 
 
 @dataclass
+class BuildEnvironmentResult:
+    status: HostedRunStatus | None = None
+    logs: list[Log] = field(default_factory=list)
+
+
+@dataclass
 class UserKeyInfo:
     key_id: str
     created_at: datetime
@@ -582,6 +588,16 @@ def _from_grpc_register_application_result(
         service_urls=from_grpc(message.service_urls)
         if message.HasField("service_urls")
         else None,
+    )
+
+
+@from_grpc.register(isolate_proto.BuildEnvironmentResult)
+def _from_grpc_build_environment_result(
+    message: isolate_proto.BuildEnvironmentResult,
+) -> BuildEnvironmentResult:
+    return BuildEnvironmentResult(
+        status=from_grpc(message.status) if message.HasField("status") else None,
+        logs=[from_grpc(log) for log in message.logs],
     )
 
 
@@ -813,6 +829,7 @@ class FalServerlessConnection:
         secrets: list[str] | None = None,
         data_mounts: list[str] | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> Iterator[RegisterApplicationResult]:
         if function is None and entrypoint is None:
             raise ValueError("either function or entrypoint must be provided.")
@@ -920,6 +937,8 @@ class FalServerlessConnection:
             request.function.MergeFrom(wrapped_function)
         if private_logs is not None:
             request.private_logs = private_logs
+        if build_environment is not None:
+            request.build_environment = build_environment
         for partial_result in self.stub.RegisterApplication(request):
             yield from_grpc(partial_result)
 
@@ -1022,6 +1041,7 @@ class FalServerlessConnection:
         secrets: list[str] | None = None,
         data_mounts: list[str] | None = None,
         entrypoint: str | None = None,
+        build_environment: bool | None = None,
     ) -> Iterator[HostedRunResult[ResultT]]:
         if function is None and entrypoint is None:
             raise ValueError("either function or entrypoint must be provided.")
@@ -1093,11 +1113,68 @@ class FalServerlessConnection:
             request.setup_func.MergeFrom(
                 to_serialized_object(setup_function, serialization_method)
             )
+        if build_environment is not None:
+            request.build_environment = build_environment
         stream = self.stub.Run(request)
         for partial_result in stream:
             res = from_grpc(partial_result)
             res.stream = stream
             yield res
+
+    def build_environment(
+        self,
+        environments: list[isolate_proto.EnvironmentDefinition],
+        *,
+        machine_requirements: MachineRequirements | None = None,
+        files: list[File] | None = None,
+        application_name: str | None = None,
+        environment_name: str | None = None,
+        secrets: list[str] | None = None,
+    ) -> Iterator[BuildEnvironmentResult]:
+        """Pre-build an environment without dispatching a run.
+
+        Pair with `Run` / `RegisterApplication` calls that set
+        `build_environment=False` to split a long env build from the
+        run/register path.
+        """
+        if machine_requirements:
+            wrapped_requirements = isolate_proto.MachineRequirements(
+                machine_type=machine_requirements.machine_types[0],
+                machine_types=machine_requirements.machine_types,
+                num_gpus=machine_requirements.num_gpus,
+                base_image=machine_requirements.base_image,
+                scheduler=machine_requirements.scheduler,
+                scheduler_options=to_struct(
+                    machine_requirements.scheduler_options or {}
+                ),
+                valid_regions=machine_requirements.valid_regions,
+            )
+        else:
+            wrapped_requirements = None
+        if files:
+            files = [
+                isolate_proto.File(hash=file.hash, relative_path=file.relative_path)
+                for file in files
+            ]
+        full_application_name = (
+            construct_alias(application_name, environment_name)
+            if application_name
+            else None
+        )
+        request = isolate_proto.BuildEnvironmentRequest(
+            environments=environments,
+            machine_requirements=wrapped_requirements,
+            files=files,
+            application_name=full_application_name,
+            environment_name=environment_name,
+            secrets=(
+                isolate_proto.SecretsConfig(names=secrets)
+                if secrets is not None
+                else None
+            ),
+        )
+        for partial_result in self.stub.BuildEnvironment(request):
+            yield from_grpc(partial_result)
 
     def create_alias(
         self,

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -37,6 +37,51 @@ def test_deploy_with_env():
     assert args.env == "dev"
 
 
+def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default():
+    from fal.api.deploy import PreparedDeployment, execute_prepared_deployment
+    from fal.sdk import (
+        RegisterApplicationResult,
+        RegisterApplicationResultType,
+        ServiceURLs,
+    )
+
+    host = MagicMock()
+    isolated_function = MagicMock()
+    isolated_function.options = Options()
+    isolated_function.func = lambda: None
+    isolated_function.run_entrypoint = None
+    isolated_function.endpoints = ["/"]
+    isolated_function.build_metadata.return_value = {}
+
+    host.register.return_value = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id"),
+        service_urls=ServiceURLs(
+            playground="https://playground.example",
+            run="https://run.example",
+            queue="https://queue.example",
+            ws="wss://ws.example",
+            log="https://log.example",
+        ),
+    )
+    prepared = PreparedDeployment(
+        host=host,
+        loaded=SimpleNamespace(
+            function=isolated_function,
+            app_name="my-app",
+            app_auth="public",
+            source_code=None,
+        ),
+        app_data=AppData(deployment_strategy="rolling"),
+        display_name="MyApp",
+    )
+
+    result_handler = MagicMock()
+    execute_prepared_deployment(prepared, result_handler=result_handler)
+
+    _, build_kwargs = host.build_environment.call_args
+    assert build_kwargs["result_handler"] is result_handler
+
+
 def test_deploy_with_env_and_other_options():
     args = parse_args(
         [

--- a/projects/fal/tests/unit/cli/test_result_handlers.py
+++ b/projects/fal/tests/unit/cli/test_result_handlers.py
@@ -1,0 +1,53 @@
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from isolate.logs import LogSource
+from rich.console import Console
+
+from fal.cli._result_handlers import (
+    CliBuildEnvironmentResultHandler,
+    CliRegisterResultHandler,
+    CliRunResultHandler,
+)
+from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
+
+
+def test_cli_run_result_handler_skips_builder_logs():
+    handler = CliRunResultHandler(
+        console=MagicMock(),
+        auth_mode="public",
+        endpoints=["/"],
+    )
+    handler.log_printer = MagicMock()
+
+    handler.on_log(SimpleNamespace(source=LogSource.BUILDER, message="cache hit"))
+
+    handler.log_printer.print.assert_not_called()
+
+
+def test_cli_register_result_handler_skips_builder_logs():
+    handler = CliRegisterResultHandler(console=MagicMock())
+    handler.log_printer = MagicMock()
+
+    handler.on_log(SimpleNamespace(source=LogSource.BUILDER, message="cache hit"))
+
+    handler.log_printer.print.assert_not_called()
+
+
+def test_cli_build_environment_result_handler_uses_minimal_cache_hit_footer():
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        color_system=None,
+        width=80,
+    )
+    handler = CliBuildEnvironmentResultHandler(console=console)
+
+    handler(BuildEnvironmentResult(status=HostedRunStatus(HostedRunState.SUCCESS)))
+
+    rendered = output.getvalue()
+    assert "Build complete" in rendered
+    assert "Building environment" not in rendered
+    assert "─" not in rendered

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -602,6 +602,117 @@ def test_data_mounts_run_sends_to_connection():
     assert call_kwargs["data_mounts"] == ["/data"]
 
 
+def test_build_environment_raises_on_internal_failure():
+    from fal.api.api import FalServerlessHost, InternalFalServerlessError, Options
+    from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
+
+    host = FalServerlessHost()
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    connection.build_environment.return_value = iter(
+        [
+            BuildEnvironmentResult(
+                status=HostedRunStatus(HostedRunState.INTERNAL_FAILURE)
+            )
+        ]
+    )
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        with pytest.raises(InternalFalServerlessError, match="building"):
+            host.build_environment(Options())
+
+
+def test_build_environment_raises_when_stream_ends_without_terminal_status():
+    from fal.api.api import FalServerlessHost, InternalFalServerlessError, Options
+    from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
+
+    host = FalServerlessHost()
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    connection.build_environment.return_value = iter(
+        [
+            BuildEnvironmentResult(),
+            BuildEnvironmentResult(status=HostedRunStatus(HostedRunState.IN_PROGRESS)),
+        ]
+    )
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        with pytest.raises(InternalFalServerlessError, match="terminal status"):
+            host.build_environment(Options())
+
+
+def test_build_environment_raises_readable_error_on_unknown_state():
+    from fal.api.api import FalServerlessHost, Options
+
+    host = FalServerlessHost()
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.logs = []
+    partial_result.service_urls = None
+    partial_result.status.state = "WEIRD"
+    connection.build_environment.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        with pytest.raises(NotImplementedError, match="Unknown state: WEIRD"):
+            host.build_environment(Options())
+
+
+def test_run_raises_readable_error_on_unknown_state():
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+
+    host = FalServerlessHost()
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.logs = []
+    partial_result.service_urls = None
+    partial_result.status.state = "WEIRD"
+    connection.run.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        with pytest.raises(NotImplementedError, match="Unknown state: WEIRD"):
+            host._run(
+                lambda: "ok",
+                Options(),
+                args=(),
+                kwargs={},
+                result_handler=ResultHandler(),
+            )
+
+
+def test_fetch_metadata_preserves_application_name():
+    from fal.api.api import IsolatedFunction, Options
+
+    host = MagicMock()
+    host.run.return_value = {}
+    isolated_function = IsolatedFunction(
+        host=host,
+        options=Options(),
+        app_name="my-app",
+        entrypoint="simple.app:SimpleApp",
+    )
+
+    isolated_function.fetch_metadata(build_environment=False)
+
+    _, call_kwargs = host.run.call_args
+    assert call_kwargs["application_name"] == "my-app"
+    assert call_kwargs["entrypoint"] == "simple.app:SimpleApp.build_metadata"
+    assert call_kwargs["build_environment"] is False
+
+
 def test_secrets_propagate_to_host_kwargs():
     class SecretsApp(App):
         secrets = ["OPENAI_API_KEY", "HF_TOKEN"]


### PR DESCRIPTION
## Summary

Pre-builds the environment as a separate `BuildEnvironment` gRPC call before `RegisterApplication` / `Run`, so `fal deploy` and non-local `fal run` get a clean two-phase flow:

- `Building environment...`
- `Deploying...` / `Running...`

Follow-up metadata, run, and register calls pass `build_environment=False`, so the server resolves the already-built environment from the request fields and fails fast if the cached build is missing.

Server side shipped in [fal-ai/isolate-cloud#7348](https://github.com/fal-ai/isolate-cloud/pull/7348); proto side shipped in [fal-ai/fal#1019](https://github.com/fal-ai/fal/pull/1019). This PR pins `isolate-proto>=0.31.3` for the new RPC and `build_environment` request fields.

## Changes

### SDK plumbing

- Adds `BuildEnvironmentResult` and a `from_grpc` converter for the new result stream.
- Adds `FalServerlessClient.build_environment(...)` for the new RPC.
- Plumbs optional `build_environment` through `FalServerlessClient.register(...)` and `FalServerlessClient.run(...)`.

### Host/API surface

- Adds the base `Host.build_environment(...)` contract and implements `FalServerlessHost.build_environment(...)` to construct the environment from `Options`, sync files, and stream build logs.
- Propagates `build_environment` through `Host.run`, `FalServerlessHost.register`, `_run`, `fal.api.run.run`, and `IsolatedFunction.fetch_metadata(...)`.
- Handles terminal `BuildEnvironment` failure immediately instead of continuing into metadata/register/run.
- Fails fast if the build stream ends without a terminal status.
- Preserves `application_name` during entrypoint metadata probes so `build_environment=False` resolves the same cached environment as the prebuild step.
- Keeps programmatic deploy logging compatible by defaulting `build_result_handler` to `result_handler` when a dedicated build handler is not provided.
- Raises readable errors if build/run streams return unknown terminal states.

### CLI orchestration and output

- `fal deploy` runs the explicit build step first, then metadata fetch, then register with `build_environment=False`.
- `fal run` does the same explicit build prelude for non-local runs.
- Adds `CliBuildEnvironmentResultHandler` for the build phase header/footer and logs.
- Renders silent build cache hits as a minimal `Build complete` line instead of an empty rule block.
- Filters builder-source cache-hit logs from the later deploy/run handlers to avoid duplicate build sections.
- Uses the shared console rule helper for Windows-safe rule rendering.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest -q projects/fal/tests/unit/cli projects/fal/tests/unit/test_app.py`
- [x] `pytest -n auto -q projects/fal/tests/unit --ignore=projects/fal/tests/unit/test_file_sync.py`
- [x] `ISOLATE_AUTH_DISABLED=1 ISOLATE_TEST_MODE=1 FAL_HOST=api.localhost pytest -q projects/fal/tests/unit/test_file_sync.py`
- [x] Manual `fal run simple_func` in `~/git/efiop/fal/python_entry_point`
- [x] Manual `fal run simple_app` in `~/git/efiop/fal/python_entry_point` through startup; stopped after the app began serving
- [ ] Manual `fal deploy` against a real cluster

Integration/e2e tests were not run locally because they require cloud credentials.