### PR TITLE
fix(cli): escape remote logs for terminal encoding

### DIFF
--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -24,6 +24,7 @@ from rich.console import Console
 from structlog.typing import EventDict
 
 from fal.api.client import SyncServerlessClient
+from fal.console.encoding import make_terminal_safe
 from fal.sdk import ReplaceState, RunnerInfo, RunnerState
 
 from .parser import FalClientParser, SinceAction, get_output_parser
@@ -677,7 +678,10 @@ class LogPrinter:
         return self._renderer(logger={}, name=event["level"], event_dict=event)
 
     def print(self, log: dict) -> None:
-        self._console.print(self._render_log(log), highlight=False)
+        self._console.print(
+            make_terminal_safe(self._render_log(log), self._console.file),
+            highlight=False,
+        )
 
 
 DEFAULT_STREAM_SINCE = timedelta(minutes=1)

--- a/projects/fal/src/fal/console/encoding.py
+++ b/projects/fal/src/fal/console/encoding.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import TextIO
+
+
+def make_terminal_safe(text: str, stream: TextIO) -> str:
+    """Escape characters that cannot be encoded by the target stream."""
+    encoding = stream.encoding or "utf-8"
+    return text.encode(encoding, errors="backslashreplace").decode(encoding)

--- a/projects/fal/src/fal/logging/isolate.py
+++ b/projects/fal/src/fal/logging/isolate.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from structlog.dev import ConsoleRenderer
 from structlog.typing import EventDict
 
+from fal.console.encoding import make_terminal_safe
+
 from .style import LEVEL_STYLES
 
 if TYPE_CHECKING:
@@ -65,7 +67,7 @@ class IsolateLogPrinter:
 
         if log.source == LogSource.USER:
             stream = sys.stderr if log.level == LogLevel.STDERR else sys.stdout
-            print(log.message, file=stream)
+            print(make_terminal_safe(log.message, stream), file=stream)
             return
 
         level = str(log.level)
@@ -90,4 +92,4 @@ class IsolateLogPrinter:
 
         # Use structlog processors to get consistent output with local logs
         message = _renderer.__call__(logger={}, name=level, event_dict=event)
-        print(message)
+        print(make_terminal_safe(message, sys.stdout))

--- a/projects/fal/tests/unit/console/test_encoding.py
+++ b/projects/fal/tests/unit/console/test_encoding.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import io
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from enum import IntEnum
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from fal.cli.runners import LogPrinter
+from fal.console.encoding import make_terminal_safe
+from fal.logging.isolate import IsolateLogPrinter
+
+
+class StrictEncodingStream(io.StringIO):
+    def __init__(self, encoding: str) -> None:
+        super().__init__()
+        self._encoding = encoding
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+    def write(self, text: str) -> int:
+        text.encode(self.encoding)
+        return super().write(text)
+
+
+class NoEncodingStream(io.StringIO):
+    @property
+    def encoding(self):
+        return None
+
+
+class LogLevel(IntEnum):
+    DEBUG = 10
+    INFO = 20
+    STDERR = 30
+
+
+class LogSource(IntEnum):
+    BUILDER = 1
+    BRIDGE = 2
+    USER = 3
+
+
+def test_make_terminal_safe_escapes_unencodable_characters() -> None:
+    stream = StrictEncodingStream("cp1252")
+
+    assert make_terminal_safe("hello 😊", stream) == "hello \\U0001f60a"
+
+
+def test_make_terminal_safe_preserves_encodable_text() -> None:
+    stream = StrictEncodingStream("utf-8")
+
+    assert make_terminal_safe("hello 😊", stream) == "hello 😊"
+
+
+def test_make_terminal_safe_preserves_text_without_stream_encoding() -> None:
+    stream = NoEncodingStream()
+
+    assert make_terminal_safe("hello 😊", stream) == "hello 😊"
+
+
+@pytest.mark.parametrize(
+    ("level", "stream_name"),
+    [(LogLevel.INFO, "stdout"), (LogLevel.STDERR, "stderr")],
+)
+def test_isolate_log_printer_escapes_user_log_for_stream_encoding(
+    level: LogLevel, stream_name: str
+) -> None:
+    stream = StrictEncodingStream("cp1252")
+    log = SimpleNamespace(
+        message="remote 😊",
+        level=level,
+        source=LogSource.USER,
+    )
+    printer = IsolateLogPrinter()
+    printer._maybe_print_header = lambda source: None
+
+    with _isolate_logs_module(), patch.object(sys, stream_name, stream):
+        printer.print(log)
+
+    assert stream.getvalue() == "remote \\U0001f60a\n"
+
+
+def test_isolate_log_printer_escapes_rendered_system_log_for_stdout_encoding() -> None:
+    stream = StrictEncodingStream("cp1252")
+    log = SimpleNamespace(
+        message="remote 😊",
+        level=LogLevel.INFO,
+        source=LogSource.BUILDER,
+        bound_env=None,
+    )
+    printer = IsolateLogPrinter()
+    printer._maybe_print_header = lambda source: None
+
+    with _isolate_logs_module(), patch.object(sys, "stdout", stream):
+        printer.print(log)
+
+    assert "\\U0001f60a" in stream.getvalue()
+
+
+def test_runner_log_printer_escapes_rendered_log_for_console_encoding() -> None:
+    stream = StrictEncodingStream("cp1252")
+    console = Console(file=stream, force_terminal=False, color_system=None, width=120)
+    printer = LogPrinter(console)
+
+    printer.print(
+        {
+            "timestamp": "2026-05-19T12:34:56Z",
+            "level": "info",
+            "message": "remote 😊",
+        }
+    )
+
+    assert "\\U0001f60a" in stream.getvalue()
+
+
+@contextmanager
+def _isolate_logs_module() -> Iterator[None]:
+    isolate_module = ModuleType("isolate")
+    logs_module = ModuleType("isolate.logs")
+    logs_module.LogLevel = LogLevel
+    logs_module.LogSource = LogSource
+    isolate_module.logs = logs_module
+
+    with patch.dict(
+        sys.modules,
+        {
+            "isolate": isolate_module,
+            "isolate.logs": logs_module,
+        },
+    ):
+        yield


### PR DESCRIPTION
## Summary

- add a small console encoding helper that escapes characters unsupported by the target terminal encoding
- apply it to IsolateLogPrinter user/system log output and `fal runner logs` pretty output
- add cp1252-focused tests for stdout, stderr, rendered isolate logs, and runner logs

## Why

Remote logs can contain arbitrary Unicode. On non-UTF terminals, especially older Windows/cp1252 environments, printing those messages directly can raise `UnicodeEncodeError` and break log streaming. Escaping unsupported characters with `backslashreplace` keeps the CLI running while preserving debuggable code points.

## Validation

- `uv run --project projects/fal --extra test pytest projects/fal/tests/unit/console projects/fal/tests/unit/cli/test_runners.py`
- `pre-commit run --all-files`
- `pre-commit run --files projects/fal/src/fal/console/encoding.py projects/fal/src/fal/logging/isolate.py projects/fal/src/fal/cli/runners.py projects/fal/tests/unit/console/test_encoding.py`
