### PR TITLE
feat(toolkit): document image/video size limits via x-fal

### DIFF
--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -11,8 +11,6 @@ from fal.toolkit.constraints import (
     ImageSizeConstraints,
     ImageValidationConfig,
     ImageValidationOptions,
-    VideoValidationConfig,
-    VideoValidationOptions,
     to_xfal,
 )
 from fal.toolkit.exceptions import (
@@ -56,8 +54,6 @@ __all__ = [
     "ImageSizeInput",
     "ImageValidationConfig",
     "ImageValidationOptions",
-    "VideoValidationConfig",
-    "VideoValidationOptions",
     "to_xfal",
     "KVStore",
     "Video",

--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -7,6 +7,14 @@ from fal.toolkit.compilation import (
     sync_inductor_cache,
     synchronized_inductor_cache,
 )
+from fal.toolkit.constraints import (
+    ImageSizeConstraints,
+    ImageValidationConfig,
+    ImageValidationOptions,
+    VideoValidationConfig,
+    VideoValidationOptions,
+    to_xfal,
+)
 from fal.toolkit.exceptions import (
     FalTookitException,
     FileUploadException,
@@ -16,7 +24,6 @@ from fal.toolkit.file import CompressedFile, File, FileField
 from fal.toolkit.image.image import (
     Image,
     ImageField,
-    ImageSizeConstraints,
     ImageSizeField,
     ImageSizeInput,
     get_image_size,
@@ -47,6 +54,11 @@ __all__ = [
     "ImageSizeConstraints",
     "ImageSizeField",
     "ImageSizeInput",
+    "ImageValidationConfig",
+    "ImageValidationOptions",
+    "VideoValidationConfig",
+    "VideoValidationOptions",
+    "to_xfal",
     "KVStore",
     "Video",
     "VideoField",

--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -13,7 +13,14 @@ from fal.toolkit.exceptions import (
     KVStoreException,
 )
 from fal.toolkit.file import CompressedFile, File, FileField
-from fal.toolkit.image.image import Image, ImageField, ImageSizeInput, get_image_size
+from fal.toolkit.image.image import (
+    Image,
+    ImageField,
+    ImageSizeConstraints,
+    ImageSizeField,
+    ImageSizeInput,
+    get_image_size,
+)
 from fal.toolkit.kv import KVStore
 from fal.toolkit.pydantic import FalBaseModel, Field, Hidden
 from fal.toolkit.utils import (
@@ -37,6 +44,8 @@ __all__ = [
     "FileField",
     "Image",
     "ImageField",
+    "ImageSizeConstraints",
+    "ImageSizeField",
     "ImageSizeInput",
     "KVStore",
     "Video",

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -8,7 +8,9 @@ from typing import Any, Optional, TypedDict
 _NON_SCHEMA_FIELDS = {"auto_fix"}
 
 
-def to_xfal(config: Any) -> dict:
+def to_xfal(
+    config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
+) -> dict[str, Any]:
     """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
     return {
         key: value

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Optional, TypedDict
+
+# Config fields that describe runtime behavior rather than documented limits, and
+# so are excluded from the ``x-fal`` schema extension.
+_NON_SCHEMA_FIELDS = {"auto_fix"}
+
+
+def to_xfal(config: Any) -> dict:
+    """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
+    return {
+        key: value
+        for key, value in dataclasses.asdict(config).items()
+        if value is not None and key not in _NON_SCHEMA_FIELDS
+    }
+
+
+def _validate_aspect_ratio_pair(
+    min_aspect_ratio: Optional[float], max_aspect_ratio: Optional[float]
+) -> None:
+    # A single bound is ambiguous since aspect ratio can be read either way.
+    if (min_aspect_ratio is None) != (max_aspect_ratio is None):
+        raise ValueError(
+            "min_aspect_ratio and max_aspect_ratio must be provided together."
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ImageSizeConstraints:
+    """Advisory limits on the image size a model can generate.
+
+    Attach to an ``image_size`` field via :func:`fal.toolkit.ImageSizeField` to
+    surface the model's size envelope in the OpenAPI schema (under the ``x-fal``
+    extension), so clients and UIs can validate sizes before a request. These are
+    documentation hints and are not enforced by the SDK.
+    """
+
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_area: Optional[int] = None
+    max_area: Optional[int] = None
+    multiple_of: Optional[int] = None
+    min_aspect_ratio: Optional[float] = None
+    max_aspect_ratio: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
+
+
+class ImageValidationOptions(TypedDict, total=False):
+    """Validation options accepted by input-image helpers."""
+
+    max_file_size: Optional[int]
+    min_width: Optional[int]
+    min_height: Optional[int]
+    max_width: Optional[int]
+    max_height: Optional[int]
+    min_aspect_ratio: Optional[float]
+    max_aspect_ratio: Optional[float]
+    timeout: Optional[float]
+
+
+@dataclasses.dataclass(frozen=True)
+class ImageValidationConfig:
+    """Limits applied to an input image. Surfaced in the schema (``x-fal``); the
+    SDK does not enforce them."""
+
+    max_file_size: Optional[int] = None
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_aspect_ratio: Optional[float] = None
+    max_aspect_ratio: Optional[float] = None
+    timeout: float = 20.0
+
+    def __post_init__(self) -> None:
+        _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
+
+
+class VideoValidationOptions(TypedDict, total=False):
+    """Validation options accepted by input-video helpers."""
+
+    max_file_size: Optional[int]
+    min_width: Optional[int]
+    min_height: Optional[int]
+    max_width: Optional[int]
+    max_height: Optional[int]
+    min_aspect_ratio: Optional[float]
+    max_aspect_ratio: Optional[float]
+    min_frames: Optional[int]
+    max_frames: Optional[int]
+    min_duration: Optional[float]
+    max_duration: Optional[float]
+    min_fps: Optional[float]
+    max_fps: Optional[float]
+    timeout: Optional[float]
+    auto_fix: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class VideoValidationConfig:
+    """Limits applied to an input video. Surfaced in the schema (``x-fal``); the
+    SDK does not enforce them."""
+
+    max_file_size: Optional[int] = None
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_aspect_ratio: Optional[float] = None
+    max_aspect_ratio: Optional[float] = None
+    min_frames: Optional[int] = None
+    max_frames: Optional[int] = None
+    min_duration: Optional[float] = None
+    max_duration: Optional[float] = None
+    min_fps: Optional[float] = None
+    max_fps: Optional[float] = None
+    timeout: float = 30.0
+    auto_fix: bool = True

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -5,11 +5,11 @@ from typing import Any, Optional, TypedDict
 
 # Runtime settings (download/processing), not client-checkable limits, so they
 # are never emitted in the ``x-fal`` schema extension.
-_NON_SCHEMA_FIELDS = {"auto_fix", "timeout"}
+_NON_SCHEMA_FIELDS = {"timeout"}
 
 
 def to_xfal(
-    config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
+    config: ImageSizeConstraints | ImageValidationConfig,
 ) -> dict[str, Any]:
     """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
     return {
@@ -82,45 +82,3 @@ class ImageValidationConfig:
 
     def __post_init__(self) -> None:
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
-
-
-class VideoValidationOptions(TypedDict, total=False):
-    """Validation options accepted by input-video helpers."""
-
-    max_file_size: Optional[int]
-    min_width: Optional[int]
-    min_height: Optional[int]
-    max_width: Optional[int]
-    max_height: Optional[int]
-    min_aspect_ratio: Optional[float]
-    max_aspect_ratio: Optional[float]
-    min_frames: Optional[int]
-    max_frames: Optional[int]
-    min_duration: Optional[float]
-    max_duration: Optional[float]
-    min_fps: Optional[float]
-    max_fps: Optional[float]
-    timeout: Optional[float]
-    auto_fix: bool
-
-
-@dataclasses.dataclass(frozen=True)
-class VideoValidationConfig:
-    """Limits applied to an input video. Surfaced in the schema (``x-fal``); the
-    SDK does not enforce them."""
-
-    max_file_size: Optional[int] = None
-    min_width: Optional[int] = None
-    min_height: Optional[int] = None
-    max_width: Optional[int] = None
-    max_height: Optional[int] = None
-    min_aspect_ratio: Optional[float] = None
-    max_aspect_ratio: Optional[float] = None
-    min_frames: Optional[int] = None
-    max_frames: Optional[int] = None
-    min_duration: Optional[float] = None
-    max_duration: Optional[float] = None
-    min_fps: Optional[float] = None
-    max_fps: Optional[float] = None
-    timeout: float = 30.0
-    auto_fix: bool = True

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -3,20 +3,29 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Optional, TypedDict
 
-# Config fields that describe runtime behavior (download/processing) rather than
-# client-validatable limits, and so are excluded from the ``x-fal`` schema extension.
-_NON_SCHEMA_FIELDS = {"auto_fix", "timeout"}
+# Processing toggles that are never documented as limits.
+_NON_SCHEMA_FIELDS = {"auto_fix"}
+# Runtime settings that ride along with real limits but never stand alone, so a
+# defaults-only config emits nothing (mirrors the registry's gated emission).
+_PASSIVE_FIELDS = {"timeout"}
 
 
 def to_xfal(
     config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
 ) -> dict[str, Any]:
-    """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
-    return {
+    """Return a config's set (non-None) limits as the ``x-fal`` schema payload.
+
+    ``auto_fix`` is always omitted; ``timeout`` is included only alongside real
+    limits, so a config that set no limits emits nothing.
+    """
+    values = {
         key: value
         for key, value in dataclasses.asdict(config).items()
         if value is not None and key not in _NON_SCHEMA_FIELDS
     }
+    if all(key in _PASSIVE_FIELDS for key in values):
+        return {}
+    return values
 
 
 def _validate_aspect_ratio_pair(

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Optional, TypedDict
 
-# Config fields that describe runtime behavior rather than documented limits, and
-# so are excluded from the ``x-fal`` schema extension.
-_NON_SCHEMA_FIELDS = {"auto_fix"}
+# Config fields that describe runtime behavior (download/processing) rather than
+# client-validatable limits, and so are excluded from the ``x-fal`` schema extension.
+_NON_SCHEMA_FIELDS = {"auto_fix", "timeout"}
 
 
 def to_xfal(

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -3,29 +3,20 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Optional, TypedDict
 
-# Processing toggles that are never documented as limits.
-_NON_SCHEMA_FIELDS = {"auto_fix"}
-# Runtime settings that ride along with real limits but never stand alone, so a
-# defaults-only config emits nothing (mirrors the registry's gated emission).
-_PASSIVE_FIELDS = {"timeout"}
+# Runtime settings (download/processing), not client-checkable limits, so they
+# are never emitted in the ``x-fal`` schema extension.
+_NON_SCHEMA_FIELDS = {"auto_fix", "timeout"}
 
 
 def to_xfal(
     config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
 ) -> dict[str, Any]:
-    """Return a config's set (non-None) limits as the ``x-fal`` schema payload.
-
-    ``auto_fix`` is always omitted; ``timeout`` is included only alongside real
-    limits, so a config that set no limits emits nothing.
-    """
-    values = {
+    """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
+    return {
         key: value
         for key, value in dataclasses.asdict(config).items()
         if value is not None and key not in _NON_SCHEMA_FIELDS
     }
-    if all(key in _PASSIVE_FIELDS for key in values):
-        return {}
-    return values
 
 
 def _validate_aspect_ratio_pair(

--- a/projects/fal/src/fal/toolkit/image/image.py
+++ b/projects/fal/src/fal/toolkit/image/image.py
@@ -68,17 +68,27 @@ def get_image_size(source: ImageSizeInput) -> ImageSize:
 
 
 @wraps(Field)
-def ImageSizeField(*args, constraints: Optional[ImageSizeConstraints] = None, **kwargs):
+def ImageSizeField(
+    *args,
+    constraints: Optional[ImageSizeConstraints] = None,
+    ui: Optional[dict] = None,
+    **kwargs,
+):
     """A ``Field`` for an ``image_size`` input that documents its size limits.
 
     Pass ``constraints`` to emit the model's size envelope under the ``x-fal``
-    schema extension; all other arguments are forwarded to ``Field``.
+    schema extension, and ``ui`` for UI metadata (e.g. ``{"important": True}``);
+    all other arguments are forwarded to ``Field``. ``ui`` is taken as an explicit
+    argument (rather than a passthrough kwarg) so it is not dropped when an
+    explicit ``json_schema_extra`` is also emitted on Pydantic v2.
     """
     fal_extra: dict = {}
     if constraints is not None:
         data = to_xfal(constraints)
         if data:
             fal_extra["x-fal"] = data
+    if ui:
+        fal_extra["ui"] = ui
 
     if IS_PYDANTIC_V2:
         json_schema_extra = kwargs.pop("json_schema_extra", None) or {}

--- a/projects/fal/src/fal/toolkit/image/image.py
+++ b/projects/fal/src/fal/toolkit/image/image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import io
 from functools import wraps
 from pathlib import Path
@@ -64,6 +65,67 @@ def get_image_size(source: ImageSizeInput) -> ImageSize:
         size = IMAGE_SIZE_PRESETS[source]
         return size
     raise TypeError(f"Invalid value for ImageSize: {source}")
+
+
+@dataclasses.dataclass(frozen=True)
+class ImageSizeConstraints:
+    """Advisory limits on the image size a model can generate.
+
+    Attach these to an ``image_size`` field via :func:`ImageSizeField` to surface
+    the model's size envelope in the OpenAPI schema (under the ``x-fal``
+    extension), so clients and UIs can validate sizes before a request. These are
+    documentation hints and are not enforced by the SDK.
+    """
+
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_area: Optional[int] = None
+    max_area: Optional[int] = None
+    multiple_of: Optional[int] = None
+    min_aspect_ratio: Optional[float] = None
+    max_aspect_ratio: Optional[float] = None
+
+    def to_schema_extra(self) -> dict:
+        """Return the set constraints as a plain dict for schema emission."""
+        return {
+            key: value
+            for key, value in dataclasses.asdict(self).items()
+            if value is not None
+        }
+
+
+@wraps(Field)
+def ImageSizeField(*args, constraints: Optional[ImageSizeConstraints] = None, **kwargs):
+    """A ``Field`` for an ``image_size`` input that documents its size limits.
+
+    Pass ``constraints`` to emit the model's size envelope under the ``x-fal``
+    schema extension; all other arguments are forwarded to ``Field``.
+    """
+    fal_extra: dict = {}
+    if constraints is not None:
+        data = constraints.to_schema_extra()
+        if data:
+            fal_extra["x-fal"] = data
+
+    if IS_PYDANTIC_V2:
+        json_schema_extra = kwargs.pop("json_schema_extra", None) or {}
+        if callable(json_schema_extra):
+            original_func = json_schema_extra
+
+            def merged_schema_extra(schema):
+                original_func(schema)
+                schema.update(fal_extra)
+
+            kwargs["json_schema_extra"] = merged_schema_extra
+        else:
+            json_schema_extra.update(fal_extra)
+            kwargs["json_schema_extra"] = json_schema_extra
+    else:
+        # Pydantic v1: extra kwargs are stored on the field and emitted as-is.
+        kwargs.update(fal_extra)
+    return Field(*args, **kwargs)
 
 
 ImageFormat = Literal["png", "jpeg", "jpg", "webp", "gif"]

--- a/projects/fal/src/fal/toolkit/image/image.py
+++ b/projects/fal/src/fal/toolkit/image/image.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import io
 from functools import wraps
 from pathlib import Path
@@ -11,6 +10,7 @@ from urllib.parse import urlparse
 from fastapi import Request
 from pydantic import BaseModel, Field
 
+from fal.toolkit.constraints import ImageSizeConstraints, to_xfal
 from fal.toolkit.file.file import (
     DEFAULT_REPOSITORY,
     FALLBACK_REPOSITORY,
@@ -67,35 +67,6 @@ def get_image_size(source: ImageSizeInput) -> ImageSize:
     raise TypeError(f"Invalid value for ImageSize: {source}")
 
 
-@dataclasses.dataclass(frozen=True)
-class ImageSizeConstraints:
-    """Advisory limits on the image size a model can generate.
-
-    Attach these to an ``image_size`` field via :func:`ImageSizeField` to surface
-    the model's size envelope in the OpenAPI schema (under the ``x-fal``
-    extension), so clients and UIs can validate sizes before a request. These are
-    documentation hints and are not enforced by the SDK.
-    """
-
-    min_width: Optional[int] = None
-    min_height: Optional[int] = None
-    max_width: Optional[int] = None
-    max_height: Optional[int] = None
-    min_area: Optional[int] = None
-    max_area: Optional[int] = None
-    multiple_of: Optional[int] = None
-    min_aspect_ratio: Optional[float] = None
-    max_aspect_ratio: Optional[float] = None
-
-    def to_schema_extra(self) -> dict:
-        """Return the set constraints as a plain dict for schema emission."""
-        return {
-            key: value
-            for key, value in dataclasses.asdict(self).items()
-            if value is not None
-        }
-
-
 @wraps(Field)
 def ImageSizeField(*args, constraints: Optional[ImageSizeConstraints] = None, **kwargs):
     """A ``Field`` for an ``image_size`` input that documents its size limits.
@@ -105,7 +76,7 @@ def ImageSizeField(*args, constraints: Optional[ImageSizeConstraints] = None, **
     """
     fal_extra: dict = {}
     if constraints is not None:
-        data = constraints.to_schema_extra()
+        data = to_xfal(constraints)
         if data:
             fal_extra["x-fal"] = data
 


### PR DESCRIPTION
NOTE: Because AIs get confused
PR https://github.com/fal-ai/fal/pull/1079 (image-size-constraints) = output constraints. ImageSizeConstraints + ImageSizeField describe the size envelope a model can generate, attached to the image_size input parameter. That's why its web-app counterpart is the constrained size picker (image-size.tsx clamping presets/custom dimensions via dimensionConstraints) - it constrains what the user requests, not what they upload.

## Summary

Adds first-class fields for declaring image-size limits on model inputs, surfaced in the OpenAPI schema (under the `x-fal` extension) so clients and UIs can validate sizes before a request. These are documentation hints; the SDK does not enforce them.

## What's added (`fal.toolkit`)

- **`ImageSizeConstraints`** - the size envelope a model can generate: `min/max_width`, `min/max_height`, `min/max_area`, `multiple_of`, `min/max_aspect_ratio`.
- **`ImageValidationConfig`** (+ matching `ImageValidationOptions` TypedDict) - limit config for input image fields.
- **`ImageSizeField(...)`** - a `Field` wrapper for an `image_size` input that emits the constraints under `x-fal` (modeled on the existing `ImageField`; pydantic v1/v2; preserves a caller `ui`).
- **`to_xfal(config)`** - shared helper turning any of the above configs into the `x-fal` payload (drops unset fields and runtime-only ones like `timeout`).

All live in a new `fal/toolkit/constraints.py` and are exported from `fal.toolkit`.

## Usage

```python
from fal.toolkit import ImageSizeInput, ImageSizeConstraints, ImageSizeField

class Input(BaseModel):
    image_size: ImageSizeInput = ImageSizeField(
        default="square_hd",
        constraints=ImageSizeConstraints(
            min_width=256, max_width=2560,
            min_height=256, max_height=2560,
            max_area=2048 * 2048,
            multiple_of=16,
        ),
    )
```

Per-model values are declared by each app; the SDK provides the generic types + emitter. Backwards compatible - `x-fal` is a vendor extension ignored by standard tooling, and nothing changes for inputs that don't set constraints.
