### PR TITLE
fix(cli): resolve app files context from pyproject

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -137,7 +137,7 @@ def get_app_data_from_toml(
         raise ValueError(
             "app_files_context_dir is only supported when app_files is provided."
         )
-    if app_files_context_dir is not None:
+    if app_files_context_dir:
         context_path = Path(app_files_context_dir)
         if not context_path.is_absolute():
             app_files_context_dir = str(Path(toml_path).parent / context_path)

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -137,6 +137,10 @@ def get_app_data_from_toml(
         raise ValueError(
             "app_files_context_dir is only supported when app_files is provided."
         )
+    if app_files_context_dir is not None:
+        context_path = Path(app_files_context_dir)
+        if not context_path.is_absolute():
+            app_files_context_dir = str(Path(toml_path).parent / context_path)
     if exposed_port is not None:
         _validate_port("exposed_port", exposed_port)
     if image_config is not None and app_files:

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -962,6 +962,29 @@ def test_get_app_data_from_toml_resolves_app_files_context_dir_from_pyproject(
     assert toml_data.options.host["app_files_context_dir"] == str(tmp_path)
 
 
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_preserves_empty_app_files_context_dir(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "app-with-files": {
+                "ref": "src/app.py::App",
+                "app_files": ["assets"],
+                "app_files_context_dir": "",
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("app-with-files")
+
+    assert toml_data.options.host["app_files_context_dir"] == ""
+
+
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -939,6 +939,29 @@ def test_get_app_data_from_toml_with_app_files(
     assert toml_data.options.environment == {}
 
 
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_resolves_app_files_context_dir_from_pyproject(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "app-with-files": {
+                "ref": "src/app.py::App",
+                "app_files": ["assets"],
+                "app_files_context_dir": ".",
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("app-with-files")
+
+    assert toml_data.options.host["app_files_context_dir"] == str(tmp_path)
+
+
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(


### PR DESCRIPTION
## Summary
- rebase on top of the merged app-files runtime support in `origin/main`
- keep the remaining CLI fix: resolve relative `app_files_context_dir` values from the `pyproject.toml` directory
- preserve `app_files_context_dir = ""` as empty instead of rewriting it to the pyproject parent
- add focused pyproject coverage for both relative-context resolution and empty-context preservation

## Tests
- `.venv/bin/pytest -q projects/fal/tests/unit/cli/test_deploy.py::test_get_app_data_from_toml_resolves_app_files_context_dir_from_pyproject projects/fal/tests/unit/cli/test_deploy.py::test_get_app_data_from_toml_preserves_empty_app_files_context_dir`
- `.venv/bin/pytest -q projects/fal/tests/unit/cli/test_deploy.py projects/fal/tests/unit/test_app.py projects/fal/tests/unit/test_api_run.py`
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --all-files`
- Windows Server 2022 manual check before the empty-string-only follow-up: function + `app_files` returned `cwd == "/app/src"`; app + `app_files` deployed, invoked, returned `cwd == "/app/src"`, then was deleted
