### PR TITLE
feat(fal): add retry_config deployment option

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -1088,6 +1088,7 @@ class FalServerlessHost(Host):
         regions = options.host.get("regions")
         health_check_config = options.host.get("health_check_config")
         skip_retry_conditions = options.host.get("skip_retry_conditions")
+        retry_config = options.host.get("retry_config")
         termination_grace_period_seconds = options.host.get(
             "termination_grace_period_seconds"
         )
@@ -1160,6 +1161,7 @@ class FalServerlessHost(Host):
             private_logs=options.host.get("private_logs"),
             files=files,
             skip_retry_conditions=skip_retry_conditions,
+            retry_config=retry_config,
             environment_name=environment_name,
             termination_grace_period_seconds=termination_grace_period_seconds,
             secrets=secrets,

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -38,6 +38,8 @@ from fal.sdk import (
     AuthModeLiteral,
     HealthCheck,
     RetryConditionLiteral,
+    RetryConfig,
+    RetryConfigDict,
 )
 from fal.toolkit.file import request_lifecycle_preference
 from fal.toolkit.file.providers.fal import _LIFECYCLE_PREFERENCE
@@ -567,6 +569,7 @@ class App(BaseServable):
     image: ClassVar[Optional[ContainerImage]] = None
     local_file_path: ClassVar[Optional[str]] = None
     skip_retry_conditions: ClassVar[Optional[list[RetryConditionLiteral]]] = None
+    retry_config: ClassVar[Optional[RetryConfig | RetryConfigDict]] = None
     termination_grace_period_seconds: ClassVar[Optional[int]] = None
     secrets: ClassVar[Optional[list[str]]] = None
     data_mounts: ClassVar[Optional[list[str]]] = None
@@ -643,6 +646,9 @@ class App(BaseServable):
 
         if cls.skip_retry_conditions is not None:
             cls.host_kwargs["skip_retry_conditions"] = cls.skip_retry_conditions
+
+        if cls.retry_config is not None:
+            cls.host_kwargs["retry_config"] = cls.retry_config
 
         if cls.termination_grace_period_seconds is not None:
             cls.host_kwargs["termination_grace_period_seconds"] = (

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -140,6 +140,7 @@ def get_app_data_from_toml(
     scheduler = app_data.pop("_scheduler", None)
     scheduler_options = app_data.pop("_scheduler_options", None)
     skip_retry_conditions = app_data.pop("skip_retry_conditions", None)
+    retry_config = app_data.pop("retry_config", None)
     termination_grace_period_seconds = app_data.pop(
         "termination_grace_period_seconds", None
     )
@@ -177,6 +178,8 @@ def get_app_data_from_toml(
         raise ValueError("_scheduler_options must be a table in pyproject.toml.")
     if skip_retry_conditions is not None:
         _validate_skip_retry_conditions(skip_retry_conditions)
+    if retry_config is not None:
+        _validate_retry_config(retry_config)
     if termination_grace_period_seconds is not None:
         _validate_int(
             "termination_grace_period_seconds", termination_grace_period_seconds
@@ -229,6 +232,8 @@ def get_app_data_from_toml(
         options.host["_scheduler_options"] = scheduler_options
     if skip_retry_conditions is not None:
         options.host["skip_retry_conditions"] = skip_retry_conditions
+    if retry_config is not None:
+        options.host["retry_config"] = retry_config
     if termination_grace_period_seconds is not None:
         options.host["termination_grace_period_seconds"] = (
             termination_grace_period_seconds
@@ -339,6 +344,12 @@ def _validate_skip_retry_conditions(value: Any) -> None:
             "Valid conditions are: "
             f"{', '.join(sorted(VALID_RETRY_CONDITIONS))}"
         )
+
+
+def _validate_retry_config(value: Any) -> None:
+    from fal.sdk import validate_retry_config_dict  # noqa: PLC0415
+
+    validate_retry_config_dict(value)
 
 
 def _validate_port(field_name: str, value: Any) -> None:

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -13,6 +13,7 @@ from fal.sdk import (
     AuthModeLiteral,
     DeploymentStrategyLiteral,
     RetryConditionLiteral,
+    validate_retry_config_dict,
 )
 
 VALID_REGIONS = {
@@ -179,7 +180,7 @@ def get_app_data_from_toml(
     if skip_retry_conditions is not None:
         _validate_skip_retry_conditions(skip_retry_conditions)
     if retry_config is not None:
-        _validate_retry_config(retry_config)
+        validate_retry_config_dict(retry_config)
     if termination_grace_period_seconds is not None:
         _validate_int(
             "termination_grace_period_seconds", termination_grace_period_seconds
@@ -344,12 +345,6 @@ def _validate_skip_retry_conditions(value: Any) -> None:
             "Valid conditions are: "
             f"{', '.join(sorted(VALID_RETRY_CONDITIONS))}"
         )
-
-
-def _validate_retry_config(value: Any) -> None:
-    from fal.sdk import validate_retry_config_dict  # noqa: PLC0415
-
-    validate_retry_config_dict(value)
 
 
 def _validate_port(field_name: str, value: Any) -> None:

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -72,15 +72,13 @@ class RetryConfig:
     connection_error: Optional[int] = None
 
     def to_dict(self) -> RetryConfigDict:
-        result = {
-            cond: {"retries": max(int(count), 0)}
-            for cond, count in (
-                ("timeout", self.timeout),
-                ("server_error", self.server_error),
-                ("connection_error", self.connection_error),
-            )
-            if count is not None
-        }
+        result: RetryConfigDict = {}
+        if self.timeout is not None:
+            result["timeout"] = {"retries": max(int(self.timeout), 0)}
+        if self.server_error is not None:
+            result["server_error"] = {"retries": max(int(self.server_error), 0)}
+        if self.connection_error is not None:
+            result["connection_error"] = {"retries": max(int(self.connection_error), 0)}
         if not result:
             raise ValueError("RetryConfig must have at least one condition.")
         return result

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -9,11 +9,14 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Generic,
     Iterator,
     Literal,
     Optional,
+    TypedDict,
     TypeVar,
+    get_args,
 )
 
 import grpc
@@ -51,6 +54,69 @@ patch_pickle()
 AuthModeLiteral = Literal["public", "private", "shared"]
 DeploymentStrategyLiteral = Literal["recreate", "rolling"]
 RetryConditionLiteral = Literal["timeout", "server_error", "connection_error"]
+
+
+class _RetriesEntry(TypedDict):
+    retries: int
+
+
+RetryConfigDict = Dict[RetryConditionLiteral, _RetriesEntry]
+
+
+@dataclass
+class RetryConfig:
+    """Per-condition retry counts, e.g. RetryConfig(server_error=3, timeout=1)."""
+
+    timeout: Optional[int] = None
+    server_error: Optional[int] = None
+    connection_error: Optional[int] = None
+
+    def to_dict(self) -> RetryConfigDict:
+        result = {
+            cond: {"retries": max(int(count), 0)}
+            for cond, count in (
+                ("timeout", self.timeout),
+                ("server_error", self.server_error),
+                ("connection_error", self.connection_error),
+            )
+            if count is not None
+        }
+        if not result:
+            raise ValueError("RetryConfig must have at least one condition.")
+        return result
+
+
+def validate_retry_config_dict(value: Any) -> RetryConfigDict:
+    """Validate a RetryConfigDict.
+
+    Raises ValueError on any invalid key, shape, or value.
+    """
+    if not isinstance(value, dict):
+        raise ValueError(
+            "retry_config must be a mapping of condition -> {retries: int}"
+        )
+    valid = set(get_args(RetryConditionLiteral))
+    normalized: RetryConfigDict = {}
+    for cond, entry in value.items():
+        if cond not in valid:
+            raise ValueError(
+                f"Invalid retry_config condition: {cond}. "
+                f"Valid conditions are: {', '.join(sorted(valid))}"
+            )
+        if not isinstance(entry, dict) or set(entry) != {"retries"}:
+            raise ValueError(
+                f"retry_config[{cond!r}] must be an object of the form "
+                '{"retries": <non-negative int>}'
+            )
+        retries = entry["retries"]
+        if not isinstance(retries, int) or isinstance(retries, bool):
+            raise ValueError(f"retry_config[{cond!r}]['retries'] must be an integer")
+        normalized[cond] = {"retries": max(retries, 0)}
+
+    if not normalized:
+        raise ValueError("retry_config must have at least one condition.")
+    return normalized
+
 
 ENVIRONMENT_SEPARATOR = "--"
 
@@ -864,6 +930,7 @@ class FalServerlessConnection:
         private_logs: bool | None = None,
         files: list[File] | None = None,
         skip_retry_conditions: list[RetryConditionLiteral] | None = None,
+        retry_config: RetryConfig | RetryConfigDict | None = None,
         environment_name: str | None = None,
         termination_grace_period_seconds: int | None = None,
         secrets: list[str] | None = None,
@@ -947,6 +1014,19 @@ class FalServerlessConnection:
         else:
             wrapped_skip_retry_conditions = []
 
+        if retry_config is None:
+            wrapped_retry_config = None
+        elif isinstance(retry_config, RetryConfig):
+            import json  # noqa: PLC0415
+
+            wrapped_retry_config = json.dumps(retry_config.to_dict(), sort_keys=True)
+        else:
+            import json  # noqa: PLC0415
+
+            wrapped_retry_config = json.dumps(
+                validate_retry_config_dict(retry_config), sort_keys=True
+            )
+
         full_application_name = (
             construct_alias(application_name, environment_name)
             if application_name
@@ -965,6 +1045,7 @@ class FalServerlessConnection:
             source_code=source_code,
             health_check_config=wrapped_health_check_config,
             skip_retry_conditions=wrapped_skip_retry_conditions,
+            retry_config=wrapped_retry_config,
             environment_name=environment_name,
             termination_grace_period_seconds=termination_grace_period_seconds,
             secrets=(

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -2014,23 +2014,3 @@ def test_deploy_with_env_check_and_yes_renders_summary_without_prompt(
     mock_prepare_deployment.assert_called_once()
     mock_execute_prepared_deployment.assert_called_once()
     mock_input.assert_not_called()
-
-
-def test_validate_retry_config_accepts_nested_form():
-    from fal.cli._utils import _validate_retry_config
-
-    _validate_retry_config({"server_error": {"retries": 3}})  # no raise
-
-
-def test_validate_retry_config_rejects_bare_int_shorthand():
-    from fal.cli._utils import _validate_retry_config
-
-    with pytest.raises(ValueError, match="must be an object"):
-        _validate_retry_config({"server_error": 3})
-
-
-def test_validate_retry_config_rejects_unknown_condition():
-    from fal.cli._utils import _validate_retry_config
-
-    with pytest.raises(ValueError, match="Invalid retry_config condition"):
-        _validate_retry_config({"nope": {"retries": 1}})

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -216,6 +216,7 @@ def mock_parse_pyproject_toml():
                     "server_error",
                     "connection_error",
                 ],
+                "retry_config": {"server_error": {"retries": 3}},
                 "termination_grace_period_seconds": 30,
                 "secrets": ["OPENAI_API_KEY", "HF_TOKEN"],
                 "data_mounts": ["/data", "/data/.cache"],
@@ -1183,6 +1184,7 @@ def test_get_app_data_from_toml_with_advanced_runtime_options(
             "server_error",
             "connection_error",
         ],
+        "retry_config": {"server_error": {"retries": 3}},
         "termination_grace_period_seconds": 30,
         "secrets": ["OPENAI_API_KEY", "HF_TOKEN"],
         "data_mounts": ["/data", "/data/.cache"],
@@ -2012,3 +2014,23 @@ def test_deploy_with_env_check_and_yes_renders_summary_without_prompt(
     mock_prepare_deployment.assert_called_once()
     mock_execute_prepared_deployment.assert_called_once()
     mock_input.assert_not_called()
+
+
+def test_validate_retry_config_accepts_nested_form():
+    from fal.cli._utils import _validate_retry_config
+
+    _validate_retry_config({"server_error": {"retries": 3}})  # no raise
+
+
+def test_validate_retry_config_rejects_bare_int_shorthand():
+    from fal.cli._utils import _validate_retry_config
+
+    with pytest.raises(ValueError, match="must be an object"):
+        _validate_retry_config({"server_error": 3})
+
+
+def test_validate_retry_config_rejects_unknown_condition():
+    from fal.cli._utils import _validate_retry_config
+
+    with pytest.raises(ValueError, match="Invalid retry_config condition"):
+        _validate_retry_config({"nope": {"retries": 1}})

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -1855,3 +1855,22 @@ def test_app_lifecycle_callbacks_are_called():
     assert "setup" in lines
     assert "handle_exit" in lines
     assert "teardown" in lines
+
+
+def test_retry_config_classvar_propagates_to_host_kwargs():
+    from fal.sdk import RetryConfig
+
+    class NoRetryApp(App):
+        pass
+
+    assert "retry_config" not in NoRetryApp.host_kwargs
+
+    class RetryDataclassApp(App):
+        retry_config = RetryConfig(server_error=3)
+
+    assert RetryDataclassApp.host_kwargs["retry_config"] == RetryConfig(server_error=3)
+
+    class RetryDictApp(App):
+        retry_config = {"timeout": {"retries": 2}}
+
+    assert RetryDictApp.host_kwargs["retry_config"] == {"timeout": {"retries": 2}}

--- a/projects/fal/tests/unit/test_sdk.py
+++ b/projects/fal/tests/unit/test_sdk.py
@@ -5,7 +5,9 @@ import pytest
 from fal.sdk import (
     FalServerlessConnection,
     FalServerlessKeyCredentials,
+    RetryConfig,
     get_credentials,
+    validate_retry_config_dict,
 )
 
 
@@ -152,3 +154,166 @@ def test_connection_run_rejects_isolate_container_without_callable():
 
     with pytest.raises(ValueError, match="either function or entrypoint"):
         list(connection.run(None, [environment]))
+
+
+def test_retry_config_to_dict_behaviors():
+    # Test emits nested form and omits None
+    cfg = RetryConfig(server_error=3, timeout=1)
+    assert cfg.to_dict() == {
+        "server_error": {"retries": 3},
+        "timeout": {"retries": 1},
+    }
+    assert "connection_error" not in cfg.to_dict()
+
+    # Test clamps negatives
+    assert RetryConfig(server_error=-5).to_dict() == {"server_error": {"retries": 0}}
+
+    # Test empty config errors: users must define at least one condition
+    with pytest.raises(ValueError, match="at least one condition"):
+        RetryConfig().to_dict()
+
+
+def test_validate_retry_config_dict_behaviors():
+    cases = [
+        (
+            {"bad_condition": {"retries": 1}},
+            "Invalid retry_config condition",
+        ),
+        (
+            {"server_error": 3},
+            "must be an object",
+        ),
+        (
+            {"server_error": {"retries": "3"}},
+            "must be an integer",
+        ),
+        (
+            {"server_error": {"retries": True}},
+            "must be an integer",
+        ),
+        (
+            {"server_error": {"retries": 1, "extra": 2}},
+            "must be an object",
+        ),
+        (
+            [("server_error", 1)],  # Not a dict, but a list of tuples
+            "must be a mapping",
+        ),
+    ]
+    for invalid_input, expected_msg in cases:
+        with pytest.raises(ValueError, match=expected_msg):
+            validate_retry_config_dict(invalid_input)
+
+    assert validate_retry_config_dict({"server_error": {"retries": 3}}) == {
+        "server_error": {"retries": 3}
+    }
+    assert validate_retry_config_dict({"timeout": {"retries": -2}}) == {
+        "timeout": {"retries": 0}
+    }
+
+
+def test_register_sets_retry_config_from_dataclass():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+            retry_config=RetryConfig(server_error=3),
+        )
+    )
+
+    assert stub.register_request.retry_config == '{"server_error": {"retries": 3}}'
+
+
+def test_register_sets_retry_config_from_dict():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+            retry_config={"timeout": {"retries": 2}},
+        )
+    )
+
+    assert stub.register_request.retry_config == '{"timeout": {"retries": 2}}'
+
+
+def test_register_rejects_invalid_retry_config_dict():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    with pytest.raises(ValueError, match="Invalid retry_config condition"):
+        list(
+            connection.register(
+                None,
+                [environment],
+                application_name="container-app",
+                deployment_strategy="rolling",
+                retry_config={"bogus": {"retries": 1}},
+            )
+        )
+
+
+def test_register_omits_retry_config_when_none():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+        )
+    )
+
+    assert not stub.register_request.HasField("retry_config")
+
+
+def test_register_rejects_empty_retry_config():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    with pytest.raises(ValueError, match="at least one condition"):
+        list(
+            connection.register(
+                None,
+                [environment],
+                application_name="container-app",
+                deployment_strategy="rolling",
+                retry_config=RetryConfig(),
+            )
+        )


### PR DESCRIPTION
## Summary

Adds a new `retry_config` deployment option that lets users configure how many times a request should be retried per failure condition (`timeout`, `server_error`, `connection_error`).

This complements the existing `skip_retry_conditions` option: where `skip_retry_conditions` disables retries for a condition entirely, `retry_config` lets you set explicit per-condition retry counts.

## What's included

- **`RetryConfig` dataclass** (`fal.sdk`) — ergonomic Python API, e.g. `RetryConfig(server_error=3, timeout=1)`. Negative counts are clamped to `0`. An empty config raises — users must either omit `retry_config` (or pass `None`) or define at least one condition.
- **`validate_retry_config_dict`** — validates the raw nested-dict form `{condition: {retries: int}}`, rejecting unknown conditions, malformed shapes, and non-integer/boolean retry values.
- **`App.retry_config` ClassVar** — set it on an `App` subclass (accepts either a `RetryConfig` or the nested dict) and it propagates into the deployment options.
- **`pyproject.toml` support** — configure `retry_config` declaratively via the nested-dict form, validated at parse time:
  ```toml
  [tool.fal.apps.my-app]
  ref = "my_app:MyApp"
  retry_config = { server_error = { retries = 3 }, timeout = { retries = 1 } }
  ```
- Wired through the SDK `register` call so the config is serialized and sent at deploy time.

## Testing

- Unit tests for `RetryConfig.to_dict()` (nested form, negative clamping, empty-config error)
- Validation tests covering valid configs and rejection of invalid conditions/shapes/types
- `register` integration tests for the dataclass form, dict form, invalid input, omitted config, and empty-config rejection
- `App` ClassVar propagation tests and TOML parsing/validation tests