### PR TITLE
 fix(fal): fail fast on local/runner Python version mismatch

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -20,6 +20,7 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
+    Iterable,
     Iterator,
     Literal,
     NamedTuple,
@@ -525,6 +526,58 @@ def _apply_runtime_config(runtime_config: FunctionRuntimeConfig | None) -> None:
         include_app_files_path(runtime_config.app_files_relative_path)
 
 
+def _check_python_version_match(
+    serialized_callables: Iterable[Callable[..., Any] | None],
+    target_python_version: str | None,
+) -> None:
+    """Fail fast on a local/remote Python minor-version mismatch.
+
+    ``fal run`` (and serialized ``register``) ships callables as cloudpickled
+    bytecode, which is CPython-version specific. If the local interpreter and the
+    app's ``python_version`` differ at the minor level, the worker cannot
+    deserialize them and the run dies with an opaque gRPC
+    ``UNAVAILABLE / "Socket closed"`` error.
+
+    The check applies whenever *any* callable is serialized client-side. This
+    includes a ``setup_function`` in entrypoint mode (where the main ``func`` is
+    ``None`` but a setup callable is still pickled and sent). If nothing is
+    serialized, or ``target_python_version`` is ``None`` (resolved server-side,
+    nothing to compare against), the check is a no-op.
+    """
+    if all(c is None for c in serialized_callables) or target_python_version is None:
+        return
+
+    from isolate.backends.common import active_python  # noqa: PLC0415
+
+    local_python = active_python()
+    if local_python.split(".")[:2] != target_python_version.split(".")[:2]:
+        raise FalServerlessError(
+            f"Local Python {local_python} differs from the app's "
+            f"python_version={target_python_version}. "
+            f"Run from a Python {target_python_version} "
+            f"interpreter, or set python_version='{local_python}' on the app."
+        )
+
+
+def check_python_version_for_options(
+    func: Callable[..., Any] | None,
+    options: Options,
+) -> None:
+    """Run the Python version guard for a prepared callable + options.
+
+    Mirrors the target resolution in ``_run``/``register`` so callers (the CLI
+    build phase) can fail fast *before* the potentially slow remote environment
+    build, instead of only once the function is about to be serialized.
+    """
+    from isolate.backends.common import active_python  # noqa: PLC0415
+
+    target = options.environment.get("python_version") or active_python()
+    _check_python_version_match(
+        [func, options.host.get("setup_function")],
+        target,
+    )
+
+
 def _prepare_partial_func(
     func: Callable[..., ReturnT],
     args: tuple[Any, ...] = (),
@@ -975,7 +1028,15 @@ class FalServerlessHost(Host):
         from isolate.backends.common import active_python  # noqa: PLC0415
 
         environment_options = options.environment.copy()
-        environment_options.setdefault("python_version", active_python())
+        # An explicit ``python_version=None`` must still resolve to the local
+        # interpreter: we ship local cloudpickled bytecode, so the remote
+        # Python must match. ``setdefault`` would leave an explicit None as-is.
+        if environment_options.get("python_version") is None:
+            environment_options["python_version"] = active_python()
+        _check_python_version_match(
+            [func, options.host.get("setup_function")],
+            environment_options["python_version"],
+        )
         self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
 
@@ -1100,7 +1161,15 @@ class FalServerlessHost(Host):
         from isolate.backends.common import active_python  # noqa: PLC0415
 
         environment_options = options.environment.copy()
-        environment_options.setdefault("python_version", active_python())
+        # An explicit ``python_version=None`` must still resolve to the local
+        # interpreter: we ship local cloudpickled bytecode, so the remote
+        # Python must match. ``setdefault`` would leave an explicit None as-is.
+        if environment_options.get("python_version") is None:
+            environment_options["python_version"] = active_python()
+        _check_python_version_match(
+            [func, options.host.get("setup_function")],
+            environment_options["python_version"],
+        )
         self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
 
@@ -1262,7 +1331,11 @@ class FalServerlessHost(Host):
         from isolate.backends.common import active_python  # noqa: PLC0415
 
         environment_options = options.environment.copy()
-        environment_options.setdefault("python_version", active_python())
+        # An explicit ``python_version=None`` must still resolve to the local
+        # interpreter: we ship local cloudpickled bytecode, so the remote
+        # Python must match. ``setdefault`` would leave an explicit None as-is.
+        if environment_options.get("python_version") is None:
+            environment_options["python_version"] = active_python()
         self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
 

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -251,6 +251,11 @@ def _execute_loaded_deployment(
         result_handler if build_result_handler is None else build_result_handler
     )
 
+    # Fail fast on a local/remote Python version mismatch
+    from fal.api.api import check_python_version_for_options
+
+    check_python_version_for_options(isolated_function.func, isolated_function.options)
+
     # Explicit build phase so the CLI / caller gets a clean "build → deploy"
     # split instead of inferring it from the log stream's source field.
     host.build_environment(

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -83,6 +83,13 @@ def _run(args):
         isolated_function.options.host["machine_type"] = args.machine_type
 
     if not args.local:
+        # Fail fast on a local/remote Python version mismatch
+        from fal.api.api import check_python_version_for_options
+
+        check_python_version_for_options(
+            isolated_function.func, isolated_function.options
+        )
+
         # Explicit build phase so the CLI gets a clean "build → run" split
         # instead of inferring it from the log stream's source field.
         from ._result_handlers import CliBuildEnvironmentResultHandler

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fal.api import Options
 from fal.cli.main import parse_args
 from fal.cli.run import _run
 from fal.project import find_project_root
@@ -79,11 +80,7 @@ def test_run_uses_cli_auth_when_provided(mock_load_function_from, mock_create_ho
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = "private"
+    loaded = mocked_loaded_function(app_auth="private")
     mock_load_function_from.return_value = loaded
 
     args = mock_args(
@@ -141,6 +138,29 @@ def mocked_fal_serverless_host(host):
     return mock
 
 
+_DEFAULT_FUNC = object()
+
+
+def mocked_loaded_function(
+    *,
+    options: Optional[Options] = None,
+    func=_DEFAULT_FUNC,
+    app_name=None,
+    app_auth=None,
+):
+    isolated_function = MagicMock()
+    isolated_function.options = options or Options()
+    isolated_function.func = (lambda: None) if func is _DEFAULT_FUNC else func
+    isolated_function.run_entrypoint = None
+    isolated_function.endpoints = ["/"]
+
+    loaded = MagicMock()
+    loaded.function = isolated_function
+    loaded.app_name = app_name
+    loaded.app_auth = app_auth
+    return loaded
+
+
 def mock_args(
     host,
     func_ref: Tuple[str, Optional[str]],
@@ -187,13 +207,13 @@ def test_run_forwards_python_entry_point_to_loader(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    isolated_function.options = MagicMock()
-    isolated_function.options.host = {}
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function(
+        options=Options(
+            environment={"python_version": "3.12", "requirements": ["fal"]},
+            gateway={"exposed_port": 9000},
+        ),
+        func=None,
+    )
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("entrypoint-app", None), host="my-host")
@@ -239,13 +259,20 @@ def test_run_image_only_forwards_no_ref_to_loader(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    isolated_function.options = MagicMock()
-    isolated_function.options.host = {}
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = "container-app"
-    loaded.app_auth = None
+    loaded = mocked_loaded_function(
+        options=Options(
+            environment={
+                "kind": "container",
+                "image": {
+                    "dockerfile_str": dockerfile,
+                    "use_isolate": False,
+                },
+            },
+            gateway={"exposed_port": 8080},
+        ),
+        func=None,
+        app_name="container-app",
+    )
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("container-app", None), host="my-host")
@@ -330,11 +357,7 @@ def test_run_forwards_limit_max_requests_to_load_function_from(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = "private"
+    loaded = mocked_loaded_function(app_auth="private")
     mock_load_function_from.return_value = loaded
 
     args = mock_args(
@@ -360,11 +383,7 @@ def test_run_forwards_exposed_port_options_to_run_api(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = "private"
+    loaded = mocked_loaded_function(app_auth="private")
     mock_load_function_from.return_value = loaded
 
     args = mock_args(
@@ -410,13 +429,7 @@ def test_run_applies_machine_type_override(mock_load_function_from, mock_create_
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    isolated_function.options = MagicMock()
-    isolated_function.options.host = {"machine_type": "GPU-A10G"}
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function(options=Options(host={"machine_type": "GPU-A10G"}))
     mock_load_function_from.return_value = loaded
 
     args = mock_args(
@@ -427,7 +440,7 @@ def test_run_applies_machine_type_override(mock_load_function_from, mock_create_
 
     _run(args)
 
-    assert isolated_function.options.host["machine_type"] == "GPU-H100"
+    assert loaded.function.options.host["machine_type"] == "GPU-H100"
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")
@@ -445,12 +458,7 @@ def test_run_with_toml_success(
 
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
-    loaded = MagicMock()
-    loaded.function = MagicMock()
-    loaded.function.options = MagicMock()
-    loaded.function.options.host = {}
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function()
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("my-app", None), host="my-host")
@@ -487,12 +495,17 @@ def test_run_with_toml_cli_name_override(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    loaded = MagicMock()
-    loaded.function = MagicMock()
-    loaded.function.options = MagicMock()
-    loaded.function.options.host = {}
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function(
+        options=Options(
+            environment={"requirements": ["numpy==1.26.4"]},
+            host={
+                "machine_type": "GPU-H100",
+                "num_gpus": 2,
+                "min_concurrency": 2,
+                "regions": ["us-east"],
+            },
+        )
+    )
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("override-app", None), host="my-host")
@@ -526,14 +539,17 @@ def test_run_with_toml_overrides_applied(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    isolated_function = MagicMock()
-    isolated_function.options = MagicMock()
-    isolated_function.options.host = {}
-    isolated_function.options.add_requirements = MagicMock()
-    loaded = MagicMock()
-    loaded.function = isolated_function
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function(
+        options=Options(
+            environment={"requirements": ["numpy==1.26.4"]},
+            host={
+                "machine_type": "GPU-H100",
+                "num_gpus": 2,
+                "min_concurrency": 2,
+                "regions": ["us-east"],
+            },
+        )
+    )
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("override-app", None), host="my-host")
@@ -566,12 +582,7 @@ def test_run_with_toml_cli_auth_override(
     host = mocked_fal_serverless_host("my-host")
     mock_create_host.return_value = host
 
-    loaded = MagicMock()
-    loaded.function = MagicMock()
-    loaded.function.options = MagicMock()
-    loaded.function.options.host = {}
-    loaded.app_name = None
-    loaded.app_auth = None
+    loaded = mocked_loaded_function()
     mock_load_function_from.return_value = loaded
 
     args = mock_args(func_ref=("team-app", None), host="my-host", auth="private")
@@ -645,6 +656,7 @@ def test_run_with_team_from_toml(
     mock_client_instance = MagicMock()
     mock_client_instance._create_host.return_value = host
     mock_client.return_value = mock_client_instance
+    mock_load_function_from.return_value = mocked_loaded_function()
 
     args = mock_args(func_ref=("team-app", None), host="my-host")
 
@@ -687,6 +699,7 @@ def test_run_with_team_from_toml_cli_team_override(
     mock_client_instance = MagicMock()
     mock_client_instance._create_host.return_value = host
     mock_client.return_value = mock_client_instance
+    mock_load_function_from.return_value = mocked_loaded_function()
 
     args = mock_args(func_ref=("team-app", None), host="my-host", team="my-cli-team")
 
@@ -729,6 +742,7 @@ def test_run_without_team_in_toml(
     mock_client_instance = MagicMock()
     mock_client_instance._create_host.return_value = host
     mock_client.return_value = mock_client_instance
+    mock_load_function_from.return_value = mocked_loaded_function()
 
     args = mock_args(func_ref=("my-app", None), host="my-host")
 

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -5,7 +5,58 @@ import pytest
 
 from fal import App, endpoint
 from fal.api import FalServerlessError, IsolatedFunction, Options
+from fal.api.api import _check_python_version_match
 from fal.api.run import run as run_api
+
+
+def _func():
+    pass
+
+
+def test_check_python_version_match_exempts_entrypoint(monkeypatch):
+    # No callable is serialized (entrypoint mode, no setup_function) -> no check.
+    monkeypatch.setattr(
+        "isolate.backends.common.active_python", lambda: "3.11", raising=True
+    )
+    _check_python_version_match([None], "3.12")  # must not raise
+
+
+def test_check_python_version_match_noop_when_target_is_none(monkeypatch):
+    # target resolved server-side -> nothing to compare against.
+    monkeypatch.setattr(
+        "isolate.backends.common.active_python", lambda: "3.11", raising=True
+    )
+    _check_python_version_match([_func], None)  # must not raise
+
+
+def test_check_python_version_match_allows_same_minor(monkeypatch):
+    monkeypatch.setattr(
+        "isolate.backends.common.active_python", lambda: "3.11", raising=True
+    )
+    # patch-level differences don't change the bytecode magic.
+    _check_python_version_match([_func], "3.11")  # must not raise
+
+
+def test_check_python_version_match_raises_on_minor_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        "isolate.backends.common.active_python", lambda: "3.11", raising=True
+    )
+    with pytest.raises(FalServerlessError) as exc_info:
+        _check_python_version_match([_func], "3.12")
+
+    msg = str(exc_info.value)
+    assert "3.11" in msg
+    assert "3.12" in msg
+
+
+def test_check_python_version_match_checks_setup_function_in_entrypoint(monkeypatch):
+    # Entrypoint mode (func is None) but a setup_function is still pickled
+    # and shipped -> the mismatch must still be caught.
+    monkeypatch.setattr(
+        "isolate.backends.common.active_python", lambda: "3.11", raising=True
+    )
+    with pytest.raises(FalServerlessError):
+        _check_python_version_match([None, _func], "3.12")
 
 
 class _FakeHost:


### PR DESCRIPTION
fixes:
```python
import fal

class T(fal.App, python_version="3.12"):
    @fal.endpoint("/")
    def t(self):
        return "ok"

```

```bash
$ fal run app.py
✘ Function execution quit unexpectedly. Error contents: <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.UNAVAILABLE
        details = "Socket closed"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:14, grpc_message:"Socket closed"}"
```