### PR TITLE
fix: set short lifecycle for sdist uploads

### DIFF
--- a/projects/fal/src/fal/api/_sdist.py
+++ b/projects/fal/src/fal/api/_sdist.py
@@ -18,7 +18,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import threading
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -31,10 +30,8 @@ from fal.project import _load_toml
 #   "build_started"  -> {"package_name": str, "project_root": Path}
 #   "build_finished" -> {"sdist_path": Path, "sdist_size": int}
 #   "upload_started" -> {"sdist_path": Path, "sdist_size": int}
-#   "upload_finished"-> {"url": str, "cached": bool, "sdist_size": int | None}
+#   "upload_finished"-> {"url": str, "sdist_size": int}
 #
-# Only the upload_finished event fires on a cache hit; in that case
-# ``cached`` is True and ``sdist_size`` is None (no upload happened).
 # Callers are free to ignore unknown events. Keeping the contract loose so
 # we can add phases later without breaking integrations.
 ProgressCallback = Callable[[str, dict], None]
@@ -43,24 +40,7 @@ ProgressCallback = Callable[[str, dict], None]
 # ``-e .``, ``file://...``) are intentionally left alone.
 _LOCAL_PATH_RE = re.compile(r"^\.(\[[^\]]+\])?$")
 
-# In-process cache to avoid re-building/re-uploading the sdist on every
-# dispatch within a single ``fal run``/``fal deploy`` invocation. Keyed by
-# resolved project root path. The user's source tree isn't expected to change
-# mid-invocation; a fresh process re-runs the build either way, so this cache
-# tradeoff matches user expectation ("I ran fal once, it packaged once").
-#
-# Note: hashing the sdist content would be more conservative but doesn't help
-# in practice — ``python -m build`` is non-deterministic (file mtimes inside
-# the tarball drift between back-to-back builds), so a content-hash cache
-# misses on every call.
-_SDIST_URL_CACHE: dict[str, tuple[str, str]] = {}
-# Global lock serializing the build+upload sequence across the whole
-# process. A finer per-root lock would let independent projects build
-# in parallel, but the realistic concurrent shape today is at most one
-# project per ``fal run``/``fal deploy`` invocation, so a single lock
-# keeps the implementation simple. The trade-off: two threads packaging
-# *different* roots in the same process will serialize.
-_SDIST_URL_CACHE_LOCK = threading.Lock()
+EXPIRATION_DURATION_SECONDS = 60 * 60
 
 Requirements = Union[List[str], List[List[str]]]
 
@@ -85,10 +65,8 @@ def materialize_local_paths(
 ) -> Requirements:
     """Rewrite ``.``/``.[extras]`` entries to ``<package> @ <url>``.
 
-    Builds an sdist of ``project_root`` once per project root per process and
-    uploads it to the fal CDN via ``fal.toolkit.File.from_path``; subsequent
-    calls within the same process reuse the cached URL. No-op when no
-    local-path entry is present.
+    Builds an sdist of ``project_root`` and uploads it to the fal CDN via
+    ``fal.toolkit.File.from_path``. No-op when no local-path entry is present.
 
     Preserves the input shape (flat list vs layered list-of-lists).
 
@@ -133,33 +111,19 @@ def _resolve_sdist_url(
         if on_progress is not None:
             on_progress(event, payload)
 
-    cache_key = str(project_root.resolve())
+    package_name = _read_package_name(project_root)
+    _emit("build_started", package_name=package_name, project_root=project_root)
+    sdist = _build_sdist(project_root)
+    try:
+        sdist_size = sdist.stat().st_size
+        _emit("build_finished", sdist_path=sdist, sdist_size=sdist_size)
 
-    # Hold the lock for the entire check-build-upload-populate sequence so
-    # a concurrent dispatch waits and re-uses the populated entry instead
-    # of running its own build + upload in parallel. See the comment on
-    # ``_SDIST_URL_CACHE_LOCK`` for the cross-root serialization caveat.
-    with _SDIST_URL_CACHE_LOCK:
-        cached = _SDIST_URL_CACHE.get(cache_key)
-        if cached is not None:
-            package_name, url = cached
-            _emit("upload_finished", url=url, cached=True, sdist_size=None)
-            return package_name, url
-
-        package_name = _read_package_name(project_root)
-        _emit("build_started", package_name=package_name, project_root=project_root)
-        sdist = _build_sdist(project_root)
-        try:
-            sdist_size = sdist.stat().st_size
-            _emit("build_finished", sdist_path=sdist, sdist_size=sdist_size)
-
-            _emit("upload_started", sdist_path=sdist, sdist_size=sdist_size)
-            url = _upload_sdist(sdist)
-            _SDIST_URL_CACHE[cache_key] = (package_name, url)
-            _emit("upload_finished", url=url, sdist_size=sdist_size, cached=False)
-        finally:
-            shutil.rmtree(sdist.parent, ignore_errors=True)
-        return package_name, url
+        _emit("upload_started", sdist_path=sdist, sdist_size=sdist_size)
+        url = _upload_sdist(sdist)
+        _emit("upload_finished", url=url, sdist_size=sdist_size)
+    finally:
+        shutil.rmtree(sdist.parent, ignore_errors=True)
+    return package_name, url
 
 
 def _read_package_name(project_root: Path) -> str:
@@ -237,5 +201,14 @@ def _build_sdist(project_root: Path) -> Path:
 def _upload_sdist(sdist_path: Path) -> str:
     from fal.toolkit import File  # noqa: PLC0415
 
-    file = File.from_path(sdist_path)
+    save_kwargs = {
+        "object_lifecycle_preference": {
+            "expiration_duration_seconds": EXPIRATION_DURATION_SECONDS
+        }
+    }
+    file = File.from_path(
+        sdist_path,
+        save_kwargs=save_kwargs,
+        fallback_save_kwargs=save_kwargs,
+    )
     return file.url

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -886,15 +886,13 @@ class FalServerlessHost(Host):
                 console.print(
                     f"Uploading {payload['sdist_path'].name} ({size_kb:.1f} KB)..."
                 )
-            elif event == "upload_finished" and not payload["cached"]:
+            elif event == "upload_finished":
                 print_rule(console, style="dim")
                 console.print(f"{check_icon} Project packaged", style="bold green")
                 console.print("")
             # ``build_finished`` has no host-side rendering: the live
             # ``python -m build`` output between the rules already tells the
-            # user the build is done. Cached ``upload_finished`` is also
-            # silent — the user saw the original packaging output once;
-            # repeating it on every dispatch is noise.
+            # user the build is done.
 
         environment_options["requirements"] = materialize_local_paths(
             requirements, self.local_project_root, on_progress=_on_progress

--- a/projects/fal/tests/unit/test_sdist.py
+++ b/projects/fal/tests/unit/test_sdist.py
@@ -10,13 +10,6 @@ import pytest
 from fal.api import _sdist
 
 
-@pytest.fixture(autouse=True)
-def _clear_cache():
-    _sdist._SDIST_URL_CACHE.clear()
-    yield
-    _sdist._SDIST_URL_CACHE.clear()
-
-
 @pytest.mark.parametrize(
     "req,expected",
     [
@@ -120,29 +113,31 @@ def test_materialize_preserves_layered_shape(tmp_path):
     assert out == [["fal"], ["simple @ https://cdn/simple.tgz", "numpy"]]
 
 
-def test_materialize_caches_by_project_root(tmp_path):
-    """Subsequent calls for the same project root skip both build and upload.
-
-    Within a single process, ``_resolve_sdist_url`` short-circuits on the
-    cached ``(package_name, url)`` rather than re-running ``python -m build``.
-    """
+def test_materialize_reuploads_each_time(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text('[project]\nname = "simple"\nversion = "0.1.0"\n')
 
-    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
-    fake_sdist.parent.mkdir()
-    fake_sdist.write_bytes(b"sdist-bytes")
+    build_count = 0
 
-    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist) as build, patch(
-        "fal.api._sdist._upload_sdist", return_value="https://cdn/simple.tgz"
+    def build_sdist(_project_root):
+        nonlocal build_count
+        build_count += 1
+        fake_sdist = tmp_path / f"build_out_{build_count}" / "simple-0.1.0.tar.gz"
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"sdist-bytes")
+        return fake_sdist
+
+    with patch.object(_sdist, "_build_sdist", side_effect=build_sdist) as build, patch(
+        "fal.api._sdist._upload_sdist",
+        side_effect=["https://cdn/simple-1.tgz", "https://cdn/simple-2.tgz"],
     ) as upload:
         first = _sdist.materialize_local_paths([".[func]"], tmp_path)
         second = _sdist.materialize_local_paths([".[app]"], tmp_path)
 
-    assert first == ["simple[func] @ https://cdn/simple.tgz"]
-    assert second == ["simple[app] @ https://cdn/simple.tgz"]
-    assert build.call_count == 1  # second call short-circuits on cache
-    assert upload.call_count == 1
+    assert first == ["simple[func] @ https://cdn/simple-1.tgz"]
+    assert second == ["simple[app] @ https://cdn/simple-2.tgz"]
+    assert build.call_count == 2
+    assert upload.call_count == 2
 
 
 def test_materialize_progress_events(tmp_path):
@@ -172,19 +167,26 @@ def test_materialize_progress_events(tmp_path):
     ]
     assert events[0][1]["package_name"] == "simple"
     assert events[3][1]["url"] == "https://cdn/simple.tgz"
-    assert events[3][1]["cached"] is False
+    assert "cached" not in events[3][1]
 
 
-def test_materialize_progress_emits_cached_on_second_call(tmp_path):
+def test_materialize_progress_repeats_after_previous_call(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text('[project]\nname = "simple"\nversion = "0.1.0"\n')
 
-    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
-    fake_sdist.parent.mkdir()
-    fake_sdist.write_bytes(b"x")
+    build_count = 0
 
-    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist), patch(
-        "fal.api._sdist._upload_sdist", return_value="https://cdn/simple.tgz"
+    def build_sdist(_project_root):
+        nonlocal build_count
+        build_count += 1
+        fake_sdist = tmp_path / f"build_out_{build_count}" / "simple-0.1.0.tar.gz"
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"x")
+        return fake_sdist
+
+    with patch.object(_sdist, "_build_sdist", side_effect=build_sdist), patch(
+        "fal.api._sdist._upload_sdist",
+        side_effect=["https://cdn/simple-1.tgz", "https://cdn/simple-2.tgz"],
     ):
         _sdist.materialize_local_paths([".[func]"], tmp_path)
         events: list[tuple[str, dict]] = []
@@ -192,8 +194,30 @@ def test_materialize_progress_emits_cached_on_second_call(tmp_path):
             [".[app]"], tmp_path, on_progress=lambda e, p: events.append((e, p))
         )
 
-    assert events == [("upload_finished", events[0][1])]
-    assert events[0][1]["cached"] is True
+    assert [name for name, _ in events] == [
+        "build_started",
+        "build_finished",
+        "upload_started",
+        "upload_finished",
+    ]
+    assert events[3][1]["url"] == "https://cdn/simple-2.tgz"
+
+
+def test_upload_sdist_uses_one_hour_lifecycle_for_primary_and_fallback(tmp_path):
+    sdist = tmp_path / "simple-0.1.0.tar.gz"
+    sdist.write_bytes(b"sdist")
+    uploaded_file = type("UploadedFile", (), {"url": "https://cdn/simple.tgz"})()
+
+    with patch("fal.toolkit.File.from_path", return_value=uploaded_file) as from_path:
+        url = _sdist._upload_sdist(sdist)
+
+    assert url == "https://cdn/simple.tgz"
+    from_path.assert_called_once()
+    _, kwargs = from_path.call_args
+    expected = {"expiration_duration_seconds": 3600}
+    assert kwargs["save_kwargs"]["object_lifecycle_preference"] == expected
+    assert kwargs["fallback_save_kwargs"]["object_lifecycle_preference"] == expected
+    assert kwargs["save_kwargs"] is kwargs["fallback_save_kwargs"]
 
 
 def test_read_package_name_missing_pyproject(tmp_path):


### PR DESCRIPTION
## Summary

- Upload locally built fal sdists with an explicit 1-hour CDN lifecycle preference.
- Apply the preference to both the primary repository and fallback upload path.
- Drop the in-process sdist URL cache so later calls do not reuse an expired CDN object.
- Add unit coverage for the lifecycle kwargs and repeated reupload behavior.

## Why

These uploaded sdists are only needed long enough for the worker environment install, so keeping them around longer than roughly an hour is unnecessary.

The previous in-process URL cache is not really used in practice right now, and once this PR introduces a short CDN TTL it becomes harder to keep correct: a long-lived process could reuse a cached URL after the object expires. Reuploading is simpler and avoids stale install URLs.

## Validation

- `uv run --project projects/fal --extra test pytest -q projects/fal/tests/unit/test_sdist.py`
- `uv run --python 3.11 --with pre-commit pre-commit run --all-files`
