### PR TITLE
[codex] fix(cli): accept GPU host options in pyproject apps

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -117,6 +117,7 @@ def get_app_data_from_toml(
     scaling_delay = app_data.pop("scaling_delay", None)
     request_timeout = app_data.pop("request_timeout", None)
     startup_timeout = app_data.pop("startup_timeout", None)
+    machine_type = app_data.pop("machine_type", None)
     regions = app_data.pop("regions", None)
     app_files = app_data.pop("app_files", None)
     app_files_ignore = app_data.pop("app_files_ignore", None)
@@ -162,6 +163,8 @@ def get_app_data_from_toml(
         options.host["request_timeout"] = request_timeout
     if startup_timeout is not None:
         options.host["startup_timeout"] = startup_timeout
+    if machine_type is not None:
+        options.host["machine_type"] = machine_type
     if regions is not None:
         options.host["regions"] = regions
     if app_files is not None:

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -118,6 +118,7 @@ def get_app_data_from_toml(
     request_timeout = app_data.pop("request_timeout", None)
     startup_timeout = app_data.pop("startup_timeout", None)
     machine_type = app_data.pop("machine_type", None)
+    num_gpus = app_data.pop("num_gpus", None)
     regions = app_data.pop("regions", None)
     app_files = app_data.pop("app_files", None)
     app_files_ignore = app_data.pop("app_files_ignore", None)
@@ -165,6 +166,8 @@ def get_app_data_from_toml(
         options.host["startup_timeout"] = startup_timeout
     if machine_type is not None:
         options.host["machine_type"] = machine_type
+    if num_gpus is not None:
+        options.host["num_gpus"] = num_gpus
     if regions is not None:
         options.host["regions"] = regions
     if app_files is not None:

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -142,6 +142,7 @@ def mock_parse_pyproject_toml():
                 "name": "override-name",
                 "auth": "private",
                 "requirements": ["numpy==1.26.4"],
+                "machine_type": "GPU-H100",
                 "min_concurrency": 2,
                 "regions": ["us-east"],
             },
@@ -390,7 +391,11 @@ def test_deploy_with_toml_overrides_applied(
             team=None,
             name="override-name",
             options=Options(
-                host={"min_concurrency": 2, "regions": ["us-east"]},
+                host={
+                    "min_concurrency": 2,
+                    "machine_type": "GPU-H100",
+                    "regions": ["us-east"],
+                },
                 environment={"requirements": ["numpy==1.26.4"]},
             ),
             local_project_root=".",
@@ -933,6 +938,41 @@ def test_get_app_data_from_toml_with_python_version(mock_parse_toml, mock_find_t
     toml_data = get_app_data_from_toml("python-version-app")
 
     assert toml_data.options.environment == {"python_version": "3.12"}
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_machine_type(
+    mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+
+    toml_data = get_app_data_from_toml("override-app")
+
+    assert toml_data.options.host["machine_type"] == "GPU-H100"
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_machine_type_fallbacks(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "gpu-app": {
+                "ref": "src/gpu_app/inference.py::GpuApp",
+                "machine_type": ["GPU-H100", "GPU-A100"],
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("gpu-app")
+
+    assert toml_data.options.host["machine_type"] == ["GPU-H100", "GPU-A100"]
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -143,6 +143,7 @@ def mock_parse_pyproject_toml():
                 "auth": "private",
                 "requirements": ["numpy==1.26.4"],
                 "machine_type": "GPU-H100",
+                "num_gpus": 2,
                 "min_concurrency": 2,
                 "regions": ["us-east"],
             },
@@ -394,6 +395,7 @@ def test_deploy_with_toml_overrides_applied(
                 host={
                     "min_concurrency": 2,
                     "machine_type": "GPU-H100",
+                    "num_gpus": 2,
                     "regions": ["us-east"],
                 },
                 environment={"requirements": ["numpy==1.26.4"]},
@@ -952,6 +954,20 @@ def test_get_app_data_from_toml_with_machine_type(
     toml_data = get_app_data_from_toml("override-app")
 
     assert toml_data.options.host["machine_type"] == "GPU-H100"
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_num_gpus(
+    mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+
+    toml_data = get_app_data_from_toml("override-app")
+
+    assert toml_data.options.host["num_gpus"] == 2
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -111,6 +111,7 @@ def mock_parse_pyproject_toml():
                 "auth": "private",
                 "requirements": ["numpy==1.26.4"],
                 "machine_type": "GPU-H100",
+                "num_gpus": 2,
                 "min_concurrency": 2,
                 "regions": ["us-east"],
             },
@@ -394,6 +395,7 @@ def test_run_with_toml_cli_name_override(
     assert call_kwargs["app_auth"] == "public"
     assert call_kwargs["options"].environment["requirements"] == ["numpy==1.26.4"]
     assert call_kwargs["options"].host["machine_type"] == "GPU-H100"
+    assert call_kwargs["options"].host["num_gpus"] == 2
     assert call_kwargs["options"].host["min_concurrency"] == 2
     assert call_kwargs["options"].host["regions"] == ["us-east"]
 
@@ -433,6 +435,7 @@ def test_run_with_toml_overrides_applied(
     assert call_kwargs["app_auth"] == "public"
     assert call_kwargs["options"].environment["requirements"] == ["numpy==1.26.4"]
     assert call_kwargs["options"].host["machine_type"] == "GPU-H100"
+    assert call_kwargs["options"].host["num_gpus"] == 2
     assert call_kwargs["options"].host["min_concurrency"] == 2
     assert call_kwargs["options"].host["regions"] == ["us-east"]
 

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -110,6 +110,7 @@ def mock_parse_pyproject_toml():
                 "name": "override-name",
                 "auth": "private",
                 "requirements": ["numpy==1.26.4"],
+                "machine_type": "GPU-H100",
                 "min_concurrency": 2,
                 "regions": ["us-east"],
             },
@@ -392,6 +393,7 @@ def test_run_with_toml_cli_name_override(
     assert call_kwargs["app_name"] == "cli-app"
     assert call_kwargs["app_auth"] == "public"
     assert call_kwargs["options"].environment["requirements"] == ["numpy==1.26.4"]
+    assert call_kwargs["options"].host["machine_type"] == "GPU-H100"
     assert call_kwargs["options"].host["min_concurrency"] == 2
     assert call_kwargs["options"].host["regions"] == ["us-east"]
 
@@ -430,6 +432,7 @@ def test_run_with_toml_overrides_applied(
     assert call_kwargs["app_name"] is None
     assert call_kwargs["app_auth"] == "public"
     assert call_kwargs["options"].environment["requirements"] == ["numpy==1.26.4"]
+    assert call_kwargs["options"].host["machine_type"] == "GPU-H100"
     assert call_kwargs["options"].host["min_concurrency"] == 2
     assert call_kwargs["options"].host["regions"] == ["us-east"]
 


### PR DESCRIPTION
## Summary
- Accept `machine_type` and `num_gpus` in `[tool.fal.apps.*]` entries from `pyproject.toml`.
- Forward the parsed values into host options so deploy/run paths can use them.
- Add CLI unit coverage for string machine types, fallback machine type lists, and `num_gpus`.

## Root Cause
`get_app_data_from_toml` did not pop these host options, so valid app config fell through to the unexpected-key check instead of being forwarded to the runtime host configuration.

## Validation
- `projects/fal/.venv/bin/pytest projects/fal/tests/unit/cli/test_deploy.py projects/fal/tests/unit/cli/test_run.py`
- `uvx --python 3.11 pre-commit run --all-files`