### PR TITLE
feat(cli): support missing pyproject app options

### DIFF
--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -549,6 +549,7 @@ class App(BaseServable):
         "resolver": "uv",
         "keep_alive": 60,
     }
+    _explicit_host_kwargs: ClassVar[set[str]] = set()
     app_name: ClassVar[Optional[str]] = None
     app_auth: ClassVar[Optional[AuthModeLiteral]] = None
     app_files: ClassVar[list[str]] = []
@@ -578,6 +579,14 @@ class App(BaseServable):
     def __init_subclass__(cls, **kwargs):
         app_name = kwargs.pop("name", None) or _to_fal_app_name(cls.__name__)
         parent_settings = getattr(cls, "host_kwargs", {})
+        parent_explicit_host_kwargs: set[str] = getattr(
+            cls, "_explicit_host_kwargs", set()
+        )
+        explicit_host_kwargs = set(parent_explicit_host_kwargs) | set(kwargs)
+        explicit_host_kwargs.update(
+            key for key in parent_settings if key in cls.__dict__
+        )
+        cls._explicit_host_kwargs = explicit_host_kwargs
         cls.host_kwargs = {**parent_settings, **kwargs}
 
         for key in parent_settings.keys():

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, get_args
 
 from fal.api import Options
 from fal.container import ContainerImage
 from fal.project import find_project_root, find_pyproject_toml, parse_pyproject_toml
-from fal.sdk import AuthModeLiteral, DeploymentStrategyLiteral
+from fal.sdk import (
+    ApplicationHealthCheckConfig,
+    AuthModeLiteral,
+    DeploymentStrategyLiteral,
+    RetryConditionLiteral,
+)
 
 VALID_REGIONS = {
     "us-west",
@@ -17,6 +22,7 @@ VALID_REGIONS = {
     "eu-north",
     "eu-west",
 }
+VALID_RETRY_CONDITIONS = set(get_args(RetryConditionLiteral))
 
 
 @dataclass(frozen=True)
@@ -117,6 +123,8 @@ def get_app_data_from_toml(
     scaling_delay = app_data.pop("scaling_delay", None)
     request_timeout = app_data.pop("request_timeout", None)
     startup_timeout = app_data.pop("startup_timeout", None)
+    keep_alive = app_data.pop("keep_alive", None)
+    private_logs = app_data.pop("private_logs", None)
     machine_type = app_data.pop("machine_type", None)
     num_gpus = app_data.pop("num_gpus", None)
     regions = app_data.pop("regions", None)
@@ -124,9 +132,22 @@ def get_app_data_from_toml(
     app_files_ignore = app_data.pop("app_files_ignore", None)
     app_files_context_dir = app_data.pop("app_files_context_dir", None)
     exposed_port = app_data.pop("exposed_port", None)
+    scheduler = app_data.pop("_scheduler", None)
+    scheduler_options = app_data.pop("_scheduler_options", None)
+    skip_retry_conditions = app_data.pop("skip_retry_conditions", None)
+    termination_grace_period_seconds = app_data.pop(
+        "termination_grace_period_seconds", None
+    )
+    secrets = app_data.pop("secrets", None)
+    data_mounts = app_data.pop("data_mounts", None)
+    health_check = app_data.pop("health_check", None)
 
     image_config = app_data.pop("image", None)
 
+    if keep_alive is not None:
+        _validate_int("keep_alive", keep_alive)
+    if private_logs is not None:
+        _validate_bool("private_logs", private_logs)
     if regions is not None:
         _validate_regions(regions)
     if app_files is not None:
@@ -147,6 +168,25 @@ def get_app_data_from_toml(
         _validate_port("exposed_port", exposed_port)
     if image_config is not None and app_files:
         raise ValueError("app_files is not supported for container apps.")
+    if scheduler is not None and not isinstance(scheduler, str):
+        raise ValueError("_scheduler must be a string.")
+    if scheduler_options is not None and not isinstance(scheduler_options, dict):
+        raise ValueError("_scheduler_options must be a table in pyproject.toml.")
+    if skip_retry_conditions is not None:
+        _validate_skip_retry_conditions(skip_retry_conditions)
+    if termination_grace_period_seconds is not None:
+        _validate_int(
+            "termination_grace_period_seconds", termination_grace_period_seconds
+        )
+    if secrets is not None:
+        _validate_str_list("secrets", secrets)
+    if data_mounts is not None:
+        _validate_str_list("data_mounts", data_mounts)
+    health_check_config = None
+    if health_check is not None:
+        health_check_config = _build_health_check_config_from_toml(
+            app_name, health_check
+        )
 
     if min_concurrency is not None:
         options.host["min_concurrency"] = min_concurrency
@@ -164,6 +204,10 @@ def get_app_data_from_toml(
         options.host["request_timeout"] = request_timeout
     if startup_timeout is not None:
         options.host["startup_timeout"] = startup_timeout
+    if keep_alive is not None:
+        options.host["keep_alive"] = keep_alive
+    if private_logs is not None:
+        options.host["private_logs"] = private_logs
     if machine_type is not None:
         options.host["machine_type"] = machine_type
     if num_gpus is not None:
@@ -176,6 +220,22 @@ def get_app_data_from_toml(
         options.host["app_files_ignore"] = app_files_ignore
     if app_files_context_dir is not None:
         options.host["app_files_context_dir"] = app_files_context_dir
+    if scheduler is not None:
+        options.host["_scheduler"] = scheduler
+    if scheduler_options is not None:
+        options.host["_scheduler_options"] = scheduler_options
+    if skip_retry_conditions is not None:
+        options.host["skip_retry_conditions"] = skip_retry_conditions
+    if termination_grace_period_seconds is not None:
+        options.host["termination_grace_period_seconds"] = (
+            termination_grace_period_seconds
+        )
+    if secrets is not None:
+        options.host["secrets"] = secrets
+    if data_mounts is not None:
+        options.host["data_mounts"] = data_mounts
+    if health_check_config is not None:
+        options.host["health_check_config"] = health_check_config
     if exposed_port is not None:
         options.gateway["exposed_port"] = exposed_port
     if requirements is not None:
@@ -249,11 +309,80 @@ def _validate_str_list(field_name: str, value: Any) -> None:
         raise ValueError(f"{field_name} must be a list of strings.")
 
 
+def _validate_int(field_name: str, value: Any) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer.")
+
+
+def _validate_bool(field_name: str, value: Any) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a boolean.")
+
+
+def _validate_skip_retry_conditions(value: Any) -> None:
+    _validate_str_list("skip_retry_conditions", value)
+    invalid_conditions = set(value) - VALID_RETRY_CONDITIONS
+    if invalid_conditions:
+        raise ValueError(
+            "Invalid skip_retry_conditions: "
+            f"{', '.join(sorted(invalid_conditions))}. "
+            "Valid conditions are: "
+            f"{', '.join(sorted(VALID_RETRY_CONDITIONS))}"
+        )
+
+
 def _validate_port(field_name: str, value: Any) -> None:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(f"{field_name} must be an integer.")
     if value < 0 or value > 65535:
         raise ValueError(f"{field_name} must be between 0 and 65535.")
+
+
+def _build_health_check_config_from_toml(
+    app_name: str, health_check: Any
+) -> ApplicationHealthCheckConfig:
+    if not isinstance(health_check, dict):
+        raise ValueError(
+            f"App {app_name} health_check must be a table in pyproject.toml"
+        )
+
+    health_check = dict(health_check)
+    path = health_check.pop("path", None)
+    if path is None:
+        raise ValueError(
+            f"App {app_name} health_check must specify 'path' in pyproject.toml"
+        )
+    if not isinstance(path, str):
+        raise ValueError(
+            f"App {app_name} health_check.path must be a string in pyproject.toml"
+        )
+
+    start_period_seconds = health_check.pop("start_period_seconds", None)
+    timeout_seconds = health_check.pop("timeout_seconds", None)
+    failure_threshold = health_check.pop("failure_threshold", None)
+    call_regularly = health_check.pop("call_regularly", None)
+
+    if start_period_seconds is not None:
+        _validate_int("health_check.start_period_seconds", start_period_seconds)
+    if timeout_seconds is not None:
+        _validate_int("health_check.timeout_seconds", timeout_seconds)
+    if failure_threshold is not None:
+        _validate_int("health_check.failure_threshold", failure_threshold)
+    if call_regularly is not None:
+        _validate_bool("health_check.call_regularly", call_regularly)
+
+    if health_check:
+        raise ValueError(
+            f"Found unexpected keys in app {app_name} health_check: {health_check}"
+        )
+
+    return ApplicationHealthCheckConfig(
+        path=path,
+        start_period_seconds=start_period_seconds,
+        timeout_seconds=timeout_seconds,
+        failure_threshold=failure_threshold,
+        call_regularly=call_regularly,
+    )
 
 
 _IMAGE_PASSTHROUGH_KEYS = (

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -144,10 +144,6 @@ def get_app_data_from_toml(
 
     image_config = app_data.pop("image", None)
 
-    if keep_alive is not None:
-        _validate_int("keep_alive", keep_alive)
-    if private_logs is not None:
-        _validate_bool("private_logs", private_logs)
     if regions is not None:
         _validate_regions(regions)
     if app_files is not None:
@@ -168,8 +164,12 @@ def get_app_data_from_toml(
         _validate_port("exposed_port", exposed_port)
     if image_config is not None and app_files:
         raise ValueError("app_files is not supported for container apps.")
-    if scheduler is not None and not isinstance(scheduler, str):
-        raise ValueError("_scheduler must be a string.")
+    if keep_alive is not None:
+        _validate_int("keep_alive", keep_alive)
+    if private_logs is not None:
+        _validate_bool("private_logs", private_logs)
+    if scheduler is not None and not (isinstance(scheduler, str) and scheduler):
+        raise ValueError("_scheduler must be a non-empty string.")
     if scheduler_options is not None and not isinstance(scheduler_options, dict):
         raise ValueError("_scheduler_options must be a table in pyproject.toml.")
     if skip_retry_conditions is not None:
@@ -332,8 +332,7 @@ def _validate_skip_retry_conditions(value: Any) -> None:
 
 
 def _validate_port(field_name: str, value: Any) -> None:
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError(f"{field_name} must be an integer.")
+    _validate_int(field_name, value)
     if value < 0 or value > 65535:
         raise ValueError(f"{field_name} must be between 0 and 65535.")
 
@@ -346,8 +345,8 @@ def _build_health_check_config_from_toml(
             f"App {app_name} health_check must be a table in pyproject.toml"
         )
 
-    health_check = dict(health_check)
-    path = health_check.pop("path", None)
+    health_check_data = dict(health_check)
+    path = health_check_data.pop("path", None)
     if path is None:
         raise ValueError(
             f"App {app_name} health_check must specify 'path' in pyproject.toml"
@@ -357,10 +356,10 @@ def _build_health_check_config_from_toml(
             f"App {app_name} health_check.path must be a string in pyproject.toml"
         )
 
-    start_period_seconds = health_check.pop("start_period_seconds", None)
-    timeout_seconds = health_check.pop("timeout_seconds", None)
-    failure_threshold = health_check.pop("failure_threshold", None)
-    call_regularly = health_check.pop("call_regularly", None)
+    start_period_seconds = health_check_data.pop("start_period_seconds", None)
+    timeout_seconds = health_check_data.pop("timeout_seconds", None)
+    failure_threshold = health_check_data.pop("failure_threshold", None)
+    call_regularly = health_check_data.pop("call_regularly", None)
 
     if start_period_seconds is not None:
         _validate_int("health_check.start_period_seconds", start_period_seconds)
@@ -371,9 +370,9 @@ def _build_health_check_config_from_toml(
     if call_regularly is not None:
         _validate_bool("health_check.call_regularly", call_regularly)
 
-    if health_check:
+    if health_check_data:
         raise ValueError(
-            f"Found unexpected keys in app {app_name} health_check: {health_check}"
+            f"Found unexpected keys in app {app_name} health_check: {health_check_data}"
         )
 
     return ApplicationHealthCheckConfig(
@@ -388,6 +387,7 @@ def _build_health_check_config_from_toml(
 _IMAGE_PASSTHROUGH_KEYS = (
     "build_args",
     "registries",
+    # Image build-time secrets, distinct from app-level runtime `secrets`.
     "secrets",
 )
 

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -289,6 +289,8 @@ def _toml_host_keys_overriding_app_defaults(
 def _is_app_default_host_option(
     app_cls: type[App], base_app_cls: type[App], key: str
 ) -> bool:
+    if key in getattr(app_cls, "_explicit_host_kwargs", set()):
+        return False
     if key in app_cls.__dict__:
         return False
 

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -162,6 +162,7 @@ def load_function_from(
         source_code = f.read()
 
     wrapped_app = False
+    toml_host_overrides: set[str] = set()
     if isinstance(target, type) and issubclass(target, App):
         # ``App.__init_subclass__`` enforces ``image``/``app_files`` exclusivity
         # at class-definition time, but ``image`` can also arrive from
@@ -174,6 +175,9 @@ def load_function_from(
         ):
             raise FalServerlessError("app_files is not supported for container apps.")
         _apply_toml_app_file_options(target, options)
+        toml_host_overrides = _toml_host_keys_overriding_app_defaults(
+            target, App, options
+        )
         target = wrap_app(
             target,
             host=host,
@@ -187,7 +191,7 @@ def load_function_from(
             f"Function '{function_name}' is not a fal.function or a fal.App"
         )
     if options is not None:
-        _merge_options(target.options, options)
+        _merge_options(target.options, options, overwrite_host_keys=toml_host_overrides)
         if wrapped_app and options.gateway.get("exposed_port") is not None:
             target.options.gateway["exposed_port"] = options.gateway["exposed_port"]
 
@@ -266,7 +270,56 @@ def _load_from_python_entry_point(
     )
 
 
-def _merge_options(target: Options, incoming: Options) -> None:
-    merge_basic_config(target.host, incoming.host)
+_MISSING = object()
+
+
+def _toml_host_keys_overriding_app_defaults(
+    app_cls: type[App], base_app_cls: type[App], options: Optional[Options]
+) -> set[str]:
+    if options is None:
+        return set()
+
+    override_keys = set()
+    for key in options.host:
+        if _is_app_default_host_option(app_cls, base_app_cls, key):
+            override_keys.add(key)
+    return override_keys
+
+
+def _is_app_default_host_option(
+    app_cls: type[App], base_app_cls: type[App], key: str
+) -> bool:
+    if key in app_cls.__dict__:
+        return False
+
+    current_host_value = app_cls.host_kwargs.get(key, _MISSING)
+    if current_host_value is not _MISSING:
+        if current_host_value is None:
+            return True
+        default_host_value = base_app_cls.host_kwargs.get(key, _MISSING)
+        return (
+            default_host_value is not _MISSING
+            and current_host_value == default_host_value
+        )
+
+    if hasattr(base_app_cls, key):
+        return getattr(app_cls, key) == getattr(base_app_cls, key)
+
+    return False
+
+
+def _merge_options(
+    target: Options, incoming: Options, *, overwrite_host_keys: set[str] | None = None
+) -> None:
+    _merge_host_config(target.host, incoming.host, overwrite_host_keys or set())
     merge_basic_config(target.environment, incoming.environment)
     merge_basic_config(target.gateway, incoming.gateway)
+
+
+def _merge_host_config(
+    target: dict[str, object], incoming: dict[str, object], overwrite_keys: set[str]
+) -> None:
+    for key, value in incoming.items():
+        if key in target and key not in overwrite_keys:
+            continue
+        target[key] = value

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1164,13 +1164,12 @@ def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(
         get_app_data_from_toml("my-app")
 
 
-@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
-@patch("fal.cli._utils.parse_pyproject_toml")
 @pytest.mark.parametrize(
     ("field_name", "value", "message"),
     [
         ("keep_alive", True, "keep_alive must be an integer."),
         ("private_logs", "yes", "private_logs must be a boolean."),
+        ("_scheduler", "", "_scheduler must be a non-empty string."),
         ("_scheduler_options", "nomad", "_scheduler_options must be a table"),
         ("secrets", "OPENAI_API_KEY", "secrets must be a list of strings."),
         ("data_mounts", ["/data", 1], "data_mounts must be a list of strings."),
@@ -1186,6 +1185,8 @@ def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(
         ),
     ],
 )
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
 def test_get_app_data_from_toml_rejects_invalid_advanced_runtime_options(
     mock_parse_toml, mock_find_toml, field_name, value, message
 ):

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -21,7 +21,7 @@ from fal.cli.deploy_check import (
 )
 from fal.cli.main import parse_args
 from fal.project import find_project_root
-from fal.sdk import AliasInfo
+from fal.sdk import AliasInfo, ApplicationHealthCheckConfig
 
 
 def test_deploy():
@@ -155,6 +155,28 @@ def mock_parse_pyproject_toml():
                 "app_files": ["assets", "config.yaml"],
                 "app_files_ignore": [r"\\.venv/"],
                 "app_files_context_dir": ".",
+            },
+            "advanced-options-app": {
+                "ref": "src/advanced_options/inference.py::AdvancedOptionsApp",
+                "keep_alive": 300,
+                "private_logs": True,
+                "_scheduler": "nomad",
+                "_scheduler_options": {"storage_region": "us-east"},
+                "skip_retry_conditions": [
+                    "timeout",
+                    "server_error",
+                    "connection_error",
+                ],
+                "termination_grace_period_seconds": 30,
+                "secrets": ["OPENAI_API_KEY", "HF_TOKEN"],
+                "data_mounts": ["/data", "/data/.cache"],
+                "health_check": {
+                    "path": "/health",
+                    "start_period_seconds": 30,
+                    "timeout_seconds": 5,
+                    "failure_threshold": 3,
+                    "call_regularly": True,
+                },
             },
             "app-with-extras": {
                 "ref": "src/app_with_extras/inference.py::AppWithExtras",
@@ -1010,8 +1032,7 @@ def test_get_app_data_from_toml_rejects_non_string_python_version(
     with pytest.raises(
         ValueError,
         match=(
-            "App python-version-app python_version must be a string "
-            "in pyproject.toml"
+            "App python-version-app python_version must be a string in pyproject.toml"
         ),
     ):
         get_app_data_from_toml("python-version-app")
@@ -1038,6 +1059,40 @@ def test_get_app_data_from_toml_with_app_files(
         "app_files_context_dir": ".",
     }
     assert toml_data.options.environment == {}
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_advanced_runtime_options(
+    mock_parse_toml, mock_find_toml, mock_parse_pyproject_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = mock_parse_pyproject_toml
+
+    toml_data = get_app_data_from_toml("advanced-options-app")
+
+    assert toml_data.options.host == {
+        "keep_alive": 300,
+        "private_logs": True,
+        "_scheduler": "nomad",
+        "_scheduler_options": {"storage_region": "us-east"},
+        "skip_retry_conditions": [
+            "timeout",
+            "server_error",
+            "connection_error",
+        ],
+        "termination_grace_period_seconds": 30,
+        "secrets": ["OPENAI_API_KEY", "HF_TOKEN"],
+        "data_mounts": ["/data", "/data/.cache"],
+        "health_check_config": ApplicationHealthCheckConfig(
+            path="/health",
+            start_period_seconds=30,
+            timeout_seconds=5,
+            failure_threshold=3,
+            call_regularly=True,
+        ),
+    }
 
 
 @patch("fal.cli._utils.find_pyproject_toml")
@@ -1105,6 +1160,72 @@ def test_get_app_data_from_toml_rejects_app_files_context_dir_without_app_files(
     with pytest.raises(
         ValueError,
         match="app_files_context_dir is only supported when app_files is provided.",
+    ):
+        get_app_data_from_toml("my-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@pytest.mark.parametrize(
+    ("field_name", "value", "message"),
+    [
+        ("keep_alive", True, "keep_alive must be an integer."),
+        ("private_logs", "yes", "private_logs must be a boolean."),
+        ("_scheduler_options", "nomad", "_scheduler_options must be a table"),
+        ("secrets", "OPENAI_API_KEY", "secrets must be a list of strings."),
+        ("data_mounts", ["/data", 1], "data_mounts must be a list of strings."),
+        (
+            "skip_retry_conditions",
+            ["client_error"],
+            "Invalid skip_retry_conditions: client_error.",
+        ),
+        (
+            "termination_grace_period_seconds",
+            "30",
+            "termination_grace_period_seconds must be an integer.",
+        ),
+    ],
+)
+def test_get_app_data_from_toml_rejects_invalid_advanced_runtime_options(
+    mock_parse_toml, mock_find_toml, field_name, value, message
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "my-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                field_name: value,
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match=message):
+        get_app_data_from_toml("my-app")
+
+
+@patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_invalid_health_check(
+    mock_parse_toml, mock_find_toml
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_parse_toml.return_value = {
+        "apps": {
+            "my-app": {
+                "ref": "src/my_app/inference.py::MyApp",
+                "health_check": {
+                    "path": "/health",
+                    "timeout_seconds": "5",
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="health_check.timeout_seconds must be an integer.",
     ):
         get_app_data_from_toml("my-app")
 

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ import fal
 from fal.api import IsolatedFunction, Options
 from fal.api.api import merge_basic_config
 from fal.api.client import SyncServerlessClient
+from fal.sdk import ApplicationHealthCheckConfig
 from fal.utils import (
     _find_target,
     _parse_python_entry_point,
@@ -187,6 +188,83 @@ def test_load_function_from_applies_toml_exposed_port_for_fal_app(tmp_path):
     loaded = load_function_from(host, str(app_file), "MyApp", options=options)
 
     assert loaded.function.options.gateway["exposed_port"] == 9000
+
+
+def test_load_function_from_applies_toml_host_options_over_app_defaults(tmp_path):
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    health_check_config = ApplicationHealthCheckConfig(
+        path="/ready",
+        start_period_seconds=30,
+        timeout_seconds=5,
+        failure_threshold=3,
+        call_regularly=True,
+    )
+    options = Options(
+        host={
+            "keep_alive": 123,
+            "_scheduler_options": {"storage_region": "eu-west"},
+            "health_check_config": health_check_config,
+        }
+    )
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.host["keep_alive"] == 123
+    assert loaded.function.options.host["_scheduler_options"] == {
+        "storage_region": "eu-west"
+    }
+    assert loaded.function.options.host["health_check_config"] == health_check_config
+
+
+def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_path):
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App, keep_alive=77):\n"
+        "    _scheduler_options = {'storage_region': 'class'}\n"
+        "\n"
+        "    @fal.endpoint('/', health_check=fal.HealthCheck(timeout_seconds=9))\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(
+        host={
+            "keep_alive": 123,
+            "_scheduler_options": {"storage_region": "toml"},
+            "health_check_config": ApplicationHealthCheckConfig(
+                path="/ready",
+                start_period_seconds=30,
+                timeout_seconds=5,
+                failure_threshold=3,
+                call_regularly=True,
+            ),
+        }
+    )
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+    health_check_config = loaded.function.options.host["health_check_config"]
+
+    assert loaded.function.options.host["keep_alive"] == 77
+    assert loaded.function.options.host["_scheduler_options"] == {
+        "storage_region": "class"
+    }
+    assert health_check_config.path == "/"
+    assert health_check_config.timeout_seconds == 9
 
 
 def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -232,8 +232,12 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
     app_file.write_text(
         "import fal\n"
         "\n"
-        "class MyApp(fal.App, keep_alive=77):\n"
-        "    _scheduler_options = {'storage_region': 'class'}\n"
+        "class MyApp(\n"
+        "    fal.App,\n"
+        "    keep_alive=60,\n"
+        "    _scheduler='nomad',\n"
+        "    _scheduler_options={'storage_region': 'us-east'},\n"
+        "):\n"
         "\n"
         "    @fal.endpoint('/', health_check=fal.HealthCheck(timeout_seconds=9))\n"
         "    def run(self):\n"
@@ -245,6 +249,7 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
     options = Options(
         host={
             "keep_alive": 123,
+            "_scheduler": "kubernetes",
             "_scheduler_options": {"storage_region": "toml"},
             "health_check_config": ApplicationHealthCheckConfig(
                 path="/ready",
@@ -259,9 +264,10 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
     loaded = load_function_from(host, str(app_file), "MyApp", options=options)
     health_check_config = loaded.function.options.host["health_check_config"]
 
-    assert loaded.function.options.host["keep_alive"] == 77
+    assert loaded.function.options.host["keep_alive"] == 60
+    assert loaded.function.options.host["_scheduler"] == "nomad"
     assert loaded.function.options.host["_scheduler_options"] == {
-        "storage_region": "class"
+        "storage_region": "us-east"
     }
     assert health_check_config.path == "/"
     assert health_check_config.timeout_seconds == 9


### PR DESCRIPTION
## Summary
- Add pyproject.toml support for advanced fal app runtime options: keep_alive, runtime secrets, data mounts, private_logs, scheduler options, retry skip conditions, termination grace period, and health checks.
- Map [tool.fal.apps.<name>.health_check] to the existing ApplicationHealthCheckConfig path.
- Let pyproject host settings override inherited fal.App defaults while preserving options explicitly set in code.