### PR TITLE
fix: rename FAILURE_DELAY runner state to CRASH_BACKOFF

### DIFF
--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -408,7 +408,7 @@ def _runners(args):
         failing_runners = [
             runner
             for runner in alias_runners
-            if runner.state == RunnerState.FAILURE_DELAY
+            if runner.state == RunnerState.CRASH_BACKOFF
         ]
         args.console.print(
             f"Runners: {len(alias_runners) - len(pending_runners) - len(setup_runners)}"
@@ -466,7 +466,7 @@ def _add_runners_parser(subparsers, parents):
             "running",
             "pending",
             "setup",
-            "failure_delay",
+            "crash_backoff",
             "terminated",
         ],
         nargs="+",

--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -352,7 +352,7 @@ def _list(args):
     ]
     setup_runners = [runner for runner in runners if runner.state == RunnerState.SETUP]
     failing_runners = [
-        runner for runner in runners if runner.state == RunnerState.FAILURE_DELAY
+        runner for runner in runners if runner.state == RunnerState.CRASH_BACKOFF
     ]
     terminated_runners = [
         runner
@@ -456,7 +456,7 @@ def _add_list_parser(subparsers, parents):
             "running",
             "pending",
             "setup",
-            "failure_delay",
+            "crash_backoff",
             "terminated",
         ],
         nargs="+",

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -355,7 +355,14 @@ class RunnerState(Enum):
     TERMINATING = "TERMINATING"
     TERMINATED = "TERMINATED"
     IDLE = "IDLE"
-    FAILURE_DELAY = "FAILURE_DELAY"
+    CRASH_BACKOFF = "CRASH_BACKOFF"
+
+    @classmethod
+    def _missing_(cls, value):
+        # Proto wire still uses the legacy name; map it to the renamed member.
+        if value == "FAILURE_DELAY":
+            return cls.CRASH_BACKOFF
+        return None
 
 
 class ReplaceState(Enum):


### PR DESCRIPTION
## Summary

Renames the runner `FAILURE_DELAY` state to `CRASH_BACKOFF` in the Python SDK and CLI filters. The protobuf wire format stays as `FAILURE_DELAY` — we explicitly do **not** touch `controller.proto` or the generated `_pb2` bindings to avoid proto-deployment churn across SDK/controller versions.

A `_missing_` hook on `RunnerState` maps the legacy proto enum name (`"FAILURE_DELAY"`) to the renamed member (`RunnerState.CRASH_BACKOFF`), so existing servers that still emit the old wire name continue to work.

## Changes

- Rename `RunnerState.FAILURE_DELAY` to `RunnerState.CRASH_BACKOFF` in `fal.sdk`
- Add `RunnerState._missing_` to translate the legacy proto name to the renamed member at the SDK boundary
- Replace `--state failure_delay` with `--state crash_backoff` for:
  - `fal runners list`
  - `fal apps runners <app>`
- **Not changed**: `projects/isolate_proto/src/isolate_proto/controller.proto` and the generated `controller_pb2.py` / `controller_pb2.pyi` — wire format keeps `FAILURE_DELAY = 9`

## Validation

- `uv run python -c "from fal.sdk import RunnerState; assert RunnerState('FAILURE_DELAY') is RunnerState.CRASH_BACKOFF"`
- `pytest projects/fal/tests/unit/cli/test_runners.py projects/fal/tests/unit/cli/test_apps.py`
- CLI help smoke checks:
  - `fal runners list --help`
  - `fal apps runners --help`