### PR TITLE
fix: deflake rollout application e2e test

### DIFF
--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -15,6 +15,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -1428,6 +1429,53 @@ def submit_and_wait_for_runner(app: str, arguments: dict = {}, *, path: str = ""
     return handle
 
 
+_TERMINAL_RUNNER_STATES = {RunnerState.DEAD, RunnerState.TERMINATED}
+
+
+def _non_terminal_runner_ids(runners):
+    return {
+        runner.runner_id
+        for runner in runners
+        if runner.state not in _TERMINAL_RUNNER_STATES
+    }
+
+
+def wait_for_runner_removal(client, app_alias: str, previous_runner_ids: Set[str]):
+    timeout = 20
+    start_time = time.monotonic()
+    last_runners = []
+
+    while time.monotonic() - start_time < timeout:
+        last_runners = client.list_alias_runners(app_alias)
+        runner_ids = _non_terminal_runner_ids(last_runners)
+        if not runner_ids.intersection(previous_runner_ids):
+            return last_runners
+        time.sleep(0.5)
+
+    raise AssertionError(
+        "Timed out waiting for rollout to remove runners "
+        f"{sorted(previous_runner_ids)}. Last runners: {last_runners}"
+    )
+
+
+def wait_for_new_runner(client, app_alias: str, previous_runner_ids: Set[str]):
+    timeout = 20
+    start_time = time.monotonic()
+    last_runners = []
+
+    while time.monotonic() - start_time < timeout:
+        last_runners = client.list_alias_runners(app_alias)
+        runner_ids = _non_terminal_runner_ids(last_runners)
+        if runner_ids and not runner_ids.intersection(previous_runner_ids):
+            return last_runners
+        time.sleep(0.5)
+
+    raise AssertionError(
+        "Timed out waiting for a new runner after rollout "
+        f"{sorted(previous_runner_ids)}. Last runners: {last_runners}"
+    )
+
+
 def test_stop_runner(host: api.FalServerlessHost, test_sleep_app: str):
     # Submit a runner and wait for it to be idle
     submit_and_wait_for_runner(test_sleep_app, arguments={"wait_time": 1})
@@ -1529,7 +1577,7 @@ def test_kill_runner(host: api.FalServerlessHost, test_sleep_app: str):
 
 
 def test_rollout_application(host: api.FalServerlessHost, test_sleep_app: str):
-    handle = apps.submit(test_sleep_app, arguments={"wait_time": 30})
+    handle = apps.submit(test_sleep_app, arguments={"wait_time": 5})
 
     while True:
         status = handle.status()
@@ -1547,22 +1595,17 @@ def test_rollout_application(host: api.FalServerlessHost, test_sleep_app: str):
         runner_id_before = runners_before[0].runner_id
 
         client.rollout_application(app_alias, force=True)
+        wait_for_runner_removal(client, app_alias, {runner_id_before})
+        submit_and_wait_for_runner(test_sleep_app, arguments={"wait_time": 1})
 
-        time.sleep(15)
-
-        runners_after = client.list_alias_runners(app_alias)
-        runner_ids_after = {r.runner_id for r in runners_after}
-
-        assert runner_id_before not in runner_ids_after
+        runners_after = wait_for_new_runner(client, app_alias, {runner_id_before})
+        runner_ids_after = _non_terminal_runner_ids(runners_after)
 
         client.rollout_application(app_alias, force=True)
+        wait_for_runner_removal(client, app_alias, runner_ids_after)
+        submit_and_wait_for_runner(test_sleep_app, arguments={"wait_time": 1})
 
-        time.sleep(3)
-
-        runners_final = client.list_alias_runners(app_alias)
-        runner_ids_final = {r.runner_id for r in runners_final}
-
-        assert not runner_ids_after.intersection(runner_ids_final)
+        wait_for_new_runner(client, app_alias, runner_ids_after)
 
 
 def test_shell_runner(host: api.FalServerlessHost, test_sleep_app: str):


### PR DESCRIPTION
## Summary
- Replace fixed rollout sleeps with polling for non-terminal runner ID rollover.
- Keep the rollout assertion focused on runner replacement while allowing backend async kill/recreate timing.

## Root Cause
Force rollout kills runners asynchronously, so the runner list can still show the previous replacement after a fixed 3 second wait.

## Validation
- `uvx --python 3.11 pre-commit run --all-files`
- `python3 -m py_compile projects/fal/tests/e2e/test_apps.py`
- Commit hook pre-commit checks passed for the staged change.

E2E was not run locally because it requires cloud credentials/network.
