### PR TITLE
feat(cli): allow image-only app references

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -465,6 +465,25 @@ class UserFunctionException(FalServerlessException):
     pass
 
 
+def _image_uses_isolate(options: Options) -> bool:
+    if options.environment.get("kind") != "container":
+        return True
+
+    image = options.environment.get("image")
+    if not isinstance(image, dict):
+        return True
+
+    return image.get("use_isolate", True) is not False
+
+
+def _uses_isolate(
+    func: Callable[..., Any] | None,
+    entrypoint: str | None,
+    options: Options,
+) -> bool:
+    return func is not None or entrypoint is not None or _image_uses_isolate(options)
+
+
 @dataclass(frozen=True)
 class FunctionRuntimeConfig:
     app_files_relative_path: str | None = None
@@ -1007,7 +1026,11 @@ class FalServerlessHost(Host):
 
         files = self.files_sync(FileSyncOptions.from_options(options))
 
-        if func is None and entrypoint is None:
+        if (
+            func is None
+            and entrypoint is None
+            and _uses_isolate(func, entrypoint, options)
+        ):
             raise FalServerlessError(
                 "register requires either a func or an entrypoint."
             )
@@ -1130,7 +1153,11 @@ class FalServerlessHost(Host):
         return_value = _UNSET
         # Allow isolate provided arguments (such as setup function) to take
         # precedence over the ones provided by the user.
-        if func is None and entrypoint is None:
+        if (
+            func is None
+            and entrypoint is None
+            and _uses_isolate(func, entrypoint, options)
+        ):
             raise FalServerlessError("_run requires either a func or an entrypoint.")
         if func is not None and entrypoint is not None:
             raise FalServerlessError(
@@ -2349,9 +2376,18 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     _entrypoint_exposed_port_defaulted: bool = False
 
     def __post_init__(self) -> None:
-        if self.raw_func is None and self.entrypoint is None:
+        if (
+            self.raw_func is None
+            and self.entrypoint is None
+            and _uses_isolate(
+                self.raw_func,
+                self.entrypoint,
+                self.options,
+            )
+        ):
             raise FalServerlessError(
-                "IsolatedFunction requires either raw_func or entrypoint."
+                "IsolatedFunction requires raw_func or entrypoint unless a "
+                "container environment is provided."
             )
 
     def __getstate__(self) -> dict[str, Any]:

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Optional
 
 from fal.sdk import AuthModeLiteral, DeploymentStrategyLiteral
 
+from .api import _uses_isolate
+
 if TYPE_CHECKING:
     from openapi_fal_rest.client import Client
 
@@ -138,9 +140,10 @@ def _resolve_deployment_reference(
         assert resolved_app_name is not None
 
         app_data = get_app_data_from_toml(resolved_app_name)
-        if app_data.python_entry_point is not None:
+        if app_data.python_entry_point is not None or app_data.ref is None:
+            # python_entry_point is resolved by the loader; ref is None for
+            # image-only apps.
             return (None, None), app_data
-        assert app_data.ref is not None
         file_path, func_name = RefAction.split_ref(app_data.ref)
         return (file_path, func_name), app_data
 
@@ -163,7 +166,11 @@ def _prepare_deployment_from_reference(
     from fal.utils import load_function_from
 
     file_path, func_name = app_ref
-    if app_data.python_entry_point is None and file_path is None:
+    if (
+        app_data.python_entry_point is None
+        and file_path is None
+        and _uses_isolate(None, None, app_data.options)
+    ):
         # Try to find a python file in the current directory
         options = list(Path(".").glob("*.py"))
         if len(options) == 0:
@@ -246,8 +253,6 @@ def _execute_loaded_deployment(
 
     # Explicit build phase so the CLI / caller gets a clean "build → deploy"
     # split instead of inferring it from the log stream's source field.
-    # Downstream steps then assert `build_environment=False` to skip re-doing
-    # the build in their own RPC.
     host.build_environment(
         isolated_function.options,
         application_name=loaded.app_name,

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -72,6 +72,8 @@ def get_app_data_from_toml(
     except KeyError:
         raise ValueError(f"App {app_name} not found in pyproject.toml")
 
+    image_config = app_data.pop("image", None)
+
     python_entry_point: str | None = app_data.pop("python_entry_point", None)
     if python_entry_point is not None:
         if not isinstance(python_entry_point, str):
@@ -84,18 +86,21 @@ def get_app_data_from_toml(
                 f"App {app_name} cannot have both ref "
                 "and python_entry_point keys in pyproject.toml"
             )
+        # python_entry_point can be paired with image: the symbol is resolved
+        # inside the custom container image instead of local source.
     else:
-        try:
-            app_ref = app_data.pop("ref")
-        except KeyError:
-            raise ValueError(
-                f"App {app_name} does not have a ref key in pyproject.toml"
-            )
-        if not isinstance(app_ref, str):
+        app_ref = app_data.pop("ref", None)
+        if app_ref is None:
+            if image_config is None:
+                raise ValueError(
+                    f"App {app_name} does not have a ref key in pyproject.toml"
+                )
+        elif not isinstance(app_ref, str):
             raise ValueError(f"App {app_name} ref must be a string in pyproject.toml")
-        # Convert the app_ref to a path relative to the project root
-        project_root, _ = find_project_root(None)
-        app_ref = str(project_root / app_ref)
+        else:
+            # Convert the app_ref to a path relative to the project root
+            project_root, _ = find_project_root(None)
+            app_ref = str(project_root / app_ref)
 
     app_auth: Optional[AuthModeLiteral] = app_data.pop("auth", None)
     app_deployment_strategy: Optional[DeploymentStrategyLiteral] = app_data.pop(
@@ -141,8 +146,6 @@ def get_app_data_from_toml(
     secrets = app_data.pop("secrets", None)
     data_mounts = app_data.pop("data_mounts", None)
     health_check = app_data.pop("health_check", None)
-
-    image_config = app_data.pop("image", None)
 
     if regions is not None:
         _validate_regions(regions)
@@ -243,8 +246,15 @@ def get_app_data_from_toml(
     if python_version is not None:
         options.environment["python_version"] = python_version
     if image_config is not None:
+        image_uses_isolate = None
+        if app_ref is None and python_entry_point is None:
+            image_uses_isolate = False
+
         container_image = _build_container_image_from_toml(
-            app_name, image_config, Path(toml_path).parent
+            app_name,
+            image_config,
+            Path(toml_path).parent,
+            use_isolate=image_uses_isolate,
         )
         options.environment["kind"] = "container"
         options.environment["image"] = container_image.to_dict()
@@ -389,11 +399,18 @@ _IMAGE_PASSTHROUGH_KEYS = (
     "registries",
     # Image build-time secrets, distinct from app-level runtime `secrets`.
     "secrets",
+    # Docker ENTRYPOINT/CMD overrides.
+    "entrypoint",
+    "cmd",
 )
 
 
 def _build_container_image_from_toml(
-    app_name: str, image_config: Any, project_root: Path
+    app_name: str,
+    image_config: Any,
+    project_root: Path,
+    *,
+    use_isolate: bool | None = None,
 ) -> ContainerImage:
     if not isinstance(image_config, dict):
         raise ValueError(f"App {app_name} image must be a table in pyproject.toml")
@@ -423,6 +440,8 @@ def _build_container_image_from_toml(
         "dockerfile_str": dockerfile_str,
         "context_dir": project_root,
     }
+    if use_isolate is not None:
+        kwargs["use_isolate"] = use_isolate
 
     for key in _IMAGE_PASSTHROUGH_KEYS:
         if key in image_config:

--- a/projects/fal/src/fal/container.py
+++ b/projects/fal/src/fal/container.py
@@ -5,9 +5,10 @@ import shlex
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 Builder = Literal["depot", "service", "worker"]
+CommandOverride = Union[str, List[str]]
 BUILDERS = {"depot", "service", "worker"}
 DEFAULT_COMPRESSION: str = "gzip"
 DEFAULT_FORCE_COMPRESSION: bool = False
@@ -30,6 +31,16 @@ DEFAULT_DOCKERIGNORE_PATTERNS = [
 ]
 
 
+def _validate_command_override(name: str, value: Optional[CommandOverride]) -> None:
+    if value is None:
+        return
+    if isinstance(value, str):
+        return
+    if isinstance(value, list) and all(isinstance(part, str) for part in value):
+        return
+    raise ValueError(f"{name} must be a string or list of strings.")
+
+
 @dataclass
 class ContainerImage:
     """ContainerImage represents a Docker image that can be built
@@ -43,6 +54,9 @@ class ContainerImage:
     compression: str = DEFAULT_COMPRESSION
     force_compression: bool = DEFAULT_FORCE_COMPRESSION
     secrets: Dict[str, str] = field(default_factory=dict)
+    entrypoint: Optional[CommandOverride] = None
+    cmd: Optional[CommandOverride] = None
+    use_isolate: Optional[bool] = None
     # Build context directory
     context_dir: os.PathLike = field(default=Path.cwd())
     dockerignore: Optional[List[str]] = field(default=None)
@@ -77,6 +91,11 @@ class ContainerImage:
                 f"Invalid builder: {self.builder}, must be one of {BUILDERS}"
             )
 
+        _validate_command_override("entrypoint", self.entrypoint)
+        _validate_command_override("cmd", self.cmd)
+        if self.use_isolate is not None and not isinstance(self.use_isolate, bool):
+            raise ValueError("use_isolate must be a bool.")
+
         if self.builder and self.builder in ("service", "worker"):
             # Yellow "Warning:" prefix via ANSI; falls back to plain text
             # on non-TTY or color-less terminals.
@@ -100,7 +119,7 @@ class ContainerImage:
             return cls.from_dockerfile_str(fobj.read(), **kwargs)
 
     def to_dict(self) -> dict:
-        return {
+        image = {
             "dockerfile_str": self.dockerfile_str,
             "build_args": self.build_args,
             "registries": self.registries,
@@ -112,6 +131,13 @@ class ContainerImage:
             "docker_files_list": self.get_copy_add_sources(),
             "docker_ignore": self._dockerignore,
         }
+        if self.entrypoint is not None:
+            image["entrypoint"] = self.entrypoint
+        if self.cmd is not None:
+            image["cmd"] = self.cmd
+        if self.use_isolate is not None:
+            image["use_isolate"] = self.use_isolate
+        return image
 
     def get_copy_add_sources(self) -> List[str]:
         """

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -814,6 +814,39 @@ class FalServerlessConnection:
             force=force,
         )
 
+    @staticmethod
+    def _image_uses_isolate(
+        environments: list[isolate_proto.EnvironmentDefinition],
+    ) -> bool:
+        for environment in environments:
+            if environment.kind != "container":
+                continue
+
+            image = environment.configuration.fields.get("image")
+            if image is None or image.WhichOneof("kind") != "struct_value":
+                continue
+
+            use_isolate = image.struct_value.fields.get("use_isolate")
+            if (
+                use_isolate is not None
+                and use_isolate.WhichOneof("kind") == "bool_value"
+                and use_isolate.bool_value is False
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _uses_isolate(
+        function: Callable[..., Any] | None,
+        entrypoint: str | None,
+        environments: list[isolate_proto.EnvironmentDefinition],
+    ) -> bool:
+        return (
+            function is not None
+            or entrypoint is not None
+            or FalServerlessConnection._image_uses_isolate(environments)
+        )
+
     def register(
         self,
         function: Callable[..., ResultT] | None,
@@ -838,7 +871,11 @@ class FalServerlessConnection:
         entrypoint: str | None = None,
         build_environment: bool | None = None,
     ) -> Iterator[RegisterApplicationResult]:
-        if function is None and entrypoint is None:
+        if (
+            function is None
+            and entrypoint is None
+            and self._uses_isolate(function, entrypoint, environments)
+        ):
             raise ValueError("either function or entrypoint must be provided.")
         if function is not None and entrypoint is not None:
             raise ValueError("only one of function or entrypoint can be provided.")
@@ -939,8 +976,7 @@ class FalServerlessConnection:
         )
         if entrypoint is not None:
             request.entrypoint = entrypoint
-        else:
-            assert wrapped_function is not None  # validated at the top
+        elif wrapped_function is not None:
             request.function.MergeFrom(wrapped_function)
         if private_logs is not None:
             request.private_logs = private_logs
@@ -1050,7 +1086,11 @@ class FalServerlessConnection:
         entrypoint: str | None = None,
         build_environment: bool | None = None,
     ) -> Iterator[HostedRunResult[ResultT]]:
-        if function is None and entrypoint is None:
+        if (
+            function is None
+            and entrypoint is None
+            and self._uses_isolate(function, entrypoint, environments)
+        ):
             raise ValueError("either function or entrypoint must be provided.")
         if function is not None and entrypoint is not None:
             raise ValueError("only one of function or entrypoint can be provided.")
@@ -1113,8 +1153,7 @@ class FalServerlessConnection:
         )
         if entrypoint is not None:
             request.entrypoint = entrypoint
-        else:
-            assert wrapped_function is not None  # validated at the top
+        elif wrapped_function is not None:
             request.function.MergeFrom(wrapped_function)
         if setup_function:
             request.setup_func.MergeFrom(

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
-from fal.api.api import merge_basic_config
+from fal.api.api import _uses_isolate, merge_basic_config
 from fal.sdk import AuthModeLiteral
 
 if TYPE_CHECKING:
@@ -144,6 +144,19 @@ def load_function_from(
         )
 
     if file_path is None:
+        if options is not None and not _uses_isolate(None, None, options):
+            return LoadedFunction(
+                IsolatedFunction(
+                    host=host,
+                    options=options,
+                    app_name=app_name,
+                    app_auth=app_auth,
+                ),
+                app_name=app_name,
+                app_auth=app_auth,
+                source_code=None,
+                class_name=None,
+            )
         raise FalServerlessError("App ref must resolve to a file path.")
 
     sys.path.append(os.getcwd())

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -82,6 +82,55 @@ def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default(
     assert build_kwargs["result_handler"] is result_handler
 
 
+def test_execute_prepared_deployment_builds_no_isolate_container():
+    from fal.api.api import IsolatedFunction
+    from fal.api.deploy import PreparedDeployment, execute_prepared_deployment
+    from fal.sdk import (
+        RegisterApplicationResult,
+        RegisterApplicationResultType,
+        ServiceURLs,
+    )
+
+    host = MagicMock()
+    options = Options(
+        environment={"kind": "container", "image": {"use_isolate": False}}
+    )
+    isolated_function = IsolatedFunction(
+        host=host,
+        options=options,
+        app_name="container-app",
+        app_auth="public",
+    )
+    host.register.return_value = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id"),
+        service_urls=ServiceURLs(
+            playground="https://playground.example",
+            run="https://run.example",
+            queue="https://queue.example",
+            ws="wss://ws.example",
+            log="https://log.example",
+        ),
+    )
+    prepared = PreparedDeployment(
+        host=host,
+        loaded=SimpleNamespace(
+            function=isolated_function,
+            app_name="container-app",
+            app_auth="public",
+            source_code=None,
+            class_name=None,
+        ),
+        app_data=AppData(deployment_strategy="rolling"),
+        display_name="container-app",
+    )
+
+    execute_prepared_deployment(prepared)
+
+    host.build_environment.assert_called_once()
+    _, register_kwargs = host.register.call_args
+    assert register_kwargs["build_environment"] is False
+
+
 def test_deploy_with_env_and_other_options():
     args = parse_args(
         [
@@ -305,6 +354,58 @@ def test_deploy_python_entry_point_forwards_to_loader(
     assert call_kwargs["python_entry_point"] == "simple.app:SimpleApp"
     assert call_kwargs["options"].environment["python_version"] == "3.12"
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_deploy_image_only_forwards_no_ref_to_loader(
+    mock_load_function_from,
+    mock_create_host,
+    mock_execute,
+    mock_parse_toml,
+    mock_find_toml,
+    tmp_path,
+):
+    dockerfile = "FROM debian:bookworm-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "auth": "public",
+                "image": {"dockerfile": "Dockerfile"},
+            }
+        }
+    }
+    mock_create_host.return_value = MagicMock()
+    loaded = MagicMock()
+    loaded.app_name = "container-app"
+    loaded.app_auth = "public"
+    loaded.class_name = None
+    loaded.function = MagicMock()
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(app_ref=("container-app", None))
+    _deploy(args)
+
+    mock_create_host.assert_called_once()
+    _, host_kwargs = mock_create_host.call_args
+    assert host_kwargs["local_file_path"] == ""
+    assert host_kwargs["local_project_root"] == str(tmp_path)
+
+    mock_load_function_from.assert_called_once()
+    call_args, call_kwargs = mock_load_function_from.call_args
+    assert call_args[1] is None
+    assert call_args[2] is None
+    assert call_kwargs["python_entry_point"] is None
+    assert call_kwargs["app_name"] == "container-app"
+    assert call_kwargs["app_auth"] == "public"
+    assert call_kwargs["options"].environment["kind"] == "container"
+    assert call_kwargs["options"].environment["image"]["dockerfile_str"] == dockerfile
+    assert call_kwargs["options"].environment["image"]["use_isolate"] is False
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
@@ -1250,6 +1351,8 @@ def test_get_app_data_from_toml_with_image(mock_parse_toml, mock_find_toml, tmp_
                         "myregistry.com": {"username": "u", "password": "p"}
                     },
                     "secrets": {"TOKEN": "shh"},
+                    "entrypoint": ["python", "-m", "server"],
+                    "cmd": ["--host", "0.0.0.0", "--port", "8080"],
                 },
             }
         }
@@ -1265,6 +1368,68 @@ def test_get_app_data_from_toml_with_image(mock_parse_toml, mock_find_toml, tmp_
         "myregistry.com": {"username": "u", "password": "p"}
     }
     assert env["image"]["secrets"] == {"TOKEN": "shh"}
+    assert env["image"]["entrypoint"] == ["python", "-m", "server"]
+    assert env["image"]["cmd"] == ["--host", "0.0.0.0", "--port", "8080"]
+    assert "use_isolate" not in env["image"]
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_allows_python_entry_point_with_image(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    dockerfile = "FROM python:3.12-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "python_entry_point": "simple.app:SimpleApp",
+                "image": {"dockerfile": "Dockerfile"},
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+
+    assert toml_data.ref is None
+    assert toml_data.python_entry_point == "simple.app:SimpleApp"
+    assert toml_data.options.environment["kind"] == "container"
+    assert toml_data.options.environment["image"]["dockerfile_str"] == dockerfile
+    assert "use_isolate" not in toml_data.options.environment["image"]
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_with_image_without_ref(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    dockerfile = "FROM debian:bookworm-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "auth": "public",
+                "machine_type": "GPU-H100",
+                "image": {"dockerfile": "Dockerfile"},
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("container-app")
+
+    assert toml_data.ref is None
+    assert toml_data.python_entry_point is None
+    assert toml_data.auth == "public"
+    assert toml_data.options.host["machine_type"] == "GPU-H100"
+    assert toml_data.options.environment["kind"] == "container"
+    assert toml_data.options.environment["image"]["dockerfile_str"] == dockerfile
+    assert toml_data.options.environment["image"]["use_isolate"] is False
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
@@ -1317,6 +1482,42 @@ def test_get_app_data_from_toml_rejects_unknown_image_keys(
     with pytest.raises(
         ValueError,
         match=r"Found unexpected keys in app container-app image",
+    ):
+        get_app_data_from_toml("container-app")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("entrypoint", 123),
+        ("entrypoint", ["python", 123]),
+        ("cmd", 123),
+        ("cmd", ["--port", 8080]),
+    ],
+)
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_invalid_image_command_overrides(
+    mock_parse_toml, mock_find_toml, tmp_path, field_name, value
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "image": {
+                    "dockerfile": "Dockerfile",
+                    field_name: value,
+                },
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=f"{field_name} must be a string or list of strings",
     ):
         get_app_data_from_toml("container-app")
 

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional, Tuple
 from unittest.mock import MagicMock, patch
 
@@ -210,6 +211,115 @@ def test_run_forwards_python_entry_point_to_loader(
     assert call_kwargs["options"].environment["python_version"] == "3.12"
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
     assert call_kwargs["options"].gateway["exposed_port"] == 9000
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_image_only_forwards_no_ref_to_loader(
+    mock_load_function_from,
+    mock_create_host,
+    mock_parse_toml,
+    mock_find_toml,
+    tmp_path,
+):
+    dockerfile = "FROM debian:bookworm-slim\n"
+    (tmp_path / "Dockerfile").write_text(dockerfile)
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "container-app": {
+                "image": {"dockerfile": "Dockerfile"},
+                "exposed_port": 8080,
+            }
+        }
+    }
+
+    host = mocked_fal_serverless_host("my-host")
+    mock_create_host.return_value = host
+
+    isolated_function = MagicMock()
+    isolated_function.options = MagicMock()
+    isolated_function.options.host = {}
+    loaded = MagicMock()
+    loaded.function = isolated_function
+    loaded.app_name = "container-app"
+    loaded.app_auth = None
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(func_ref=("container-app", None), host="my-host")
+
+    _run(args)
+
+    mock_create_host.assert_called_once_with(
+        local_file_path="",
+        local_project_root=str(tmp_path),
+        environment_name=None,
+    )
+    mock_load_function_from.assert_called_once()
+    call_args, call_kwargs = mock_load_function_from.call_args
+    assert call_args[1] is None
+    assert call_args[2] is None
+    assert call_kwargs["python_entry_point"] is None
+    assert call_kwargs["options"].environment["kind"] == "container"
+    assert call_kwargs["options"].environment["image"]["dockerfile_str"] == dockerfile
+    assert call_kwargs["options"].environment["image"]["use_isolate"] is False
+    assert call_kwargs["options"].gateway["exposed_port"] == 8080
+
+
+@patch("fal.api.run.run")
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_image_only_builds_no_isolate_container(
+    mock_load_function_from,
+    mock_create_host,
+    mock_parse_toml,
+    mock_find_toml,
+    mock_run_api,
+    tmp_path,
+):
+    from fal.api.api import IsolatedFunction
+
+    (tmp_path / "Dockerfile").write_text("FROM debian:bookworm-slim\n")
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {"container-app": {"image": {"dockerfile": "Dockerfile"}}}
+    }
+    host = mocked_fal_serverless_host("my-host")
+    mock_create_host.return_value = host
+
+    def fake_load_function_from(
+        host_arg,
+        _file_path,
+        _func_name,
+        *,
+        options,
+        app_name,
+        app_auth,
+        **_kwargs,
+    ):
+        return SimpleNamespace(
+            function=IsolatedFunction(
+                host=host_arg,
+                options=options,
+                app_name=app_name,
+                app_auth=app_auth,
+            ),
+            app_name=app_name,
+            app_auth=app_auth,
+        )
+
+    mock_load_function_from.side_effect = fake_load_function_from
+
+    args = mock_args(func_ref=("container-app", None), host="my-host")
+    _run(args)
+
+    host.build_environment.assert_called_once()
+    _, run_kwargs = mock_run_api.call_args
+    assert run_kwargs["build_environment"] is False
 
 
 @patch("fal.api.client.SyncServerlessClient._create_host")

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -185,6 +185,101 @@ def test_register_forwards_explicit_private_logs_false():
     assert call_kwargs["private_logs"] is False
 
 
+def test_register_allows_container_without_func_or_entrypoint():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    host = FalServerlessHost()
+    options = Options(
+        environment={"kind": "container", "image": {"use_isolate": False}}
+    )
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            None,
+            options,
+            application_name="container-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    call_args, call_kwargs = connection.register.call_args
+    assert call_args[0] is None
+    assert call_kwargs["entrypoint"] is None
+
+
+def test_run_allows_container_without_func_or_entrypoint():
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+
+    host = FalServerlessHost()
+    options = Options(
+        environment={"kind": "container", "image": {"use_isolate": False}}
+    )
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "ok"
+    connection.run.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host._run(
+            None,
+            options,
+            args=(),
+            kwargs={},
+            application_name="container-app",
+            result_handler=ResultHandler(),
+        )
+
+    assert result == "ok"
+    call_args, call_kwargs = connection.run.call_args
+    assert call_args[0] is None
+    assert call_kwargs["entrypoint"] is None
+    assert call_kwargs["application_name"] == "container-app"
+
+
+def test_load_function_from_allows_container_without_ref():
+    from fal.api.api import Options
+    from fal.utils import load_function_from
+
+    host = MagicMock()
+    options = Options(
+        environment={"kind": "container", "image": {"use_isolate": False}}
+    )
+
+    loaded = load_function_from(
+        host,
+        None,
+        options=options,
+        app_name="container-app",
+        app_auth="public",
+    )
+
+    assert loaded.app_name == "container-app"
+    assert loaded.app_auth == "public"
+    assert loaded.source_code is None
+    assert loaded.class_name is None
+    assert loaded.function.func is None
+    assert loaded.function.run_entrypoint is None
+    assert loaded.function.options is options
+
+
 def test_wrap_app_allows_resolver_with_container_kind():
     from fal.app import wrap_app
 

--- a/projects/fal/tests/unit/test_container.py
+++ b/projects/fal/tests/unit/test_container.py
@@ -465,6 +465,33 @@ class TestContainerImageValidation:
                 registries={"docker.io": {"username": "user"}},
             )
 
+    @pytest.mark.parametrize("field_name", ["entrypoint", "cmd"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            123,
+            ["python", 123],
+            {"command": "python"},
+        ],
+    )
+    def test_invalid_command_override_raises_valueerror(self, field_name, value):
+        """Command overrides should be shell strings or exec-form string lists."""
+        with pytest.raises(
+            ValueError, match=f"{field_name} must be a string or list of strings"
+        ):
+            ContainerImage(
+                dockerfile_str="FROM python:3.11",
+                **{field_name: value},
+            )
+
+    def test_invalid_use_isolate_raises_valueerror(self):
+        """use_isolate should be a boolean when provided."""
+        with pytest.raises(ValueError, match="use_isolate must be a bool"):
+            ContainerImage(
+                dockerfile_str="FROM python:3.11",
+                use_isolate="false",  # type: ignore[arg-type]
+            )
+
 
 class TestContainerImageFromDockerfileStr:
     """Tests for from_dockerfile_str class method."""
@@ -649,3 +676,28 @@ class TestToDict:
         assert isinstance(d["docker_context_dir"], str)
         # builder defaults to None
         assert d["builder"] is None
+        assert "entrypoint" not in d
+        assert "cmd" not in d
+        assert "use_isolate" not in d
+
+    def test_command_overrides_in_dict(self):
+        """Should include Docker ENTRYPOINT/CMD overrides when provided."""
+        img = ContainerImage(
+            dockerfile_str="FROM python:3.11",
+            entrypoint=["python", "-m", "server"],
+            cmd="--host 0.0.0.0 --port 8080",
+        )
+        d = img.to_dict()
+
+        assert d["entrypoint"] == ["python", "-m", "server"]
+        assert d["cmd"] == "--host 0.0.0.0 --port 8080"
+
+    def test_use_isolate_in_dict(self):
+        """Should include use_isolate when provided."""
+        img = ContainerImage(
+            dockerfile_str="FROM python:3.11",
+            use_isolate=False,
+        )
+        d = img.to_dict()
+
+        assert d["use_isolate"] is False

--- a/projects/fal/tests/unit/test_sdk.py
+++ b/projects/fal/tests/unit/test_sdk.py
@@ -1,8 +1,26 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fal.sdk import FalServerlessKeyCredentials, get_credentials
+from fal.sdk import (
+    FalServerlessConnection,
+    FalServerlessKeyCredentials,
+    get_credentials,
+)
+
+
+class RecordingStub:
+    def __init__(self):
+        self.register_request = None
+        self.run_request = None
+
+    def RegisterApplication(self, request):
+        self.register_request = request
+        return iter([])
+
+    def Run(self, request):
+        self.run_request = request
+        return iter([])
 
 
 def test_get_credentials_returns_key_credentials_when_available():
@@ -68,3 +86,69 @@ def test_get_credentials_passes_profile_to_key_credentials():
             get_credentials(profile="my-profile")
 
     mock_key_credentials.assert_called_once_with(profile="my-profile")
+
+
+def test_connection_register_allows_no_isolate_container_without_callable():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+        )
+    )
+
+    assert stub.register_request is not None
+    assert stub.register_request.WhichOneof("callable") is None
+
+
+def test_connection_register_rejects_isolate_container_without_callable():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim"},
+    )
+
+    with pytest.raises(ValueError, match="either function or entrypoint"):
+        list(
+            connection.register(
+                None,
+                [environment],
+                application_name="container-app",
+                deployment_strategy="rolling",
+            )
+        )
+
+
+def test_connection_run_allows_no_isolate_container_without_callable():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(connection.run(None, [environment]))
+
+    assert stub.run_request is not None
+    assert stub.run_request.WhichOneof("callable") is None
+
+
+def test_connection_run_rejects_isolate_container_without_callable():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim"},
+    )
+
+    with pytest.raises(ValueError, match="either function or entrypoint"):
+        list(connection.run(None, [environment]))


### PR DESCRIPTION
## Summary

- allow pyproject apps with an `image` table to omit both `ref` and `python_entry_point`
- pass image-only apps through deploy/run loading without fabricating a Python file or entrypoint
- allow container image registrations/runs to reach the backend with both `func` and `entrypoint` unset when an image is present

## Notes

This is intentionally separate from the wrapper POC. It only wires the SDK/CLI path needed for backend-native Docker execution.

## Testing

- `uv run --python 3.12 --project projects/fal --extra test pytest projects/fal/tests/unit/cli/test_deploy.py projects/fal/tests/unit/cli/test_run.py projects/fal/tests/unit/test_app.py -q`
- `uvx --python 3.12 pre-commit run --all-files`
