### PR TITLE
fix: prepare local requirements before prebuild

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -51,6 +51,7 @@ from typing_extensions import Concatenate, ParamSpec
 
 import fal.flags as flags
 from fal._serialization import include_module, include_modules_from, patch_pickle
+from fal.api._sdist import ProgressCallback, has_local_path, materialize_local_paths
 from fal.app_files import get_app_files_relative_path, include_app_files_path
 from fal.console import console
 from fal.container import ContainerImage
@@ -427,6 +428,20 @@ class Host(Generic[ArgsT, ReturnT]):
         entrypoint: str | None = None,
     ) -> SpawnInfo:
         raise NotImplementedError
+
+    def prepare_options(
+        self,
+        options: Options,
+        *,
+        func: Callable[..., Any] | None = None,
+        on_progress: ProgressCallback | None = None,
+    ) -> Options:
+        return replace(
+            options,
+            host=options.host.copy(),
+            environment=options.environment.copy(),
+            gateway=options.gateway.copy(),
+        )
 
 
 def cached(func: Callable[ArgsT, ReturnT]) -> Callable[ArgsT, ReturnT]:
@@ -937,7 +952,9 @@ class FalServerlessHost(Host):
             return client.connect()
 
     def _materialize_local_requirements(
-        self, environment_options: dict[str, Any]
+        self,
+        environment_options: dict[str, Any],
+        on_progress: ProgressCallback | None = None,
     ) -> None:
         """Rewrite ``.``/``.[extras]`` in ``environment_options['requirements']``
         to point at an uploaded sdist of ``self.local_project_root``.
@@ -946,52 +963,49 @@ class FalServerlessHost(Host):
         project root or no local-path requirement to rewrite — keeps the
         dispatch hot path quiet for users who don't use this feature.
         """
-        if not self.local_project_root:
+        local_project_root = self.local_project_root
+        if not local_project_root:
             return
+
         requirements = environment_options.get("requirements")
         if not requirements:
             return
 
-        from fal.api._sdist import (  # noqa: PLC0415
-            has_local_path,
-            materialize_local_paths,
-        )
-        from fal.console import console  # noqa: PLC0415
-        from fal.console.icons import get_check_icon  # noqa: PLC0415
-        from fal.console.rules import print_rule  # noqa: PLC0415
-
-        if not has_local_path(requirements, self.local_project_root):
+        if not has_local_path(requirements, local_project_root):
             return
 
-        check_icon = get_check_icon(console)
-
-        # Render in the same shape as the remote BUILDER phase
-        # (``Building environment...`` → rule → live logs → rule →
-        # ``✓ Build complete``) so the local sdist build feels like a
-        # natural sibling phase rather than out-of-band CLI chatter.
-        def _on_progress(event: str, payload: dict[str, Any]) -> None:
-            if event == "build_started":
-                console.print(
-                    f"Packaging local project [cyan]{payload['package_name']}[/]...",
-                    style="bold",
-                )
-                print_rule(console, style="dim")
-            elif event == "upload_started":
-                size_kb = payload["sdist_size"] / 1024
-                console.print(
-                    f"Uploading {payload['sdist_path'].name} ({size_kb:.1f} KB)..."
-                )
-            elif event == "upload_finished":
-                print_rule(console, style="dim")
-                console.print(f"{check_icon} Project packaged", style="bold green")
-                console.print("")
-            # ``build_finished`` has no host-side rendering: the live
-            # ``python -m build`` output between the rules already tells the
-            # user the build is done.
-
         environment_options["requirements"] = materialize_local_paths(
-            requirements, self.local_project_root, on_progress=_on_progress
+            requirements, local_project_root, on_progress=on_progress
         )
+
+    def prepare_options(
+        self,
+        options: Options,
+        *,
+        func: Callable[..., Any] | None = None,
+        on_progress: ProgressCallback | None = None,
+    ) -> Options:
+        from isolate.backends.common import active_python  # noqa: PLC0415
+
+        prepared_options = super().prepare_options(options)
+        environment_options = prepared_options.environment
+
+        # An explicit ``python_version=None`` must still resolve to the local
+        # interpreter: we ship local cloudpickled bytecode, so the remote
+        # Python must match. ``setdefault`` would leave an explicit None as-is.
+        if environment_options.get("python_version") is None:
+            environment_options["python_version"] = active_python()
+
+        _check_python_version_match(
+            [func, prepared_options.host.get("setup_function")],
+            environment_options["python_version"],
+        )
+
+        self._materialize_local_requirements(
+            environment_options, on_progress=on_progress
+        )
+
+        return prepared_options
 
     def files_sync(self, options: FileSyncOptions) -> list[File]:
         """Sync files to the server."""
@@ -1048,25 +1062,10 @@ class FalServerlessHost(Host):
         entrypoint: str | None = None,
         build_environment: bool | None = None,
     ) -> Optional[RegisterApplicationResult]:
-        from isolate.backends.common import active_python  # noqa: PLC0415
-
-        environment_options = options.environment.copy()
-
-        # An explicit ``python_version=None`` must still resolve to the local
-        # interpreter: we ship local cloudpickled bytecode, so the remote
-        # Python must match. ``setdefault`` would leave an explicit None as-is.
-        if environment_options.get("python_version") is None:
-            environment_options["python_version"] = active_python()
-        _check_python_version_match(
-            [func, options.host.get("setup_function")],
-            environment_options["python_version"],
-        )
-
+        options = self.prepare_options(options, func=func)
+        environment_options = options.environment
         if build_environment is False:
             environment_options.pop("force", None)
-
-        environment_options.setdefault("python_version", active_python())
-        self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
 
         machine_type: list[str] | str = options.host.get(
@@ -1189,25 +1188,10 @@ class FalServerlessHost(Host):
         entrypoint: str | None = None,
         build_environment: bool | None = None,
     ) -> ReturnT:
-        from isolate.backends.common import active_python  # noqa: PLC0415
-
-        environment_options = options.environment.copy()
-
-        # An explicit ``python_version=None`` must still resolve to the local
-        # interpreter: we ship local cloudpickled bytecode, so the remote
-        # Python must match. ``setdefault`` would leave an explicit None as-is.
-        if environment_options.get("python_version") is None:
-            environment_options["python_version"] = active_python()
-        _check_python_version_match(
-            [func, options.host.get("setup_function")],
-            environment_options["python_version"],
-        )
-
+        options = self.prepare_options(options, func=func)
+        environment_options = options.environment
         if build_environment is False:
             environment_options.pop("force", None)
-
-        environment_options.setdefault("python_version", active_python())
-        self._materialize_local_requirements(environment_options)
         environments = [self._connection.define_environment(**environment_options)]
 
         machine_type: list[str] | str = options.host.get(
@@ -1365,15 +1349,8 @@ class FalServerlessHost(Host):
         Streams build logs through ``result_handler`` (defaults to a no-op
         handler if not provided).
         """
-        from isolate.backends.common import active_python  # noqa: PLC0415
-
-        environment_options = options.environment.copy()
-        # An explicit ``python_version=None`` must still resolve to the local
-        # interpreter: we ship local cloudpickled bytecode, so the remote
-        # Python must match. ``setdefault`` would leave an explicit None as-is.
-        if environment_options.get("python_version") is None:
-            environment_options["python_version"] = active_python()
-        self._materialize_local_requirements(environment_options)
+        options = self.prepare_options(options)
+        environment_options = options.environment
         environments = [self._connection.define_environment(**environment_options)]
 
         machine_type: list[str] | str = options.host.get(

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+from fal.api._sdist import ProgressCallback
 from fal.sdk import AuthModeLiteral, DeploymentStrategyLiteral
 
 from .api import _uses_isolate
@@ -242,19 +243,23 @@ def _execute_loaded_deployment(
     environment_name: str | None = None,
     result_handler: ResultHandler | None = None,
     build_result_handler: ResultHandler | None = None,
+    prepare_options_handler: ProgressCallback | None = None,
 ) -> DeploymentResult:
     from fal.api import FalServerlessError
 
-    isolated_function = loaded.function
     strategy = app_data.deployment_strategy or "rolling"
     build_result_handler = (
         result_handler if build_result_handler is None else build_result_handler
     )
 
-    # Fail fast on a local/remote Python version mismatch
-    from fal.api.api import check_python_version_for_options
-
-    check_python_version_for_options(isolated_function.func, isolated_function.options)
+    isolated_function = replace(
+        loaded.function,
+        options=host.prepare_options(
+            loaded.function.options,
+            func=loaded.function.func,
+            on_progress=prepare_options_handler,
+        ),
+    )
 
     # Explicit build phase so the CLI / caller gets a clean "build → deploy"
     # split instead of inferring it from the log stream's source field.
@@ -347,6 +352,7 @@ def execute_prepared_deployment(
     *,
     result_handler: ResultHandler | None = None,
     build_result_handler: ResultHandler | None = None,
+    prepare_options_handler: ProgressCallback | None = None,
 ) -> DeploymentResult:
     return _execute_loaded_deployment(
         host=prepared.host,
@@ -356,6 +362,7 @@ def execute_prepared_deployment(
         environment_name=prepared.environment_name,
         result_handler=result_handler,
         build_result_handler=build_result_handler,
+        prepare_options_handler=prepare_options_handler,
     )
 
 

--- a/projects/fal/src/fal/cli/_result_handlers.py
+++ b/projects/fal/src/fal/cli/_result_handlers.py
@@ -16,6 +16,38 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 
+class PrepareRequirementsCallback:
+    """Renders local requirement packaging as a top-level CLI step."""
+
+    def __init__(self, *, console: Console) -> None:
+        self.console = console
+
+    def __call__(self, event: str, payload: dict[str, Any]) -> None:
+        from fal.console.rules import print_rule  # noqa: PLC0415
+
+        if event == "build_started":
+            self.console.print(
+                f"Packaging local project [cyan]{payload['package_name']}[/]...",
+                style="bold",
+            )
+            print_rule(self.console, style="dim")
+        elif event == "upload_started":
+            size_kb = payload["sdist_size"] / 1024
+            self.console.print(
+                f"Uploading {payload['sdist_path'].name} ({size_kb:.1f} KB)..."
+            )
+        elif event == "upload_finished":
+            from fal.console.icons import get_check_icon  # noqa: PLC0415
+
+            print_rule(self.console, style="dim")
+            check_icon = get_check_icon(self.console)
+            self.console.print(f"{check_icon} Project packaged", style="bold green")
+            self.console.print("")
+        # ``build_finished`` has no host-side rendering: the live
+        # ``python -m build`` output between the rules already tells the
+        # user the build is done.
+
+
 class CliRunResultHandler(ResultHandler):
     """Renders an ephemeral-app banner + streams logs for ``fal run``."""
 

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -13,6 +13,7 @@ def _deploy(args):
     from ._result_handlers import (
         CliBuildEnvironmentResultHandler,
         CliRegisterResultHandler,
+        PrepareRequirementsCallback,
     )
 
     team, app_ref = _resolve_team_and_app_ref(args)
@@ -28,6 +29,7 @@ def _deploy(args):
     client = SyncServerlessClient(host=args.host, team=team)
     result_handler = CliRegisterResultHandler(console=args.console)
     build_result_handler = CliBuildEnvironmentResultHandler(console=args.console)
+    prepare_options_handler = PrepareRequirementsCallback(console=args.console)
 
     deploy_check_source = _resolve_deploy_check_source(args, client)
     if deploy_check_source is not None:
@@ -40,6 +42,7 @@ def _deploy(args):
             source=deploy_check_source,
             result_handler=result_handler,
             build_result_handler=build_result_handler,
+            prepare_options_handler=prepare_options_handler,
         )
     else:
         from fal.api import deploy as deploy_api
@@ -63,6 +66,7 @@ def _deploy(args):
             prepared,
             result_handler=result_handler,
             build_result_handler=build_result_handler,
+            prepare_options_handler=prepare_options_handler,
         )
 
     _render_deploy_result(args, res)

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -11,6 +11,7 @@ from fal.sdk import construct_alias
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from fal.api._sdist import ProgressCallback
     from fal.api.api import ResultHandler
     from fal.api.client import SyncServerlessClient
     from fal.api.deploy import DeploymentResult, PreparedDeployment
@@ -108,6 +109,7 @@ def deploy_with_check(
     source: DeployCheckSource,
     result_handler: ResultHandler | None = None,
     build_result_handler: ResultHandler | None = None,
+    prepare_options_handler: ProgressCallback | None = None,
 ) -> DeploymentResult:
     from fal.api import deploy as deploy_api
 
@@ -142,6 +144,7 @@ def deploy_with_check(
         prepared,
         result_handler=result_handler,
         build_result_handler=build_result_handler,
+        prepare_options_handler=prepare_options_handler,
     )
 
 

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -83,11 +83,12 @@ def _run(args):
         isolated_function.options.host["machine_type"] = args.machine_type
 
     if not args.local:
-        # Fail fast on a local/remote Python version mismatch
-        from fal.api.api import check_python_version_for_options
+        from ._result_handlers import PrepareRequirementsCallback
 
-        check_python_version_for_options(
-            isolated_function.func, isolated_function.options
+        isolated_function.options = host.prepare_options(
+            isolated_function.options,
+            func=isolated_function.func,
+            on_progress=PrepareRequirementsCallback(console=args.console),
         )
 
         # Explicit build phase so the CLI gets a clean "build → run" split

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -6,6 +6,7 @@ import pytest
 from rich.console import Console
 
 from fal.api import Options
+from fal.api.api import IsolatedFunction
 from fal.cli._utils import AppData
 from fal.cli.deploy import _deploy
 from fal.cli.deploy_check import (
@@ -46,12 +47,15 @@ def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default(
     )
 
     host = MagicMock()
-    isolated_function = MagicMock()
-    isolated_function.options = Options()
-    isolated_function.func = lambda: None
-    isolated_function.run_entrypoint = None
-    isolated_function.endpoints = ["/"]
-    isolated_function.build_metadata.return_value = {}
+    options = Options(environment={"requirements": ["."]})
+    prepared_options = Options(environment={"requirements": ["simple @ https://cdn"]})
+    isolated_function = IsolatedFunction(
+        host=host,
+        raw_func=lambda: None,
+        options=options,
+        app_name="my-app",
+        app_auth="public",
+    )
 
     host.register.return_value = RegisterApplicationResult(
         result=RegisterApplicationResultType(application_id="app-id"),
@@ -63,6 +67,7 @@ def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default(
             log="https://log.example",
         ),
     )
+    host.prepare_options.return_value = prepared_options
     prepared = PreparedDeployment(
         host=host,
         loaded=SimpleNamespace(
@@ -76,14 +81,28 @@ def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default(
     )
 
     result_handler = MagicMock()
-    execute_prepared_deployment(prepared, result_handler=result_handler)
+    prepare_options_handler = MagicMock()
+    execute_prepared_deployment(
+        prepared,
+        result_handler=result_handler,
+        prepare_options_handler=prepare_options_handler,
+    )
 
     _, build_kwargs = host.build_environment.call_args
     assert build_kwargs["result_handler"] is result_handler
+    assert host.build_environment.call_args.args[0] is prepared_options
+    host.prepare_options.assert_called_once_with(
+        options,
+        func=isolated_function.func,
+        on_progress=prepare_options_handler,
+    )
+    _, register_kwargs = host.register.call_args
+    assert register_kwargs["options"] is prepared_options
+    assert isolated_function.options is options
+    assert isolated_function.options.environment["requirements"] == ["."]
 
 
 def test_execute_prepared_deployment_builds_no_isolate_container():
-    from fal.api.api import IsolatedFunction
     from fal.api.deploy import PreparedDeployment, execute_prepared_deployment
     from fal.sdk import (
         RegisterApplicationResult,
@@ -111,6 +130,7 @@ def test_execute_prepared_deployment_builds_no_isolate_container():
             log="https://log.example",
         ),
     )
+    host.prepare_options.return_value = options
     prepared = PreparedDeployment(
         host=host,
         loaded=SimpleNamespace(

--- a/projects/fal/tests/unit/cli/test_result_handlers.py
+++ b/projects/fal/tests/unit/cli/test_result_handlers.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -9,6 +10,7 @@ from fal.cli._result_handlers import (
     CliBuildEnvironmentResultHandler,
     CliRegisterResultHandler,
     CliRunResultHandler,
+    PrepareRequirementsCallback,
 )
 from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
 
@@ -33,6 +35,29 @@ def test_cli_register_result_handler_skips_builder_logs():
     handler.on_log(SimpleNamespace(source=LogSource.BUILDER, message="cache hit"))
 
     handler.log_printer.print.assert_not_called()
+
+
+def test_prepare_requirements_callback_renders_packaging_step():
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        color_system=None,
+        width=80,
+    )
+    handler = PrepareRequirementsCallback(console=console)
+
+    handler("build_started", {"package_name": "simple"})
+    handler(
+        "upload_started",
+        {"sdist_path": Path("simple-0.1.0.tar.gz"), "sdist_size": 2048},
+    )
+    handler("upload_finished", {"url": "https://cdn/simple.tar.gz", "sdist_size": 2048})
+
+    rendered = output.getvalue()
+    assert "Packaging local project simple" in rendered
+    assert "Uploading simple-0.1.0.tar.gz (2.0 KB)" in rendered
+    assert "Project packaged" in rendered
 
 
 def test_cli_build_environment_result_handler_uses_minimal_cache_hit_footer():

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from fal.api import Options
+from fal.cli._result_handlers import PrepareRequirementsCallback
 from fal.cli.main import parse_args
 from fal.cli.run import _run
 from fal.project import find_project_root
@@ -135,6 +135,8 @@ def mock_parse_pyproject_toml():
 def mocked_fal_serverless_host(host):
     mock = MagicMock()
     mock.host = host
+    mock.local_project_root = ""
+    mock.prepare_options.side_effect = lambda options, **_: options
     return mock
 
 
@@ -309,6 +311,7 @@ def test_run_image_only_builds_no_isolate_container(
     tmp_path,
 ):
     from fal.api.api import IsolatedFunction
+    from fal.utils import LoadedFunction
 
     (tmp_path / "Dockerfile").write_text("FROM debian:bookworm-slim\n")
     mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
@@ -328,15 +331,17 @@ def test_run_image_only_builds_no_isolate_container(
         app_auth,
         **_kwargs,
     ):
-        return SimpleNamespace(
-            function=IsolatedFunction(
-                host=host_arg,
-                options=options,
-                app_name=app_name,
-                app_auth=app_auth,
-            ),
+        isolated_function = IsolatedFunction(
+            host=host_arg,
+            options=options,
             app_name=app_name,
             app_auth=app_auth,
+        )
+        return LoadedFunction(
+            function=isolated_function,
+            app_name=app_name,
+            app_auth=app_auth,
+            source_code=None,
         )
 
     mock_load_function_from.side_effect = fake_load_function_from
@@ -370,6 +375,15 @@ def test_run_forwards_limit_max_requests_to_load_function_from(
 
     _, call_kwargs = mock_load_function_from.call_args
     assert call_kwargs["limit_max_requests"] == 1
+    assert "local" not in call_kwargs
+    host.prepare_options.assert_called_once()
+    (options,) = host.prepare_options.call_args.args
+    progress = host.prepare_options.call_args.kwargs["on_progress"]
+
+    assert options is loaded.function.options
+    assert host.prepare_options.call_args.kwargs["func"] is loaded.function.func
+    assert isinstance(progress, PrepareRequirementsCallback)
+    assert progress.console is args.console
 
 
 @patch("fal.api.run.run")
@@ -396,6 +410,7 @@ def test_run_forwards_exposed_port_options_to_run_api(
 
     _run(args)
 
+    host.prepare_options.assert_not_called()
     _, call_kwargs = mock_run_api.call_args
     assert call_kwargs["local"] is True
     assert call_kwargs["exposed_port"] == 3000

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -214,6 +214,237 @@ def test_run_omits_force_when_build_environment_false():
     assert options.environment["force"] is True
 
 
+LOCAL_PATH_REQUIREMENT_CASES = [
+    (
+        ["."],
+        ["simple @ https://cdn/simple-0.1.0.tar.gz"],
+    ),
+    (
+        [["."], ["other-pkg"]],
+        [["simple @ https://cdn/simple-0.1.0.tar.gz"], ["other-pkg"]],
+    ),
+]
+
+
+def _exercise_local_path_cache_only_sequence(tmp_path, requirements, prepare_for_build):
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import (
+        BuildEnvironmentResult,
+        HostedRunState,
+        HostedRunStatus,
+        RegisterApplicationResult,
+        RegisterApplicationResultType,
+    )
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    app_file = tmp_path / "app.py"
+    app_file.write_text(
+        "import fal\n" "\n" "@fal.function()\n" "def run():\n" "    return 'ok'\n"
+    )
+    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost(local_project_root=str(tmp_path))
+    options = Options(environment={"kind": "virtualenv", "requirements": requirements})
+
+    connection = MagicMock()
+    connection.define_environment.side_effect = lambda **kwargs: kwargs
+    connection.build_environment.return_value = iter(
+        [BuildEnvironmentResult(status=HostedRunStatus(HostedRunState.SUCCESS))]
+    )
+
+    run_result = MagicMock()
+    run_result.status.state = HostedRunState.SUCCESS
+    run_result.result = "ok"
+    connection.run.return_value = iter([run_result])
+
+    register_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([register_result])
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        ).return_value = connection
+        build_sdist = stack.enter_context(
+            patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist)
+        )
+        upload_sdist = stack.enter_context(
+            patch(
+                "fal.api._sdist._upload_sdist",
+                return_value="https://cdn/simple-0.1.0.tar.gz",
+            )
+        )
+
+        active_options = prepare_for_build(host, options, app_file)
+        result = host._run(
+            None,
+            active_options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+            entrypoint="simple.app:run",
+            build_environment=False,
+        )
+        registered = host.register(
+            None,
+            active_options,
+            deployment_strategy="recreate",
+            entrypoint="simple.app:run",
+            build_environment=False,
+        )
+
+    return {
+        "active_options": active_options,
+        "build_sdist": build_sdist,
+        "fake_sdist": fake_sdist,
+        "options": options,
+        "registered": registered,
+        "register_result": register_result,
+        "result": result,
+        "rewritten_requirements": [
+            call.kwargs["requirements"]
+            for call in connection.define_environment.call_args_list
+        ],
+        "upload_sdist": upload_sdist,
+    }
+
+
+@pytest.mark.parametrize(
+    ("requirements", "expected_requirements"), LOCAL_PATH_REQUIREMENT_CASES
+)
+def test_prepare_options_materializes_loaded_requirements_for_cache_only_calls(
+    tmp_path, requirements, expected_requirements
+):
+    from fal.utils import load_function_from
+
+    def prepare_for_build(host, options, app_file):
+        loaded = load_function_from(
+            host,
+            str(app_file),
+            "run",
+            options=options,
+        )
+        loaded.function.options = host.prepare_options(loaded.function.options)
+        host.build_environment(loaded.function.options)
+        return loaded.function.options
+
+    case = _exercise_local_path_cache_only_sequence(
+        tmp_path, requirements, prepare_for_build
+    )
+
+    assert case["result"] == "ok"
+    assert case["registered"] == case["register_result"]
+    assert case["rewritten_requirements"] == [expected_requirements] * 3
+    assert case["options"].environment["requirements"] == requirements
+    assert case["active_options"].environment["requirements"] == expected_requirements
+    case["build_sdist"].assert_called_once_with(tmp_path.resolve())
+    case["upload_sdist"].assert_called_once_with(case["fake_sdist"])
+
+
+@pytest.mark.parametrize(
+    ("requirements", "expected_requirements"), LOCAL_PATH_REQUIREMENT_CASES
+)
+def test_prepare_options_materializes_host_requirements_for_cache_only_calls(
+    tmp_path, requirements, expected_requirements
+):
+    def prepare_for_build(host, options, _app_file):
+        prepared_options = host.prepare_options(options)
+        host.build_environment(prepared_options)
+        return prepared_options
+
+    case = _exercise_local_path_cache_only_sequence(
+        tmp_path, requirements, prepare_for_build
+    )
+
+    assert case["result"] == "ok"
+    assert case["registered"] == case["register_result"]
+    assert case["rewritten_requirements"] == [expected_requirements] * 3
+    assert case["options"].environment["requirements"] == requirements
+    assert case["active_options"].environment["requirements"] == expected_requirements
+    case["build_sdist"].assert_called_once_with(tmp_path.resolve())
+    case["upload_sdist"].assert_called_once_with(case["fake_sdist"])
+
+
+def test_prepare_options_checks_python_version_before_materializing_requirements(
+    tmp_path,
+):
+    from fal.api.api import FalServerlessError, FalServerlessHost, Options
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+
+    host = FalServerlessHost(local_project_root=str(tmp_path))
+    options = Options(
+        environment={
+            "kind": "virtualenv",
+            "python_version": "3.12",
+            "requirements": ["."],
+        }
+    )
+
+    with patch("isolate.backends.common.active_python", return_value="3.11"):
+        with patch("fal.api._sdist._build_sdist") as build_sdist:
+            with pytest.raises(FalServerlessError, match="Local Python 3.11"):
+                host.prepare_options(options, func=lambda: None)
+
+    build_sdist.assert_not_called()
+
+
+def test_build_environment_keeps_local_requirements_for_future_rebuilds(tmp_path):
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir(exist_ok=True)
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost(local_project_root=str(tmp_path))
+    options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
+
+    connection = MagicMock()
+    connection.define_environment.side_effect = lambda **kwargs: kwargs
+    connection.build_environment.return_value = iter(
+        [BuildEnvironmentResult(status=HostedRunStatus(HostedRunState.SUCCESS))]
+    )
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(FalServerlessHost, "_connection", new_callable=PropertyMock)
+        ).return_value = connection
+        build_sdist = stack.enter_context(
+            patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist)
+        )
+        upload_sdist = stack.enter_context(
+            patch(
+                "fal.api._sdist._upload_sdist",
+                return_value="https://cdn/simple-0.1.0.tar.gz",
+            )
+        )
+
+        host.build_environment(options)
+
+    _, call_kwargs = connection.define_environment.call_args
+    assert call_kwargs["requirements"] == ["simple @ https://cdn/simple-0.1.0.tar.gz"]
+    assert options.environment["requirements"] == ["."]
+    build_sdist.assert_called_once_with(tmp_path.resolve())
+    upload_sdist.assert_called_once_with(fake_sdist)
+
+
 def test_register_leaves_private_logs_unset_by_default():
     from fal.api.api import FalServerlessHost, Options
     from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType


### PR DESCRIPTION
Local path requirements like `.` were being materialized separately for the explicit prebuild and the later cache-only run/register call. That produced different uploaded package URLs, so the cache-only call looked for a different environment and failed with `Pre-built environment not found`.

This fixes it by adding an explicit `host.prepare_options(...)` step that returns a prepared copy of the options. CLI/deploy reuse that prepared options object for the prebuild and cache-only follow-up, so local path requirements are uploaded once without mutating the caller-owned options.