### PR TITLE
fix(cli): treat remote deserialization as user exception

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -22,8 +22,8 @@ authors = [{ name = "Features & Labels <support@fal.ai>"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "isolate[build]>=0.26.7,<0.27.0",
-    "isolate-proto>=0.31.3,<1",
+    "isolate[build]>=0.26.9,<0.27.0",
+    "isolate-proto>=0.32.0,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle>=3.0.0,<3.2",

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -62,6 +62,7 @@ from fal.exceptions import (
 )
 from fal.exceptions.gpu import _is_cuda_oom_exception, _is_generic_gpu_error
 from fal.file_sync import FileSync, FileSyncOptions
+from fal.logging import get_logger
 from fal.logging.isolate import IsolateLogPrinter
 from fal.sdk import (
     FAL_SERVERLESS_DEFAULT_CONCURRENCY_BUFFER,
@@ -85,6 +86,8 @@ from fal.sdk import (
 
 if TYPE_CHECKING:
     from isolate.backends import BaseEnvironment
+
+logger = get_logger(__name__)
 
 ArgsT = ParamSpec("ArgsT")
 ReturnT = TypeVar("ReturnT", covariant=True)  # noqa: PLC0105
@@ -736,7 +739,22 @@ def _handle_grpc_error():
                 msg = str(e)
                 cause = e.__cause__
                 if isinstance(e, ExceptionDeserializationError):
-                    raise FalSerializationError(msg) from e
+                    logger.warning(
+                        "Failed to deserialize remote exception",
+                        exc_info=True,
+                    )
+                    exc_type = type(
+                        e.original_exception_type_name or "Exception",
+                        (Exception,),
+                        {"__module__": "builtins"},
+                    )
+                    exc_message = e.original_exception_message or ""
+                    remote_exc = exc_type(exc_message).with_traceback(
+                        e.original_traceback
+                    )
+                    raise UserFunctionException(
+                        "Uncaught user function exception"
+                    ) from remote_exc
                 if isinstance(cause, ModuleNotFoundError):
                     missing_module = cause.name
                     msg += (

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import List
 
 import rich
 
@@ -82,52 +81,6 @@ def _print_error(msg):
     console.print(f"{get_cross_icon(console)} {msg}")
 
 
-def _remote_exception_summary(stringized_traceback):
-    if not stringized_traceback:
-        return None
-
-    in_frames = False
-    summary_lines: List[str] = []
-    for line in stringized_traceback.splitlines():
-        if line.startswith("Traceback (most recent call last):"):
-            if summary_lines:
-                break
-            in_frames = True
-            continue
-        if summary_lines:
-            if line.startswith(
-                (
-                    "During handling of the above exception",
-                    "The above exception was the direct cause",
-                )
-            ):
-                break
-            summary_lines.append(line.rstrip())
-            continue
-        if not in_frames or not line.strip():
-            continue
-        if not line.startswith((" ", "\t")):
-            summary_lines.append(line.strip())
-
-    if summary_lines:
-        return "\n".join(summary_lines).strip()
-    return None
-
-
-def _render_remote_traceback(remote_exception, remote_traceback):
-    if remote_exception:
-        qualname, _, message = remote_exception.partition(": ")
-        exc_type = type(qualname, (Exception,), {})
-    else:
-        exc_type, message = Exception, ""
-
-    return rich.traceback.Traceback.from_exception(
-        exc_type,
-        exc_type(message),
-        remote_traceback,
-    )
-
-
 def _check_latest_version():
     from packaging.version import parse
     from rich.panel import Panel
@@ -169,10 +122,8 @@ def _check_latest_version():
 
 def main(argv=None) -> int:
     import grpc
-    from isolate.connections.common import ExceptionDeserializationError
 
     from fal.api import FalSerializationError, UserFunctionException
-    from fal.sdk import RemoteExceptionDeserializationError
 
     _check_latest_version()
 
@@ -184,31 +135,13 @@ def main(argv=None) -> int:
             ret = args.func(args)
     except (UserFunctionException, FalSerializationError) as _exc:
         cause = _exc.__cause__
-
-        if (
-            isinstance(_exc, FalSerializationError)
-            and isinstance(cause, ExceptionDeserializationError)
-            and cause.original_traceback is not None
-        ):
-            # Keep the runner error separate from local deserialization failure.
-            stringized_traceback = None
-            if isinstance(cause, RemoteExceptionDeserializationError):
-                stringized_traceback = cause.stringized_traceback
-            remote_exception = _remote_exception_summary(stringized_traceback)
-            console.print(
-                "[bold]The application raised this error on the runner:[/bold]"
-            )
-            console.print(
-                _render_remote_traceback(remote_exception, cause.original_traceback)
-            )
-        else:
-            exc: BaseException = cause or _exc
-            tb = rich.traceback.Traceback.from_exception(
-                type(exc),
-                exc,
-                exc.__traceback__,
-            )
-            console.print(tb)
+        exc: BaseException = cause or _exc
+        tb = rich.traceback.Traceback.from_exception(
+            type(exc),
+            exc,
+            exc.__traceback__,
+        )
+        console.print(tb)
 
         if isinstance(_exc, UserFunctionException):
             msg = "Unhandled user exception"

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -5,7 +5,6 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -19,10 +18,6 @@ from typing import (
 
 import grpc
 import isolate_proto
-from isolate.connections.common import (
-    ExceptionDeserializationError,
-    load_serialized_object,
-)
 from isolate.server.interface import from_grpc, to_serialized_object, to_struct
 
 from fal import flags
@@ -601,36 +596,6 @@ def _from_grpc_register_application_result(
         if message.HasField("service_urls")
         else None,
     )
-
-
-class RemoteExceptionDeserializationError(ExceptionDeserializationError):
-    """A remote exception that couldn't be deserialized locally."""
-
-    def __init__(
-        self,
-        message: str,
-        original_traceback: TracebackType | None,
-        stringized_traceback: str | None = None,
-    ) -> None:
-        super().__init__(message, original_traceback)
-        self.stringized_traceback = stringized_traceback
-
-
-@from_grpc.register(isolate_proto.SerializedObject)
-def _from_grpc_serialized_object(message: isolate_proto.SerializedObject) -> Any:
-    try:
-        return load_serialized_object(
-            message.method,
-            message.definition,
-            was_it_raised=message.was_it_raised,
-            stringized_traceback=message.stringized_traceback,
-        )
-    except ExceptionDeserializationError as exc:
-        raise RemoteExceptionDeserializationError(
-            exc.message,
-            original_traceback=exc.original_traceback,
-            stringized_traceback=message.stringized_traceback or None,
-        ) from exc.__cause__
 
 
 @from_grpc.register(isolate_proto.BuildEnvironmentResult)

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -1,17 +1,19 @@
 import importlib
 from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import isolate_proto
 from isolate.server.interface import from_grpc
 from rich.console import Console
 
-from fal.api.api import _handle_grpc_error
+import fal.api.api as api_module
+from fal.api.api import UserFunctionException, _handle_grpc_error
 
 cli_main = importlib.import_module("fal.cli.main")
 
 
-def test_main_shows_remote_exception_without_local_deserialization_traceback(
+def test_main_shows_synthetic_remote_exception_for_deserialization_error(
     monkeypatch,
 ) -> None:
     console = Console(record=True, width=120, force_terminal=False, color_system=None)
@@ -27,6 +29,8 @@ def test_main_shows_remote_exception_without_local_deserialization_traceback(
             definition=b"not a pickle",
             was_it_raised=True,
             stringized_traceback=stringized_traceback,
+            exception_type_name="LocalEntryNotFoundError",
+            exception_message="test error\nadditional remote detail",
         ),
     )
 
@@ -40,16 +44,58 @@ def test_main_shows_remote_exception_without_local_deserialization_traceback(
     monkeypatch.setattr(
         cli_main, "parse_args", lambda _argv: SimpleNamespace(func=fail)
     )
+    warning = MagicMock()
+    monkeypatch.setattr(api_module, "logger", SimpleNamespace(warning=warning))
 
     assert cli_main.main([]) == 1
     output = console.export_text()
-    remote_exception = "huggingface_hub.errors.LocalEntryNotFoundError: test error"
+    remote_exception = "LocalEntryNotFoundError: test error"
 
-    assert "The application raised this error on the runner" in output
     assert output.index("Traceback (most recent call last)") < output.index(
         remote_exception
     )
     assert "additional remote detail" in output
     assert "in boom:13" in output
+    assert "Remote exception class was not importable locally" not in output
+    assert "Unhandled user exception" in output
     assert "\nException\n" not in output
-    assert "pickle data was truncated" not in output
+    assert "ExceptionDeserializationError" not in output
+    assert "UnpicklingError" not in output
+    assert "invalid load key" not in output
+    assert "Error while deserializing the given object" not in output
+    warning.assert_called_once_with(
+        "Failed to deserialize remote exception",
+        exc_info=True,
+    )
+
+
+def test_remote_exception_deserialization_is_user_function_exception() -> None:
+    stringized_traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "/app/handler.py", line 13, in boom\n'
+        "dvc.exceptions.DvcException: This is a test error\n"
+    )
+    result = isolate_proto.HostedRunResult(
+        return_value=isolate_proto.SerializedObject(
+            method="pickle",
+            definition=b"not a pickle",
+            was_it_raised=True,
+            stringized_traceback=stringized_traceback,
+            exception_type_name="DvcException",
+            exception_message="This is a test error",
+        ),
+    )
+
+    @_handle_grpc_error()
+    def fail():
+        from_grpc(result)
+
+    try:
+        fail()
+    except UserFunctionException as exc:
+        assert str(exc) == "Uncaught user function exception"
+        assert type(exc.__cause__).__name__ == "DvcException"
+        assert str(exc.__cause__) == "This is a test error"
+        assert exc.__cause__.__cause__ is None
+    else:
+        raise AssertionError("expected UserFunctionException")

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -4,12 +4,43 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fal import App, endpoint
-from fal.api import FalServerlessError, IsolatedFunction, Options
+from fal.api import (
+    FalServerlessError,
+    IsolatedFunction,
+    Options,
+    UserFunctionException,
+)
 from fal.api.run import run as run_api
 
 
 class _FakeHost:
     pass
+
+
+def test_run_reraises_synthetic_remote_exception_for_deserialization_error():
+    remote_error = type(
+        "RemoteOnlyError",
+        (Exception,),
+        {"__module__": "builtins"},
+    )("remote message")
+    user_error = UserFunctionException("Uncaught user function exception")
+    user_error.__cause__ = remote_error
+
+    host = MagicMock()
+    host.run.side_effect = user_error
+    iso = IsolatedFunction(
+        host=host,
+        raw_func=lambda: None,
+        options=Options(),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        run_api(iso)
+
+    assert type(exc_info.value).__name__ == "RemoteOnlyError"
+    assert str(exc_info.value) == "remote message"
+    assert not isinstance(exc_info.value, UserFunctionException)
+    assert exc_info.value.__cause__ is None
 
 
 def test_options_get_exposed_port_prefers_configured_port_for_serve_true():


### PR DESCRIPTION
## Summary

- Treat remote exception deserialization failures as `UserFunctionException` so the CLI keeps the usual unhandled-user-exception UX.
- Upgrade to `isolate>=0.26.9` and `isolate-proto>=0.32.0`, and render the remote exception from isolate's `original_exception_type_name` / `original_exception_message` metadata instead of parsing traceback text.
- Keep `fal.api.run(..., reraise=True)` from unwrapping these failures into the local `ExceptionDeserializationError`, since that cause is a transport detail rather than the original user exception.

## Why

When the remote exception class is not importable locally, the deserialization failure is an implementation detail of transporting/rendering the remote error. The user-facing error is still the unhandled remote user exception.

## Validation

- `/tmp/fal-remote-exc-venv/bin/python -m pytest -q projects/fal/tests/unit/cli/test_main.py projects/fal/tests/unit/test_api_run.py`
- `/tmp/fal-remote-exc-venv/bin/python -m pytest -q projects/fal/tests/unit/cli/test_main.py projects/fal/tests/unit/test_grpc_error_handling.py projects/fal/tests/unit/test_api_run.py`
- `uvx --python /Users/efiop/.local/share/uv/python/cpython-3.11.11-macos-aarch64-none/bin/python3.11 pre-commit run --all-files`
