### PR TITLE
fix: apply app-files runtime setup to functions

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -50,6 +50,7 @@ from typing_extensions import Concatenate, ParamSpec
 
 import fal.flags as flags
 from fal._serialization import include_module, include_modules_from, patch_pickle
+from fal.app_files import get_app_files_relative_path, include_app_files_path
 from fal.console import console
 from fal.container import ContainerImage
 from fal.exceptions import (
@@ -452,17 +453,61 @@ class UserFunctionException(FalServerlessException):
     pass
 
 
+@dataclass(frozen=True)
+class FunctionRuntimeConfig:
+    app_files_relative_path: str | None = None
+    include_cwd_in_sys_path: bool = False
+
+
+def _runtime_config_from_options(
+    options: Options, local_file_path: str | None
+) -> FunctionRuntimeConfig | None:
+    app_files_relative_path = None
+    if options.host.get("app_files"):
+        # Hosts created outside the CLI/deploy loaders may not have an app file
+        # path. In that case, keep app_files relative to the current directory.
+        app_files_relative_path = get_app_files_relative_path(
+            local_file_path or os.getcwd(),
+            options.host.get("app_files_context_dir"),
+        )
+
+    include_cwd_in_sys_path = options.environment.get("kind") == "container"
+    if app_files_relative_path is None and not include_cwd_in_sys_path:
+        return None
+
+    return FunctionRuntimeConfig(
+        app_files_relative_path=app_files_relative_path,
+        include_cwd_in_sys_path=include_cwd_in_sys_path,
+    )
+
+
+def _apply_runtime_config(runtime_config: FunctionRuntimeConfig | None) -> None:
+    if runtime_config is None:
+        return
+
+    if runtime_config.include_cwd_in_sys_path and "" not in sys.path:
+        # isolate's runpy.run_path() overrides sys.path[0], so container working
+        # directories need to be restored explicitly for local imports.
+        sys.path.insert(0, "")
+
+    if runtime_config.app_files_relative_path is not None:
+        include_app_files_path(runtime_config.app_files_relative_path)
+
+
 def _prepare_partial_func(
-    func: Callable[ArgsT, ReturnT],
-    *args: ArgsT.args,
-    **kwargs: ArgsT.kwargs,
-) -> Callable[ArgsT, ReturnT]:
+    func: Callable[..., ReturnT],
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+    runtime_config: FunctionRuntimeConfig | None = None,
+) -> Callable[..., ReturnT]:
     """Prepare the given function for execution on isolate workers."""
+    bound_kwargs = kwargs or {}
 
     @wraps(func)
-    def wrapper(*remote_args: ArgsT.args, **remote_kwargs: ArgsT.kwargs) -> ReturnT:
+    def wrapper(*remote_args: Any, **remote_kwargs: Any) -> ReturnT:
         try:
-            result = func(*remote_args, *args, **remote_kwargs, **kwargs)
+            _apply_runtime_config(runtime_config)
+            result = func(*remote_args, *args, **remote_kwargs, **bound_kwargs)
         except FalServerlessException:
             raise
         except Exception as exc:
@@ -533,7 +578,13 @@ class LocalHost(Host):
             environment.create(),
             extra_inheritance_paths=[self._AGENT_ENVIRONMENT.create()],
         ) as connection:
-            executable = _prepare_partial_func(func, *args, **kwargs)
+            runtime_config = _runtime_config_from_options(options, None)
+            executable = _prepare_partial_func(
+                func,
+                args=args,
+                kwargs=kwargs,
+                runtime_config=runtime_config,
+            )
             return connection.run(executable)
 
 
@@ -756,6 +807,9 @@ class FalServerlessHost(Host):
         default_factory=ThreadPoolExecutor, init=False
     )
 
+    def _runtime_config(self, options: Options) -> FunctionRuntimeConfig | None:
+        return _runtime_config_from_options(options, self.local_file_path)
+
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         state["_thread_pool"] = None
@@ -948,9 +1002,10 @@ class FalServerlessHost(Host):
                 "only one of a func or an entrypoint can be provided."
             )
 
+        runtime_config = self._runtime_config(options)
         partial_func = None
         if func is not None:
-            partial_func = _prepare_partial_func(func)
+            partial_func = _prepare_partial_func(func, runtime_config=runtime_config)
 
         if metadata is None:
             metadata = {}
@@ -1024,7 +1079,12 @@ class FalServerlessHost(Host):
         scheduler = options.host.get("_scheduler", None)
         scheduler_options = options.host.get("_scheduler_options", None)
         exposed_port = options.get_exposed_port()
+        runtime_config = self._runtime_config(options)
         setup_function = options.host.get("setup_function", None)
+        if setup_function is not None and runtime_config is not None:
+            setup_function = _prepare_partial_func(
+                setup_function, runtime_config=runtime_config
+            )
         request_timeout = options.host.get("request_timeout")
         startup_timeout = options.host.get("startup_timeout")
         regions = options.host.get("regions")
@@ -1063,7 +1123,12 @@ class FalServerlessHost(Host):
 
         partial_func = None
         if func is not None:
-            partial_func = _prepare_partial_func(func, *args, **kwargs)
+            partial_func = _prepare_partial_func(
+                func,
+                args=args,
+                kwargs=kwargs,
+                runtime_config=runtime_config,
+            )
         effective_app_name = (
             application_name or getattr(func, "__name__", None) or entrypoint
         )
@@ -2374,6 +2439,7 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         previous_isolate_env = os.environ.get("IS_ISOLATE_AGENT")
         os.environ["IS_ISOLATE_AGENT"] = "1"
         try:
+            self._apply_runtime_config()
             result = func(*args, **call_kwargs)
             if inspect.isawaitable(result):
                 awaited = cast(Awaitable[ReturnT], result)
@@ -2388,6 +2454,15 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
                 del os.environ["IS_ISOLATE_AGENT"]
             else:
                 os.environ["IS_ISOLATE_AGENT"] = previous_isolate_env
+
+    def _local_runtime_config(self) -> FunctionRuntimeConfig | None:
+        return _runtime_config_from_options(
+            self.options,
+            getattr(self.host, "local_file_path", None),
+        )
+
+    def _apply_runtime_config(self) -> None:
+        _apply_runtime_config(self._local_runtime_config())
 
     def _resolve_entrypoint_target(self) -> Any:
         if self.entrypoint is None:

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -10,7 +10,6 @@ import threading
 import time
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Callable, ClassVar, Optional
 
 import fastapi
@@ -136,10 +135,6 @@ async def _set_logger_labels(
 def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
     include_modules_from(cls)
     limit_max_requests = kwargs.pop("limit_max_requests", None)
-
-    host = kwargs.get("host", None)
-    if host:
-        cls.local_file_path = host.local_file_path
 
     def initialize_and_serve(
         *,
@@ -459,63 +454,6 @@ def _print_python_packages() -> None:
     print("[debug] Python packages installed:", ", ".join(packages))
 
 
-def _include_app_files_path(
-    local_file_path: str | None, app_files_context_dir: str | None
-):
-    base_cloud_dir = Path("/app")
-    if local_file_path is None:
-        return
-
-    # In case of container apps, the /app directory is not created by default
-    # so we need to check if it exists before proceeding
-    if not base_cloud_dir.exists():
-        return
-
-    base_path = Path(local_file_path).resolve()
-    if base_path.is_dir():
-        original_script_dir = base_path
-    else:
-        original_script_dir = base_path.parent
-
-    if app_files_context_dir:
-        context_path = Path(app_files_context_dir)
-        if context_path.is_absolute():
-            final_script_dir = context_path.resolve()
-        else:
-            final_script_dir = (original_script_dir / context_path).resolve()
-
-        # relative path between the original script dir
-        # and where the app_files_context_dir is targetting
-        relative_path = os.path.relpath(original_script_dir, final_script_dir)
-        # cloud final_path based on the `/app` base dir,
-        final_path = base_cloud_dir / Path(relative_path)
-    else:
-        # if no app_files_context_dir is provided, the base directory is the root
-        final_path = base_cloud_dir
-
-    # Create the final path if it doesn't exist
-    # This is for cases when fal app is not in root
-    # and its parent directory is not in app_files
-    # Which means that the relative path to app won't be created by default
-    final_path.mkdir(parents=True, exist_ok=True)
-
-    # Add local files deployment path to sys.path so imports
-    # work correctly in the isolate agent
-    # Append the final path to sys.path first so that the
-    # relative directory is resolved first in case of conflicts
-    sys.path.append(str(final_path))
-
-    # Add the base cloud dir path to sys.path so that
-    # the app can access the files in the top level directory
-    # This is for cases when fal app is not in root,
-    # and user wants to access the files without using relative imports
-    sys.path.append(str(base_cloud_dir))
-
-    # Change the current working directory to the path of the app
-    # so that the app can access the files in the current directory
-    os.chdir(str(final_path))
-
-
 @dataclass
 class RequestContext:
     request_id: str | None
@@ -826,9 +764,6 @@ class App(BaseServable):
     async def lifespan(self, app: fastapi.FastAPI):
         os.environ["FAL_RUNNER_STATE"] = "SETUP"
 
-        # Configure sys.path based on deployment type:
-        # - app_files: files synced to /app
-        # - container: files baked into image
         # HACK: Import at runtime to avoid weird error during deserialization
         import contextvars  # noqa: PLC0415
 
@@ -846,18 +781,6 @@ class App(BaseServable):
         except (ImportError, AttributeError):
             pass
 
-        # We want to not do any directory changes for container apps,
-        # since we don't have explicit checks to see the kind of app
-        # We check for app_files here and check kind and app_files earlier
-        # to ensure that container apps don't have app_files
-        if self.app_files:
-            # For app_files deployments (always use /app)
-            _include_app_files_path(self.local_file_path, self.app_files_context_dir)
-        elif self.image is not None:
-            # For containers, add the working directory to sys.path
-            # isolate's runpy.run_path() overrides sys.path[0],
-            # so the working directory is never added to sys.path
-            sys.path.insert(0, "")
         _print_python_packages()
         setup_started_at = time.perf_counter()
         await _call_any_fn(self.setup)

--- a/projects/fal/src/fal/app_files.py
+++ b/projects/fal/src/fal/app_files.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def get_app_files_relative_path(
+    local_file_path: str | None, app_files_context_dir: str | None
+) -> str | None:
+    if local_file_path is None:
+        return None
+
+    base_path = Path(local_file_path).resolve()
+    if base_path.is_dir():
+        original_script_dir = base_path
+    else:
+        original_script_dir = base_path.parent
+
+    if app_files_context_dir:
+        context_path = Path(app_files_context_dir)
+        if context_path.is_absolute():
+            final_script_dir = context_path.resolve()
+        else:
+            final_script_dir = (original_script_dir / context_path).resolve()
+
+        relative_path = os.path.relpath(original_script_dir, final_script_dir)
+        if os.sep != "/":
+            relative_path = relative_path.replace(os.sep, "/")
+        return relative_path
+    else:
+        return "."
+
+
+def include_app_files_path(app_files_relative_path: str | None) -> None:
+    base_cloud_dir = Path("/app")
+
+    # In case of container apps, the /app directory is not created by default
+    # so we need to check if it exists before proceeding.
+    if not base_cloud_dir.exists():
+        return
+
+    if not app_files_relative_path or app_files_relative_path == ".":
+        final_path = base_cloud_dir
+    else:
+        final_path = base_cloud_dir / app_files_relative_path
+
+    # Create the final path if it doesn't exist. This is for cases where the app
+    # is not in root and its parent directory is not in app_files.
+    final_path.mkdir(parents=True, exist_ok=True)
+
+    # Add local files deployment paths to sys.path so imports work correctly in
+    # the isolate agent.
+    for path in (final_path, base_cloud_dir):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.append(path_str)
+
+    # Change the current working directory to the app path so app files are
+    # accessible through relative paths.
+    if Path.cwd() != final_path:
+        os.chdir(str(final_path))

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -56,6 +57,39 @@ def test_run_local_without_entrypoint_uses_raw_func():
         (1,),
         {"x": 2},
     )
+
+
+def test_run_local_with_app_files_configures_runtime_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def run():
+        return "local"
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=run,
+        options=Options(
+            host={"app_files": ["assets"], "app_files_context_dir": "."},
+        ),
+    )
+
+    with patch("fal.api.api.include_app_files_path") as include_app_files_path:
+        assert run_api(iso, local=True) == "local"
+
+    include_app_files_path.assert_called_once_with(".")
+
+
+def test_run_local_container_config_includes_cwd_on_sys_path(monkeypatch):
+    monkeypatch.setattr(sys, "path", [path for path in sys.path if path != ""])
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(environment={"kind": "container"}),
+    )
+
+    assert run_api(iso, local=True) == "local"
+    assert sys.path[0] == ""
 
 
 def test_run_local_forwards_exposed_ports_to_entrypoint_app(monkeypatch):

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -721,6 +721,289 @@ def test_app_files_classvars_propagate_to_host_kwargs():
     assert hk["max_multiplexing"] == 7
 
 
+def test_app_files_runtime_path_uses_relative_app_directory(tmp_path):
+    from fal.app_files import get_app_files_relative_path
+
+    app_file = tmp_path / "src" / "app.py"
+    app_file.parent.mkdir()
+    app_file.write_text("# app\n")
+
+    assert get_app_files_relative_path(str(app_file), str(tmp_path)) == "src"
+    assert get_app_files_relative_path(str(app_file), ".") == "."
+
+
+def test_plain_function_app_files_configures_runtime_path_before_run(tmp_path):
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+
+    app_file = tmp_path / "app.py"
+    app_file.write_text("# app\n")
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    options = Options(
+        host={"app_files": ["assets"], "app_files_context_dir": "."},
+    )
+
+    captured = {}
+
+    def user_func(*args, **kwargs):
+        return args, kwargs
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "remote-ok"
+
+    def fake_run(partial_func, *args, **kwargs):
+        captured["partial_func"] = partial_func
+        return iter([partial_result])
+
+    connection.run.side_effect = fake_run
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "files_sync", return_value=[])
+        )
+        mock_connection = stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        )
+        mock_connection.return_value = connection
+        result = host._run(
+            user_func,
+            options,
+            args=("bound",),
+            kwargs={"from_client": True},
+            result_handler=ResultHandler(),
+        )
+
+    assert result == "remote-ok"
+
+    with patch("fal.api.api.include_app_files_path") as include_app_files_path:
+        assert captured["partial_func"]("remote", from_worker=True) == (
+            ("remote", "bound"),
+            {"from_worker": True, "from_client": True},
+        )
+
+    include_app_files_path.assert_called_once_with(".")
+
+
+def test_plain_function_container_config_includes_cwd_on_sys_path(monkeypatch):
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+
+    host = FalServerlessHost()
+    options = Options(environment={"kind": "container"})
+    captured = {}
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "remote-ok"
+
+    def fake_run(partial_func, *args, **kwargs):
+        captured["partial_func"] = partial_func
+        return iter([partial_result])
+
+    connection.run.side_effect = fake_run
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "files_sync", return_value=[])
+        )
+        mock_connection = stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        )
+        mock_connection.return_value = connection
+        result = host._run(
+            lambda: "ok",
+            options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+        )
+
+    assert result == "remote-ok"
+
+    monkeypatch.setattr(sys, "path", [path for path in sys.path if path != ""])
+
+    assert captured["partial_func"]() == "ok"
+    assert sys.path[0] == ""
+
+
+def test_plain_function_app_files_configures_runtime_path_before_setup_function(
+    tmp_path,
+):
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+
+    app_file = tmp_path / "app.py"
+    app_file.write_text("# app\n")
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    options = Options(
+        host={
+            "app_files": ["assets"],
+            "app_files_context_dir": ".",
+            "setup_function": lambda: "setup-ok",
+        },
+    )
+    captured = {}
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "remote-ok"
+
+    def fake_run(partial_func, *args, **kwargs):
+        captured["setup_function"] = kwargs["setup_function"]
+        return iter([partial_result])
+
+    connection.run.side_effect = fake_run
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "files_sync", return_value=[])
+        )
+        mock_connection = stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        )
+        mock_connection.return_value = connection
+        result = host._run(
+            lambda: "ok",
+            options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+        )
+
+    assert result == "remote-ok"
+
+    with patch("fal.api.api.include_app_files_path") as include_app_files_path:
+        assert captured["setup_function"]() == "setup-ok"
+
+    include_app_files_path.assert_called_once_with(".")
+
+
+def test_plain_function_app_files_configures_runtime_path_before_register(tmp_path):
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    app_file = tmp_path / "app.py"
+    app_file.write_text("# app\n")
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    options = Options(
+        host={"app_files": ["assets"], "app_files_context_dir": "."},
+    )
+    captured = {}
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+
+    def fake_register(partial_func, *args, **kwargs):
+        captured["partial_func"] = partial_func
+        return iter([partial_result])
+
+    connection.register.side_effect = fake_register
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "files_sync", return_value=[])
+        )
+        mock_connection = stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        )
+        mock_connection.return_value = connection
+        result = host.register(
+            lambda: "ok",
+            options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+
+    with patch("fal.api.api.include_app_files_path") as include_app_files_path:
+        assert captured["partial_func"]() == "ok"
+
+    include_app_files_path.assert_called_once_with(".")
+
+
+def test_app_files_configures_runtime_path_before_wrapped_app_serves(
+    tmp_path,
+    monkeypatch,
+):
+    import asyncio
+
+    from fal.api.api import FalServerlessHost, ResultHandler
+    from fal.app import wrap_app
+    from fal.sdk import HostedRunState
+
+    monkeypatch.setenv("IS_ISOLATE_AGENT", "1")
+    app_file = tmp_path / "app.py"
+    app_file.write_text("# app\n")
+
+    class AppFilesApp(App):
+        app_files = ["assets"]
+        app_files_context_dir = "."
+
+        @endpoint("/")
+        def hello(self) -> str:
+            return "ok"
+
+    async def fake_serve(self, **kwargs):
+        return "served"
+
+    monkeypatch.setattr(AppFilesApp, "serve", fake_serve)
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    fn = wrap_app(AppFilesApp, host=host)
+    captured = {}
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "remote-ok"
+
+    def fake_run(partial_func, *args, **kwargs):
+        captured["partial_func"] = partial_func
+        return iter([partial_result])
+
+    connection.run.side_effect = fake_run
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "files_sync", return_value=[])
+        )
+        mock_connection = stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        )
+        mock_connection.return_value = connection
+        result = host._run(
+            fn.func,
+            fn.options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+        )
+
+    assert result == "remote-ok"
+
+    with patch("fal.api.api.include_app_files_path") as include_app_files_path, patch(
+        "fal.app.set_current_app"
+    ):
+        assert asyncio.run(captured["partial_func"]()) == "served"
+
+    include_app_files_path.assert_called_once_with(".")
+
+
 def test_files_sync_auto_excludes_app_file_with_posix_relative_path(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Summary

- move app-files cwd/sys.path setup into the shared function runtime wrapper
- apply that runtime setup to plain functions, setup functions, registration, run_local, and LocalHost runs
- remove the duplicate app-files/container import setup from App.lifespan()
- add regression coverage for wrapped fal.App app-files setup before serve()

## Root Cause

app_files were synced for fal.function, but the runtime cwd/sys.path adjustment lived in fal.App.lifespan(), so plain functions did not get the same worker-side setup. The runtime setup now lives at the function execution boundary, which also covers fal.App because it is wrapped as an IsolatedFunction.

## Validation

- projects/fal/.venv/bin/pytest projects/fal/tests/unit/test_app.py projects/fal/tests/unit/test_api_run.py -q
- uvx --python /opt/homebrew/bin/python3.12 pre-commit run --all-files
