### PR TITLE
feat(fal): support local path requirements

### DIFF
--- a/projects/fal/src/fal/api/_sdist.py
+++ b/projects/fal/src/fal/api/_sdist.py
@@ -1,11 +1,12 @@
 """Build, upload, and rewrite local-path requirements for fal apps.
 
-When a ``[tool.fal.apps.*]`` block in ``pyproject.toml`` lists ``.`` or
-``.[extras]`` in its ``requirements``, the user means "install this project
-itself on the worker." We can't ship the source tree as a pip requirement,
-so we build an sdist locally, upload it to the fal CDN via
-``fal.toolkit.File``, and rewrite the requirement to ``<package> @ <url>``
-(or ``<package>[extras] @ <url>``) so the worker can pip-install it.
+When a ``[tool.fal.apps.*]`` block in ``pyproject.toml`` lists ``.``,
+``.[extras]``, or another local project path in its ``requirements``, the
+user means "install this project on the worker." We can't ship the source
+tree as a pip requirement, so we build an sdist locally, upload it to the fal
+CDN via ``fal.toolkit.File``, and rewrite the requirement to
+``<package> @ <url>`` (or ``<package>[extras] @ <url>``) so the worker can
+pip-install it.
 
 This module is the pure helper. ``FalServerlessHost`` calls
 ``materialize_local_paths`` on the way to dispatch.
@@ -18,6 +19,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -36,24 +38,33 @@ from fal.project import _load_toml
 # we can add phases later without breaking integrations.
 ProgressCallback = Callable[[str, dict], None]
 
-# Match ``.`` or ``.[extras]`` exactly. Other path-like forms (``./subdir``,
-# ``-e .``, ``file://...``) are intentionally left alone.
-_LOCAL_PATH_RE = re.compile(r"^\.(\[[^\]]+\])?$")
+_EXTRAS_SUFFIX_RE = re.compile(r"(?P<extras>\[[^\]]+\])$")
 
 EXPIRATION_DURATION_SECONDS = 60 * 60
 
 Requirements = Union[List[str], List[List[str]]]
 
 
-def has_local_path(requirements: Any) -> bool:
-    """True if ``requirements`` contains any ``.``/``.[extras]`` entry."""
+@dataclass(frozen=True)
+class _LocalPathRequirement:
+    path: Path
+    extras: str = ""
+
+
+def has_local_path(requirements: Any, project_root: Union[str, Path]) -> bool:
+    """True if ``requirements`` contains a local path entry.
+
+    Requirement strings are resolved relative to ``project_root``; if the path
+    part points at an existing directory, it is treated as local.
+    """
     if not isinstance(requirements, list):
         return False
+    base_path = Path(project_root)
     for item in requirements:
         if isinstance(item, list):
-            if has_local_path(item):
+            if has_local_path(item, base_path):
                 return True
-        elif isinstance(item, str) and _LOCAL_PATH_RE.match(item.strip()):
+        elif isinstance(item, str) and _parse_local_path_requirement(item, base_path):
             return True
     return False
 
@@ -63,10 +74,11 @@ def materialize_local_paths(
     project_root: Union[str, Path],
     on_progress: Optional[ProgressCallback] = None,
 ) -> Requirements:
-    """Rewrite ``.``/``.[extras]`` entries to ``<package> @ <url>``.
+    """Rewrite local path entries to ``<package> @ <url>``.
 
-    Builds an sdist of ``project_root`` and uploads it to the fal CDN via
-    ``fal.toolkit.File.from_path``. No-op when no local-path entry is present.
+    Builds an sdist for each referenced local project and uploads it to the fal
+    CDN via ``fal.toolkit.File.from_path``. No-op when no local-path entry is
+    present.
 
     Preserves the input shape (flat list vs layered list-of-lists).
 
@@ -74,33 +86,80 @@ def materialize_local_paths(
     :data:`ProgressCallback` for the event contract. Defaults to a no-op so
     library callers don't have to care about presentation.
     """
-    if not has_local_path(requirements):
-        return requirements
     project_root_path = Path(project_root)
-    package_name, url = _resolve_sdist_url(project_root_path, on_progress)
-    return _walk_and_rewrite(requirements, package_name, url)
+    resolved_sdists: dict[Path, tuple[str, str]] = {}
+    return _walk_and_rewrite(
+        requirements, project_root_path, resolved_sdists, on_progress
+    )
 
 
 def _walk_and_rewrite(
-    requirements: Requirements, package_name: str, url: str
+    requirements: Requirements,
+    project_root: Path,
+    resolved_sdists: dict[Path, tuple[str, str]],
+    on_progress: Optional[ProgressCallback],
 ) -> Requirements:
     out: list = []
     for item in requirements:
         if isinstance(item, list):
-            out.append(_walk_and_rewrite(item, package_name, url))
+            out.append(
+                _walk_and_rewrite(item, project_root, resolved_sdists, on_progress)
+            )
         elif isinstance(item, str):
-            out.append(_rewrite_one(item, package_name, url))
+            out.append(_rewrite_one(item, project_root, resolved_sdists, on_progress))
         else:
             out.append(item)
     return out  # type: ignore[return-value]
 
 
-def _rewrite_one(req: str, package_name: str, url: str) -> str:
-    match = _LOCAL_PATH_RE.match(req.strip())
-    if match is None:
+def _rewrite_one(
+    req: str,
+    project_root: Path,
+    resolved_sdists: dict[Path, tuple[str, str]],
+    on_progress: Optional[ProgressCallback],
+) -> str:
+    local_path_req = _parse_local_path_requirement(req, project_root)
+    if local_path_req is None:
         return req
-    extras = match.group(1) or ""
-    return f"{package_name}{extras} @ {url}"
+
+    local_project_root = local_path_req.path
+    package_name_url = resolved_sdists.get(local_project_root)
+    if package_name_url is None:
+        package_name_url = _resolve_sdist_url(local_project_root, on_progress)
+        resolved_sdists[local_project_root] = package_name_url
+
+    package_name, url = package_name_url
+    return f"{package_name}{local_path_req.extras} @ {url}"
+
+
+def _parse_local_path_requirement(
+    req: str, project_root: Path
+) -> Optional[_LocalPathRequirement]:
+    req = req.strip()
+    if not req:
+        return None
+
+    path_part = req
+    extras = ""
+    extras_match = _EXTRAS_SUFFIX_RE.search(req)
+    if extras_match is not None:
+        candidate_path = req[: extras_match.start()].strip()
+        if not candidate_path:
+            return None
+        path_part = candidate_path
+        extras = extras_match.group("extras")
+
+    path = _resolve_path(path_part, project_root)
+    if path.is_dir():
+        return _LocalPathRequirement(path, extras)
+    return None
+
+
+def _resolve_path(path: str, project_root: Path) -> Path:
+    result = Path(path).expanduser()
+    if not result.is_absolute():
+        result = project_root / result
+    return result.resolve()
 
 
 def _resolve_sdist_url(

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -960,7 +960,7 @@ class FalServerlessHost(Host):
         from fal.console.icons import get_check_icon  # noqa: PLC0415
         from fal.console.rules import print_rule  # noqa: PLC0415
 
-        if not has_local_path(requirements):
+        if not has_local_path(requirements, self.local_project_root):
             return
 
         check_icon = get_check_icon(console)

--- a/projects/fal/tests/unit/test_sdist.py
+++ b/projects/fal/tests/unit/test_sdist.py
@@ -11,26 +11,49 @@ from fal.api import _sdist
 
 
 @pytest.mark.parametrize(
-    "req,expected",
+    "req,expected_parts,expected_extras",
     [
-        (".", True),
-        (".[func]", True),
-        (".[func,app]", True),
-        ("  .  ", True),
-        ("  .[app]  ", True),
-        ("simple", False),
-        ("./subdir", False),
-        ("..", False),
-        (".[]", False),
-        ("-e .", False),
-        ("file:///abs/path", False),
-        ("git+https://example.com/foo.git", False),
-        ("simple[extra]", False),
+        (".", ("project",), ""),
+        (".[func]", ("project",), "[func]"),
+        (".[func,app]", ("project",), "[func,app]"),
+        ("  .  ", ("project",), ""),
+        ("  .[app]  ", ("project",), "[app]"),
+        ("./subdir", ("project", "subdir"), ""),
+        ("./subdir[func]", ("project", "subdir"), "[func]"),
+        ("./subdir [func]", ("project", "subdir"), "[func]"),
+        ("../shared", ("shared",), ""),
+        ("..", (), ""),
     ],
 )
-def test_local_path_regex(req, expected):
-    matched = _sdist._LOCAL_PATH_RE.match(req.strip()) is not None
-    assert matched is expected
+def test_parse_local_path_requirement_for_existing_dirs(
+    tmp_path, req, expected_parts, expected_extras
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "subdir").mkdir()
+    (tmp_path / "shared").mkdir()
+
+    parsed = _sdist._parse_local_path_requirement(req, project_root)
+    assert parsed is not None
+    assert parsed.path == tmp_path.joinpath(*expected_parts).resolve()
+    assert parsed.extras == expected_extras
+
+
+@pytest.mark.parametrize(
+    "req",
+    [
+        "simple",
+        "./subdir",
+        ".[]",
+        "-e .",
+        "file:///abs/path",
+        "git+https://example.com/foo.git",
+        "simple[extra]",
+    ],
+)
+def test_parse_local_path_requirement_for_non_dirs(tmp_path, req):
+    parsed = _sdist._parse_local_path_requirement(req, tmp_path)
+    assert parsed is None
 
 
 @pytest.mark.parametrize(
@@ -40,28 +63,36 @@ def test_local_path_regex(req, expected):
         (["fal"], False),
         (["fal", "."], True),
         (["fal", ".[func]"], True),
+        (["fal", "./subdir"], False),
         ([["fal"], [".[app]"]], True),
         ([["fal"], ["numpy"]], False),
     ],
 )
-def test_has_local_path(requirements, expected):
-    assert _sdist.has_local_path(requirements) is expected
+def test_has_local_path(tmp_path, requirements, expected):
+    assert _sdist.has_local_path(requirements, tmp_path) is expected
 
 
-def test_rewrite_one_dot():
-    assert _sdist._rewrite_one(".", "simple", "https://cdn/simple.tgz") == (
+def test_has_local_path_detects_existing_relative_dir(tmp_path):
+    (tmp_path / "subdir").mkdir()
+    assert _sdist.has_local_path(["fal", "./subdir"], tmp_path) is True
+
+
+def test_rewrite_one_dot(tmp_path):
+    resolved_sdists = {tmp_path.resolve(): ("simple", "https://cdn/simple.tgz")}
+    assert _sdist._rewrite_one(".", tmp_path, resolved_sdists, None) == (
         "simple @ https://cdn/simple.tgz"
     )
 
 
-def test_rewrite_one_with_extras():
-    assert _sdist._rewrite_one(".[func]", "simple", "https://cdn/simple.tgz") == (
+def test_rewrite_one_with_extras(tmp_path):
+    resolved_sdists = {tmp_path.resolve(): ("simple", "https://cdn/simple.tgz")}
+    assert _sdist._rewrite_one(".[func]", tmp_path, resolved_sdists, None) == (
         "simple[func] @ https://cdn/simple.tgz"
     )
 
 
-def test_rewrite_one_passthrough():
-    assert _sdist._rewrite_one("numpy", "simple", "https://cdn/simple.tgz") == "numpy"
+def test_rewrite_one_passthrough(tmp_path):
+    assert _sdist._rewrite_one("numpy", tmp_path, {}, None) == "numpy"
 
 
 def test_materialize_noop_when_no_local_path(tmp_path):
@@ -93,8 +124,161 @@ def test_materialize_rewrites_flat_list(tmp_path):
         "simple[func] @ https://cdn/simple-0.1.0.tar.gz",
         "numpy",
     ]
-    build.assert_called_once_with(tmp_path)
+    build.assert_called_once_with(tmp_path.resolve())
     upload.assert_called_once()
+
+
+def test_materialize_rewrites_relative_project_path(tmp_path):
+    package_root = tmp_path / "packages" / "common"
+    package_root.mkdir(parents=True)
+    pyproject = package_root / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "common"\nversion = "0.1.0"\n')
+
+    fake_sdist = tmp_path / "build_out" / "common-0.1.0.tar.gz"
+    fake_sdist.parent.mkdir()
+    fake_sdist.write_bytes(b"fake-sdist-bytes")
+
+    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist) as build, patch(
+        "fal.api._sdist._upload_sdist", return_value="https://cdn/common-0.1.0.tar.gz"
+    ):
+        out = _sdist.materialize_local_paths(
+            ["fal", "./packages/common[func]"], tmp_path
+        )
+
+    assert out == [
+        "fal",
+        "common[func] @ https://cdn/common-0.1.0.tar.gz",
+    ]
+    build.assert_called_once_with(package_root.resolve())
+
+
+def test_materialize_rewrites_bare_local_project_dir(tmp_path):
+    package_root = tmp_path / "common"
+    package_root.mkdir()
+    pyproject = package_root / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "common"\nversion = "0.1.0"\n')
+
+    fake_sdist = tmp_path / "build_out" / "common-0.1.0.tar.gz"
+    fake_sdist.parent.mkdir()
+    fake_sdist.write_bytes(b"fake-sdist-bytes")
+
+    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist), patch(
+        "fal.api._sdist._upload_sdist", return_value="https://cdn/common-0.1.0.tar.gz"
+    ):
+        out = _sdist.materialize_local_paths(["common[func]"], tmp_path)
+
+    assert out == ["common[func] @ https://cdn/common-0.1.0.tar.gz"]
+
+
+def test_materialize_bare_directory_without_pyproject_raises(tmp_path):
+    (tmp_path / "common").mkdir()
+
+    with pytest.raises(RuntimeError, match="no pyproject.toml"):
+        _sdist.materialize_local_paths(["common"], tmp_path)
+
+
+def test_materialize_rewrites_multiple_local_project_paths(tmp_path):
+    package_a = tmp_path / "packages" / "package_a"
+    package_b = tmp_path / "packages" / "package_b"
+    package_a.mkdir(parents=True)
+    package_b.mkdir(parents=True)
+    (package_a / "pyproject.toml").write_text(
+        '[project]\nname = "package-a"\nversion = "0.1.0"\n'
+    )
+    (package_b / "pyproject.toml").write_text(
+        '[project]\nname = "package-b"\nversion = "0.1.0"\n'
+    )
+    fake_sdist_a = tmp_path / "build_out_a" / "package-a-0.1.0.tar.gz"
+    fake_sdist_b = tmp_path / "build_out_b" / "package-b-0.1.0.tar.gz"
+    fake_sdist_a.parent.mkdir()
+    fake_sdist_b.parent.mkdir()
+    fake_sdist_a.write_bytes(b"fake-sdist-a")
+    fake_sdist_b.write_bytes(b"fake-sdist-b")
+
+    with patch.object(
+        _sdist, "_build_sdist", side_effect=[fake_sdist_a, fake_sdist_b]
+    ) as build, patch(
+        "fal.api._sdist._upload_sdist",
+        side_effect=["https://cdn/package-a.tgz", "https://cdn/package-b.tgz"],
+    ):
+        out = _sdist.materialize_local_paths(
+            ["./packages/package_a[api]", "./packages/package_b"], tmp_path
+        )
+
+    assert out == [
+        "package-a[api] @ https://cdn/package-a.tgz",
+        "package-b @ https://cdn/package-b.tgz",
+    ]
+    assert build.call_args_list[0].args == (package_a.resolve(),)
+    assert build.call_args_list[1].args == (package_b.resolve(),)
+
+
+def test_materialize_reuses_sdist_for_same_local_project_path(tmp_path):
+    package_root = tmp_path / "packages" / "common"
+    package_root.mkdir(parents=True)
+    (package_root / "pyproject.toml").write_text(
+        '[project]\nname = "common"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = tmp_path / "build_out" / "common-0.1.0.tar.gz"
+    fake_sdist.parent.mkdir()
+    fake_sdist.write_bytes(b"fake-sdist-bytes")
+
+    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist) as build, patch(
+        "fal.api._sdist._upload_sdist", return_value="https://cdn/common.tgz"
+    ):
+        out = _sdist.materialize_local_paths(
+            ["./packages/common[api]", "./packages/common[worker]"], tmp_path
+        )
+
+    assert out == [
+        "common[api] @ https://cdn/common.tgz",
+        "common[worker] @ https://cdn/common.tgz",
+    ]
+    build.assert_called_once_with(package_root.resolve())
+
+
+def test_materialize_reuses_sdist_without_duplicate_progress_events(tmp_path):
+    package_root = tmp_path / "packages" / "common"
+    package_root.mkdir(parents=True)
+    (package_root / "pyproject.toml").write_text(
+        '[project]\nname = "common"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = tmp_path / "build_out" / "common-0.1.0.tar.gz"
+    fake_sdist.parent.mkdir()
+    fake_sdist.write_bytes(b"fake-sdist-bytes")
+    events: list[tuple[str, dict]] = []
+
+    with patch.object(_sdist, "_build_sdist", return_value=fake_sdist) as build, patch(
+        "fal.api._sdist._upload_sdist", return_value="https://cdn/common.tgz"
+    ):
+        out = _sdist.materialize_local_paths(
+            ["./packages/common[api]", "./packages/common[worker]"],
+            tmp_path,
+            on_progress=lambda e, p: events.append((e, p)),
+        )
+
+    assert out == [
+        "common[api] @ https://cdn/common.tgz",
+        "common[worker] @ https://cdn/common.tgz",
+    ]
+    build.assert_called_once_with(package_root.resolve())
+    assert [name for name, _ in events] == [
+        "build_started",
+        "build_finished",
+        "upload_started",
+        "upload_finished",
+    ]
+
+
+def test_materialize_missing_local_project_path_passthrough(tmp_path):
+    with patch.object(_sdist, "_build_sdist") as build, patch.object(
+        _sdist, "_upload_sdist"
+    ) as upload:
+        out = _sdist.materialize_local_paths(["./missing"], tmp_path)
+
+    assert out == ["./missing"]
+    build.assert_not_called()
+    upload.assert_not_called()
 
 
 def test_materialize_preserves_layered_shape(tmp_path):


### PR DESCRIPTION
We currently support `.[extra]` in the requirements, but not arbitrary paths. This PR introduces support for that, so that users are not forced to have the project in the root (e.g. monorepos).