### PR TITLE
ci: run fal integration and e2e tests on Windows

### DIFF
--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -29,12 +29,13 @@ permissions:
 
 jobs:
   e2e:
-    name: e2e (py ${{ matrix.python }}, ${{ matrix.deps }})
-    runs-on: ubuntu-latest
+    name: e2e (${{ matrix.os }}, py ${{ matrix.python }}, ${{ matrix.deps }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
@@ -52,6 +53,10 @@ jobs:
             python: "3.13"
           - deps: "pydantic==1.10.18"
             python: "3.14"
+        include:
+          - os: windows-2022
+            deps: "pydantic==2.13.3"
+            python: "3.12"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -27,12 +27,13 @@ permissions:
 
 jobs:
   integration:
-    name: integration (py ${{ matrix.python }}, ${{ matrix.deps }})
-    runs-on: ubuntu-latest
+    name: integration (${{ matrix.os }}, py ${{ matrix.python }}, ${{ matrix.deps }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
@@ -50,6 +51,10 @@ jobs:
             python: "3.13"
           - deps: "pydantic==1.10.18"
             python: "3.14"
+        include:
+          - os: windows-2022
+            deps: "pydantic==2.13.3"
+            python: "3.12"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- add a Windows 2022 job to the fal integration test matrix
- add a Windows 2022 job to the fal e2e test matrix
- keep the existing Ubuntu matrices unchanged
- run the full integration and e2e suites on Windows with Python 3.12 and pydantic 2.13.3

## Validation
- `uvx --python 3.11 pre-commit run --all-files`
- parsed `.github/workflows/fal-integration-tests.yml` and `.github/workflows/fal-e2e-tests.yml` with PyYAML

Integration and e2e tests require CI secrets, so the Windows runs are intentionally validated by GitHub Actions.