### PR TITLE
feat(cli): support image-only Docker entrypoints

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import atexit
 import copy
+import json
+import re
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -66,6 +71,9 @@ def get_app_data_from_toml(
     except KeyError:
         raise ValueError(f"App {app_name} not found in pyproject.toml")
 
+    image_config = app_data.pop("image", None)
+
+    generated_docker_entrypoint = False
     python_entry_point: str | None = app_data.pop("python_entry_point", None)
     if python_entry_point is not None:
         if not isinstance(python_entry_point, str):
@@ -79,17 +87,22 @@ def get_app_data_from_toml(
                 "and python_entry_point keys in pyproject.toml"
             )
     else:
-        try:
-            app_ref = app_data.pop("ref")
-        except KeyError:
-            raise ValueError(
-                f"App {app_name} does not have a ref key in pyproject.toml"
-            )
-        if not isinstance(app_ref, str):
-            raise ValueError(f"App {app_name} ref must be a string in pyproject.toml")
-        # Convert the app_ref to a path relative to the project root
-        project_root, _ = find_project_root(None)
-        app_ref = str(project_root / app_ref)
+        app_ref = app_data.pop("ref", None)
+        if app_ref is None:
+            if image_config is None:
+                raise ValueError(
+                    f"App {app_name} does not have a ref key in pyproject.toml"
+                )
+            python_entry_point = _GENERATED_DOCKER_ENTRYPOINT
+            generated_docker_entrypoint = True
+        else:
+            if not isinstance(app_ref, str):
+                raise ValueError(
+                    f"App {app_name} ref must be a string in pyproject.toml"
+                )
+            # Convert the app_ref to a path relative to the project root
+            project_root, _ = find_project_root(None)
+            app_ref = str(project_root / app_ref)
 
     app_auth: Optional[AuthModeLiteral] = app_data.pop("auth", None)
     app_deployment_strategy: Optional[DeploymentStrategyLiteral] = app_data.pop(
@@ -124,8 +137,6 @@ def get_app_data_from_toml(
     app_files_ignore = app_data.pop("app_files_ignore", None)
     app_files_context_dir = app_data.pop("app_files_context_dir", None)
     exposed_port = app_data.pop("exposed_port", None)
-
-    image_config = app_data.pop("image", None)
 
     if regions is not None:
         _validate_regions(regions)
@@ -184,7 +195,10 @@ def get_app_data_from_toml(
         options.environment["python_version"] = python_version
     if image_config is not None:
         container_image = _build_container_image_from_toml(
-            app_name, image_config, Path(toml_path).parent
+            app_name,
+            image_config,
+            Path(toml_path).parent,
+            inject_generated_entrypoint=generated_docker_entrypoint,
         )
         options.environment["kind"] = "container"
         options.environment["image"] = container_image.to_dict()
@@ -263,13 +277,39 @@ _IMAGE_PASSTHROUGH_KEYS = (
 )
 
 
+_GENERATED_DOCKER_ENTRYPOINT = "fal_entrypoint:fal_entry_point"
+
+
 def _build_container_image_from_toml(
-    app_name: str, image_config: Any, project_root: Path
+    app_name: str,
+    image_config: Any,
+    project_root: Path,
+    *,
+    inject_generated_entrypoint: bool = False,
 ) -> ContainerImage:
     if not isinstance(image_config, dict):
         raise ValueError(f"App {app_name} image must be a table in pyproject.toml")
 
+    project_root = project_root.resolve()
     image_config = dict(image_config)
+
+    wrapper_entrypoint = image_config.pop("entrypoint", None)
+    wrapper_cmd = image_config.pop("cmd", None)
+    if inject_generated_entrypoint:
+        wrapper_entrypoint = _validate_docker_command_list(
+            app_name, "entrypoint", wrapper_entrypoint
+        )
+        wrapper_cmd = _validate_docker_command_list(app_name, "cmd", wrapper_cmd)
+        if wrapper_entrypoint is None and wrapper_cmd is None:
+            raise ValueError(
+                f"App {app_name} image-only deployment must specify "
+                "image.entrypoint or image.cmd in pyproject.toml"
+            )
+    elif wrapper_entrypoint is not None or wrapper_cmd is not None:
+        raise ValueError(
+            f"App {app_name} image.entrypoint and image.cmd are only supported "
+            "for image-only deployments in pyproject.toml"
+        )
 
     dockerfile_path = image_config.pop("dockerfile", None)
     if dockerfile_path is None:
@@ -290,6 +330,19 @@ def _build_container_image_from_toml(
     except FileNotFoundError:
         raise ValueError(f"App {app_name} image.dockerfile not found: {resolved_path}")
 
+    if inject_generated_entrypoint:
+        assert wrapper_entrypoint is not None or wrapper_cmd is not None
+        generated_source = _write_generated_docker_entrypoint(
+            project_root,
+            entrypoint=wrapper_entrypoint,
+            cmd=wrapper_cmd,
+        )
+        source_path = generated_source.relative_to(project_root).as_posix()
+        dockerfile_str = _append_generated_entrypoint_copy(
+            dockerfile_str,
+            source_path=source_path,
+        )
+
     kwargs: dict[str, Any] = {
         "dockerfile_str": dockerfile_str,
         "context_dir": project_root,
@@ -305,3 +358,116 @@ def _build_container_image_from_toml(
         )
 
     return ContainerImage(**kwargs)
+
+
+def _validate_docker_command_list(
+    app_name: str,
+    field_name: str,
+    value: Any,
+) -> list[str] | None:
+    if value is None:
+        return None
+    if not (isinstance(value, list) and all(isinstance(item, str) for item in value)):
+        raise ValueError(
+            f"App {app_name} image.{field_name} must be a list of strings "
+            "in pyproject.toml"
+        )
+    if len(value) == 0:
+        raise ValueError(
+            f"App {app_name} image.{field_name} must not be empty in pyproject.toml"
+        )
+    return value
+
+
+def _write_generated_docker_entrypoint(
+    project_root: Path,
+    *,
+    entrypoint: list[str] | None,
+    cmd: list[str] | None,
+) -> Path:
+    generated_dir = Path(
+        tempfile.mkdtemp(prefix="fal-generated-", dir=project_root)
+    ).resolve()
+    atexit.register(shutil.rmtree, generated_dir, ignore_errors=True)
+    generated_path = generated_dir / "fal_entrypoint"
+    generated_path.write_text(
+        _render_generated_docker_entrypoint(entrypoint=entrypoint, cmd=cmd),
+        encoding="utf-8",
+    )
+    return generated_path
+
+
+def _render_generated_docker_entrypoint(
+    *,
+    entrypoint: list[str] | None,
+    cmd: list[str] | None,
+) -> str:
+    return f"""\
+import os
+import signal
+import subprocess
+
+_ENTRYPOINT = {json.dumps(entrypoint or [])}
+_CMD = {json.dumps(cmd or [])}
+
+
+def _argv():
+    if _ENTRYPOINT:
+        return [*_ENTRYPOINT, *_CMD]
+    return [*_CMD]
+
+
+class fal_entry_point:
+    @staticmethod
+    def build_metadata():
+        return {{}}
+
+    @staticmethod
+    def run_local():
+        popen_kwargs = {{}}
+        if os.name != "nt":
+            popen_kwargs["start_new_session"] = True
+
+        proc = subprocess.Popen(
+            _argv(),
+            stdin=subprocess.DEVNULL,
+            **popen_kwargs,
+        )
+
+        def _terminate(signum, frame):
+            del frame
+            try:
+                if os.name != "nt":
+                    os.killpg(proc.pid, signum)
+                else:
+                    proc.send_signal(signum)
+            except ProcessLookupError:
+                pass
+
+        try:
+            signal.signal(signal.SIGTERM, _terminate)
+            signal.signal(signal.SIGINT, _terminate)
+        except ValueError:
+            pass
+
+        code = proc.wait()
+        if code != 0:
+            raise RuntimeError(f"Process exited with code {{code}}")
+"""
+
+
+def _append_generated_entrypoint_copy(
+    dockerfile_str: str,
+    *,
+    source_path: str,
+) -> str:
+    if not re.match(r"^[A-Za-z0-9._/-]+$", source_path):
+        raise ValueError(f"Invalid generated entrypoint path: {source_path}")
+
+    return (
+        dockerfile_str.rstrip()
+        + "\n\n"
+        + "# fal generated Docker wrapper entrypoint\n"
+        + f"COPY {source_path} /app/fal_entrypoint.py\n"
+        + 'ENV PYTHONPATH="/app:${PYTHONPATH}"\n'
+    )

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -5,6 +5,7 @@ import copy
 import json
 import re
 import shutil
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -199,6 +200,7 @@ def get_app_data_from_toml(
             image_config,
             Path(toml_path).parent,
             inject_generated_entrypoint=generated_docker_entrypoint,
+            python_version=python_version,
         )
         options.environment["kind"] = "container"
         options.environment["image"] = container_image.to_dict()
@@ -278,6 +280,34 @@ _IMAGE_PASSTHROUGH_KEYS = (
 
 
 _GENERATED_DOCKER_ENTRYPOINT = "fal_entrypoint:fal_entry_point"
+_PYTHON_BUILD_STANDALONE_RELEASE = "20260510"
+_PYTHON_BUILD_STANDALONE_ARCHIVES = {
+    "3.10": (
+        "cpython-3.10.20+20260510-x86_64-unknown-linux-gnu-"
+        "install_only_stripped.tar.gz",
+        "sha256:dc734bdd388975c0b093fe730b272af741a2e192475d38bc6845a687b6405922",
+    ),
+    "3.11": (
+        "cpython-3.11.15+20260510-x86_64-unknown-linux-gnu-"
+        "install_only_stripped.tar.gz",
+        "sha256:171dffd8c0f66e8a0725364a7428015b22fc18dd298b24f541392e17dd0e561f",
+    ),
+    "3.12": (
+        "cpython-3.12.13+20260510-x86_64-unknown-linux-gnu-"
+        "install_only_stripped.tar.gz",
+        "sha256:d480f5d5878910ecbae212bf23bd7c25d7b209eb8cf5e98823c977384d272e88",
+    ),
+    "3.13": (
+        "cpython-3.13.13+20260510-x86_64-unknown-linux-gnu-"
+        "install_only_stripped.tar.gz",
+        "sha256:bbe27549e475fe5f22d42a8e0d553dc79d80d8a00e05712599637857d287360e",
+    ),
+    "3.14": (
+        "cpython-3.14.5+20260510-x86_64-unknown-linux-gnu-"
+        "install_only_stripped.tar.gz",
+        "sha256:dc10977b0db3bef1ee2275107fde6fe9c148135b556fa352e83c6baa67d17ed6",
+    ),
+}
 
 
 def _build_container_image_from_toml(
@@ -286,6 +316,7 @@ def _build_container_image_from_toml(
     project_root: Path,
     *,
     inject_generated_entrypoint: bool = False,
+    python_version: str | None = None,
 ) -> ContainerImage:
     if not isinstance(image_config, dict):
         raise ValueError(f"App {app_name} image must be a table in pyproject.toml")
@@ -341,6 +372,7 @@ def _build_container_image_from_toml(
         dockerfile_str = _append_generated_entrypoint_copy(
             dockerfile_str,
             source_path=source_path,
+            python_version=python_version,
         )
 
     kwargs: dict[str, Any] = {
@@ -460,14 +492,55 @@ def _append_generated_entrypoint_copy(
     dockerfile_str: str,
     *,
     source_path: str,
+    python_version: str | None,
 ) -> str:
     if not re.match(r"^[A-Za-z0-9._/-]+$", source_path):
         raise ValueError(f"Invalid generated entrypoint path: {source_path}")
 
+    python_archive_url, python_archive_checksum = _python_runtime_archive(
+        python_version
+    )
+
     return (
         dockerfile_str.rstrip()
         + "\n\n"
+        + "# fal generated Python runtime for wrapper entrypoint\n"
+        + f"ADD --checksum={python_archive_checksum} {python_archive_url} "
+        + "/tmp/fal-python.tar.gz\n"
+        + "RUN mkdir -p /opt/fal && "
+        + "tar -xzf /tmp/fal-python.tar.gz -C /opt/fal && "
+        + "rm /tmp/fal-python.tar.gz\n"
+        + 'ENV PATH="${PATH}:/opt/fal/python/bin"\n\n'
         + "# fal generated Docker wrapper entrypoint\n"
         + f"COPY {source_path} /app/fal_entrypoint.py\n"
         + 'ENV PYTHONPATH="/app:${PYTHONPATH}"\n'
+    )
+
+
+def _python_runtime_archive(python_version: str | None) -> tuple[str, str]:
+    if python_version is None:
+        normalized_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    else:
+        match = re.match(r"^(\d+\.\d+)(?:\.\d+)?$", python_version)
+        if match is None:
+            raise ValueError(
+                "python_version must be in '<major>.<minor>' or "
+                "'<major>.<minor>.<patch>' format for image-only deployments."
+            )
+        normalized_version = match.group(1)
+
+    try:
+        filename, checksum = _PYTHON_BUILD_STANDALONE_ARCHIVES[normalized_version]
+    except KeyError:
+        supported = ", ".join(sorted(_PYTHON_BUILD_STANDALONE_ARCHIVES))
+        raise ValueError(
+            "image-only deployments currently support generated Python runtime "
+            f"injection for Python versions: {supported}."
+        )
+
+    escaped_filename = filename.replace("+", "%2B")
+    return (
+        "https://github.com/astral-sh/python-build-standalone/releases/download/"
+        f"{_PYTHON_BUILD_STANDALONE_RELEASE}/{escaped_filename}",
+        checksum,
     )

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -5,7 +5,6 @@ import copy
 import json
 import re
 import shutil
-import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -117,11 +116,23 @@ def get_app_data_from_toml(
     requirements = app_data.pop("requirements", None)
     if requirements is not None:
         _validate_requirements(requirements)
-    python_version = app_data.pop("python_version", None)
-    if python_version is not None and not isinstance(python_version, str):
+    configured_python_version = app_data.pop("python_version", None)
+    if configured_python_version is not None and not isinstance(
+        configured_python_version, str
+    ):
         raise ValueError(
             f"App {app_name} python_version must be a string in pyproject.toml"
         )
+    python_version: str | None
+    if generated_docker_entrypoint:
+        if configured_python_version is not None:
+            raise ValueError(
+                f"App {app_name} python_version is managed automatically for "
+                "image-only deployments."
+            )
+        python_version = _GENERATED_DOCKER_PYTHON_VERSION
+    else:
+        python_version = configured_python_version
     options = Options()
     min_concurrency = app_data.pop("min_concurrency", None)
     max_concurrency = app_data.pop("max_concurrency", None)
@@ -280,6 +291,7 @@ _IMAGE_PASSTHROUGH_KEYS = (
 
 
 _GENERATED_DOCKER_ENTRYPOINT = "fal_entrypoint:fal_entry_point"
+_GENERATED_DOCKER_PYTHON_VERSION = "3.12"
 _PYTHON_BUILD_STANDALONE_RELEASE = "20260510"
 _PYTHON_BUILD_STANDALONE_ARCHIVES = {
     "3.10": (
@@ -519,7 +531,7 @@ def _append_generated_entrypoint_copy(
 
 def _python_runtime_archive(python_version: str | None) -> tuple[str, str]:
     if python_version is None:
-        normalized_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        normalized_version = _GENERATED_DOCKER_PYTHON_VERSION
     else:
         match = re.match(r"^(\d+\.\d+)(?:\.\d+)?$", python_version)
         if match is None:

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1145,6 +1145,156 @@ def test_get_app_data_from_toml_with_image(mock_parse_toml, mock_find_toml, tmp_
     assert env["image"]["secrets"] == {"TOKEN": "shh"}
 
 
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    dockerfile = "FROM python:3.12-slim\nCOPY server.py /app/server.py\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    (tmp_path / "server.py").write_text("print('hello')\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "auth": "public",
+                "machine_type": "GPU-H100",
+                "exposed_port": 8000,
+                "image": {
+                    "dockerfile": "Dockerfile",
+                    "entrypoint": ["python", "/app/server.py"],
+                    "cmd": ["--host", "0.0.0.0", "--port", "8000"],
+                },
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+
+    image = toml_data.options.environment["image"]
+    dockerfile_str = image["dockerfile_str"]
+    generated_sources = [
+        source
+        for source in image["docker_files_list"]
+        if source.startswith("fal-generated-")
+    ]
+    assert toml_data.ref is None
+    assert toml_data.python_entry_point == "fal_entrypoint:fal_entry_point"
+    assert toml_data.auth == "public"
+    assert toml_data.options.host["machine_type"] == "GPU-H100"
+    assert toml_data.options.gateway["exposed_port"] == 8000
+    assert toml_data.options.environment["kind"] == "container"
+    assert dockerfile_str.startswith(dockerfile)
+    assert "COPY fal-generated-" in dockerfile_str
+    assert " /app/fal_entrypoint.py\n" in dockerfile_str
+    assert 'ENV PYTHONPATH="/app:${PYTHONPATH}"' in dockerfile_str
+    assert "server.py" in image["docker_files_list"]
+    assert len(generated_sources) == 1
+    assert generated_sources[0].endswith("/fal_entrypoint")
+
+    generated_source = (tmp_path / generated_sources[0]).read_text()
+    assert "import fal" not in generated_source
+    assert "class fal_entry_point:" in generated_source
+    assert "def build_metadata():" in generated_source
+    assert "def run_local():" in generated_source
+    assert '_ENTRYPOINT = ["python", "/app/server.py"]' in generated_source
+    assert '_CMD = ["--host", "0.0.0.0", "--port", "8000"]' in generated_source
+    assert "subprocess.Popen" in generated_source
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_only_without_command(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "image": {"dockerfile": "Dockerfile"},
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "App container-app image-only deployment must specify "
+            "image.entrypoint or image.cmd in pyproject.toml"
+        ),
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_command_with_ref(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "image": {
+                    "dockerfile": "Dockerfile",
+                    "entrypoint": ["python", "/app/server.py"],
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "App container-app image.entrypoint and image.cmd are only "
+            "supported for image-only deployments in pyproject.toml"
+        ),
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "message"),
+    [
+        ("entrypoint", "python /app/server.py", "must be a list of strings"),
+        ("cmd", [], "must not be empty"),
+    ],
+)
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_invalid_image_command(
+    mock_parse_toml, mock_find_toml, tmp_path, field_name, field_value, message
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    image_config = {
+        "dockerfile": "Dockerfile",
+        "entrypoint": ["python", "/app/server.py"],
+    }
+    image_config[field_name] = field_value
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "image": image_config,
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match=message):
+        get_app_data_from_toml("container-app")
+
+
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
 @patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_rejects_image_without_dockerfile(

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1161,6 +1161,7 @@ def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
             "container-app": {
                 "auth": "public",
                 "machine_type": "GPU-H100",
+                "python_version": "3.12",
                 "exposed_port": 8000,
                 "image": {
                     "dockerfile": "Dockerfile",
@@ -1187,6 +1188,14 @@ def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
     assert toml_data.options.gateway["exposed_port"] == 8000
     assert toml_data.options.environment["kind"] == "container"
     assert dockerfile_str.startswith(dockerfile)
+    assert "python-build-standalone/releases/download/20260510/" in dockerfile_str
+    assert "cpython-3.12.13%2B20260510" in dockerfile_str
+    assert (
+        "sha256:d480f5d5878910ecbae212bf23bd7c25d7b209eb8cf5e98823c977384d272e88"
+        in dockerfile_str
+    )
+    assert "tar -xzf /tmp/fal-python.tar.gz -C /opt/fal" in dockerfile_str
+    assert 'ENV PATH="${PATH}:/opt/fal/python/bin"' in dockerfile_str
     assert "COPY fal-generated-" in dockerfile_str
     assert " /app/fal_entrypoint.py\n" in dockerfile_str
     assert 'ENV PYTHONPATH="/app:${PYTHONPATH}"' in dockerfile_str

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1161,7 +1161,6 @@ def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
             "container-app": {
                 "auth": "public",
                 "machine_type": "GPU-H100",
-                "python_version": "3.12",
                 "exposed_port": 8000,
                 "image": {
                     "dockerfile": "Dockerfile",
@@ -1186,6 +1185,7 @@ def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
     assert toml_data.auth == "public"
     assert toml_data.options.host["machine_type"] == "GPU-H100"
     assert toml_data.options.gateway["exposed_port"] == 8000
+    assert toml_data.options.environment["python_version"] == "3.12"
     assert toml_data.options.environment["kind"] == "container"
     assert dockerfile_str.startswith(dockerfile)
     assert "python-build-standalone/releases/download/20260510/" in dockerfile_str
@@ -1211,6 +1211,37 @@ def test_get_app_data_from_toml_with_image_only_generated_entrypoint(
     assert '_ENTRYPOINT = ["python", "/app/server.py"]' in generated_source
     assert '_CMD = ["--host", "0.0.0.0", "--port", "8000"]' in generated_source
     assert "subprocess.Popen" in generated_source
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_image_only_python_version(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM debian:bookworm-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "python_version": "3.12",
+                "image": {
+                    "dockerfile": "Dockerfile",
+                    "entrypoint": ["/app/server"],
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "App container-app python_version is managed automatically for "
+            "image-only deployments."
+        ),
+    ):
+        get_app_data_from_toml("container-app")
 
 
 @patch("fal.cli._utils.find_pyproject_toml")


### PR DESCRIPTION
## Summary
- Add an image-only pyproject path for container apps with no `ref` and no `python_entry_point`.
- Generate `fal_entrypoint:fal_entry_point` as a wrapper class that launches exec-form `image.entrypoint`/`image.cmd` without importing `fal` inside the user image.
- Inject a pinned Astral `python-build-standalone` runtime for the wrapper path so images do not need to provide Python themselves.
- Append the generated wrapper file, Python runtime wiring, and `PYTHONPATH` setup to the Docker build, with validation around where `entrypoint`/`cmd` are allowed.

## Notes
- The injected runtime is appended to `PATH` instead of prepended so an image's existing Python remains preferred when present.
- This is still a bridge implementation while the backend relies on isolate; direct Docker mode can later skip this runtime injection entirely.

## Testing
- `uv run --python 3.12 --project projects/fal --extra test pytest projects/fal/tests/unit/cli/test_deploy.py projects/fal/tests/unit/cli/test_run.py -q`
- `uvx --python 3.12 pre-commit run --all-files`
- `FAL_PROFILE=falbot PYTHONUNBUFFERED=1 uv run --python 3.12 --project /Users/efiop/.codex/worktrees/c320/fal/projects/fal --extra test fal run --no-cache simple_func` from `efiop/docker_entry_point` using `debian:bookworm-slim`
- `FAL_PROFILE=falbot PYTHONUNBUFFERED=1 uv run --python 3.12 --project /Users/efiop/.codex/worktrees/c320/fal/projects/fal --extra test fal run --no-cache simple_app` from `efiop/docker_entry_point` using `Dockerfile.simple_app`: Rust build stage, final `debian:bookworm-slim` with `RUN ! command -v python && ! command -v python3`, then `curl` the ephemeral endpoint
