### PR TITLE
fix(cli): avoid forced rebuild on no-cache deploy registration

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -975,6 +975,8 @@ class FalServerlessHost(Host):
         from isolate.backends.common import active_python  # noqa: PLC0415
 
         environment_options = options.environment.copy()
+        if build_environment is False:
+            environment_options.pop("force", None)
         environment_options.setdefault("python_version", active_python())
         self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
@@ -1100,6 +1102,8 @@ class FalServerlessHost(Host):
         from isolate.backends.common import active_python  # noqa: PLC0415
 
         environment_options = options.environment.copy()
+        if build_environment is False:
+            environment_options.pop("force", None)
         environment_options.setdefault("python_version", active_python())
         self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -124,6 +124,96 @@ def test_run_forwards_regions_to_machine_requirements():
     assert call_kwargs["machine_requirements"].valid_regions == ["us-east"]
 
 
+def test_build_environment_forwards_force_environment_option():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import HostedRunState
+
+    host = FalServerlessHost()
+    options = Options(environment={"kind": "virtualenv", "force": True})
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    connection.build_environment.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        host.build_environment(options)
+
+    _, call_kwargs = connection.define_environment.call_args
+    assert call_kwargs["force"] is True
+
+
+def test_register_omits_force_when_build_environment_false():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    host = FalServerlessHost()
+    options = Options(environment={"kind": "virtualenv", "force": True})
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            None,
+            options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+            entrypoint="example:run",
+            build_environment=False,
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.define_environment.call_args
+    assert "force" not in call_kwargs
+    assert options.environment["force"] is True
+
+
+def test_run_omits_force_when_build_environment_false():
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+
+    host = FalServerlessHost()
+    options = Options(environment={"kind": "virtualenv", "force": True})
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "ok"
+    connection.run.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host._run(
+            None,
+            options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+            entrypoint="example:run",
+            build_environment=False,
+        )
+
+    assert result == "ok"
+    _, call_kwargs = connection.define_environment.call_args
+    assert "force" not in call_kwargs
+    assert options.environment["force"] is True
+
+
 def test_register_leaves_private_logs_unset_by_default():
     from fal.api.api import FalServerlessHost, Options
     from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType


### PR DESCRIPTION
The regression was introduced by `e70e60ac` (`feat: explicit BuildEnvironment step in fal deploy / fal run`, #1028), released starting with `fal_v1.75.0`. That split the flow into an explicit environment build followed by metadata/register calls with `build_environment=False`, but the `force` flag from `--no-cache` remained on those follow-up requests. The server rejects `force=True` together with `build_environment=False`.