### PR TITLE
feat(fal): add metrics port machine config

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.26.9,<0.27.0",
-    "isolate-proto>=0.32.0,<1",
+    "isolate-proto>=0.33.0,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle>=3.0.0,<3.2",

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -905,6 +905,7 @@ class FalServerlessHost(Host):
             "metadata",
             "request_timeout",
             "startup_timeout",
+            "metrics_port",
             "private_logs",
             "_base_image",
             "_scheduler",
@@ -1082,6 +1083,7 @@ class FalServerlessHost(Host):
         scaling_delay = options.host.get("scaling_delay")
         max_multiplexing = options.host.get("max_multiplexing")
         exposed_port = options.get_exposed_port()
+        metrics_port = options.get_metrics_port()
         request_timeout = options.host.get("request_timeout")
         startup_timeout = options.host.get("startup_timeout")
         regions = options.host.get("regions")
@@ -1099,6 +1101,7 @@ class FalServerlessHost(Host):
             keep_alive=keep_alive,
             base_image=base_image,
             exposed_port=exposed_port,
+            metrics_port=metrics_port,
             scheduler=scheduler,
             scheduler_options=scheduler_options,
             max_multiplexing=max_multiplexing,
@@ -1208,6 +1211,7 @@ class FalServerlessHost(Host):
         scheduler = options.host.get("_scheduler", None)
         scheduler_options = options.host.get("_scheduler_options", None)
         exposed_port = options.get_exposed_port()
+        metrics_port = options.get_metrics_port()
         runtime_config = self._runtime_config(options)
         setup_function = options.host.get("setup_function", None)
         if setup_function is not None and runtime_config is not None:
@@ -1225,6 +1229,7 @@ class FalServerlessHost(Host):
             keep_alive=keep_alive,
             base_image=base_image,
             exposed_port=exposed_port,
+            metrics_port=metrics_port,
             scheduler=scheduler,
             scheduler_options=scheduler_options,
             max_multiplexing=max_multiplexing,
@@ -1442,6 +1447,10 @@ class FalServerlessHost(Host):
         return ret
 
 
+_SERVE_PORT = 8080
+_METRICS_PORT = 9090
+
+
 @dataclass
 class Options:
     host: BasicConfig = field(default_factory=dict)
@@ -1486,8 +1495,15 @@ class Options:
         else:
             return None
 
+    def get_metrics_port(self) -> int | None:
+        metrics_port = self.host.get("metrics_port")
+        if metrics_port is not None:
+            return metrics_port
+        elif self.get_exposed_port() is not None and _image_uses_isolate(self):
+            return _METRICS_PORT
+        else:
+            return None
 
-_SERVE_PORT = 8080
 
 # Overload @function to help users identify the correct signature.
 # NOTE: This is both in sync with host options and with environment configs from
@@ -1543,6 +1559,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[False] = False,
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -1577,6 +1594,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[True],
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -1663,6 +1681,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[False] = False,
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -1702,6 +1721,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[True],
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -1735,6 +1755,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[False] = False,
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -1768,6 +1789,7 @@ def function(
     host: FalServerlessHost | None = None,
     serve: Literal[True],
     exposed_port: int | None = None,
+    metrics_port: int | None = None,
     max_concurrency: int | None = None,
     local_python_modules: list[str] | None = None,
     # FalServerlessHost options
@@ -2460,7 +2482,6 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
     app_name: str | None = None
     app_auth: AuthModeLiteral | None = None
     entrypoint: str | None = None
-    _entrypoint_exposed_port_defaulted: bool = False
 
     def __post_init__(self) -> None:
         if (
@@ -2487,8 +2508,6 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
         self.__dict__.update(state)
         if not hasattr(self, "executor"):
             self.executor = ThreadPoolExecutor()
-        if not hasattr(self, "_entrypoint_exposed_port_defaulted"):
-            self._entrypoint_exposed_port_defaulted = False
 
     @property
     def run_entrypoint(self) -> str | None:
@@ -2642,18 +2661,25 @@ class IsolatedFunction(Generic[ArgsT, ReturnT]):
             )
 
         if supports_local_serve_options:
-            entrypoint_target_keeps_own_port = (
-                self.raw_func is None
-                and isinstance(local_serve_options_target, IsolatedFunction)
-                and self._entrypoint_exposed_port_defaulted
-            )
-            effective_exposed_port = exposed_port
-            if effective_exposed_port is None and not entrypoint_target_keeps_own_port:
-                effective_exposed_port = self.options.get_exposed_port()
+            is_entrypoint_wrapper = self.raw_func is None
+            if is_entrypoint_wrapper:
+                effective_exposed_port = exposed_port
+                effective_metrics_port = exposed_metrics_port
+            else:
+                effective_exposed_port = (
+                    exposed_port
+                    if exposed_port is not None
+                    else self.options.get_exposed_port()
+                )
+                effective_metrics_port = (
+                    exposed_metrics_port
+                    if exposed_metrics_port is not None
+                    else self.options.get_metrics_port()
+                )
             if effective_exposed_port is not None:
                 call_kwargs["exposed_port"] = effective_exposed_port
-            if exposed_metrics_port is not None:
-                call_kwargs["exposed_metrics_port"] = exposed_metrics_port
+            if effective_metrics_port is not None:
+                call_kwargs["exposed_metrics_port"] = effective_metrics_port
 
         previous_isolate_env = os.environ.get("IS_ISOLATE_AGENT")
         os.environ["IS_ISOLATE_AGENT"] = "1"

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -149,10 +149,15 @@ def wrap_app(cls: type[App], **kwargs) -> IsolatedFunction:
         set_current_app(app)
 
         serve_kwargs: dict[str, Any] = {"limit_max_requests": limit_max_requests}
+        app_metrics_port = cls.metrics_port
+        if app_metrics_port is None:
+            app_metrics_port = cls.host_kwargs.get("metrics_port")
         if exposed_port is not None:
             serve_kwargs["port"] = exposed_port
         if exposed_metrics_port is not None:
             serve_kwargs["metrics_port"] = exposed_metrics_port
+        elif app_metrics_port is not None:
+            serve_kwargs["metrics_port"] = app_metrics_port
 
         if threading.current_thread() == threading.main_thread():
             return app.serve(**serve_kwargs)
@@ -516,6 +521,8 @@ class App(BaseServable):
             Defaults to the directory containing the app file.
         request_timeout: Maximum seconds for a single request. None for default.
         startup_timeout: Maximum seconds for app startup/setup. None for default.
+        metrics_port: Internal metrics server port for platform scrapes.
+            When omitted, served/exposed deployments default to 9090.
         min_concurrency: Minimum warm instances to keep running. Set to 1+ to
             avoid cold starts. Default is 0 (scale to zero).
         max_concurrency: Maximum instances to scale up to.
@@ -559,6 +566,7 @@ class App(BaseServable):
     app_files_context_dir: ClassVar[Optional[str]] = None
     request_timeout: ClassVar[Optional[int]] = None
     startup_timeout: ClassVar[Optional[int]] = None
+    metrics_port: ClassVar[Optional[int]] = None
     min_concurrency: ClassVar[Optional[int]] = None
     max_concurrency: ClassVar[Optional[int]] = None
     concurrency_buffer: ClassVar[Optional[int]] = None
@@ -602,6 +610,9 @@ class App(BaseServable):
 
         if cls.startup_timeout is not None:
             cls.host_kwargs["startup_timeout"] = cls.startup_timeout
+
+        if cls.metrics_port is not None:
+            cls.host_kwargs["metrics_port"] = cls.metrics_port
 
         if cls.app_files:
             cls.host_kwargs["app_files"] = cls.app_files

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -138,6 +138,7 @@ def get_app_data_from_toml(
     app_files_ignore = app_data.pop("app_files_ignore", None)
     app_files_context_dir = app_data.pop("app_files_context_dir", None)
     exposed_port = app_data.pop("exposed_port", None)
+    metrics_port = app_data.pop("metrics_port", None)
     scheduler = app_data.pop("_scheduler", None)
     scheduler_options = app_data.pop("_scheduler_options", None)
     skip_retry_conditions = app_data.pop("skip_retry_conditions", None)
@@ -167,6 +168,8 @@ def get_app_data_from_toml(
             app_files_context_dir = str(Path(toml_path).parent / context_path)
     if exposed_port is not None:
         _validate_port("exposed_port", exposed_port)
+    if metrics_port is not None:
+        _validate_port("metrics_port", metrics_port)
     if image_config is not None and app_files:
         raise ValueError("app_files is not supported for container apps.")
     if keep_alive is not None:
@@ -247,6 +250,8 @@ def get_app_data_from_toml(
         options.host["health_check_config"] = health_check_config
     if exposed_port is not None:
         options.gateway["exposed_port"] = exposed_port
+    if metrics_port is not None:
+        options.host["metrics_port"] = metrics_port
     if requirements is not None:
         options.environment["requirements"] = requirements
     if python_version is not None:

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -726,6 +726,7 @@ class MachineRequirements:
     request_timeout: int | None = None
     startup_timeout: int | None = None
     valid_regions: list[str] | None = None
+    metrics_port: int | None = None
 
     def __post_init__(self):
         if isinstance(self.machine_types, str):
@@ -959,6 +960,7 @@ class FalServerlessConnection:
                 keep_alive=machine_requirements.keep_alive,
                 base_image=machine_requirements.base_image,
                 exposed_port=machine_requirements.exposed_port,
+                metrics_port=machine_requirements.metrics_port,
                 scheduler=machine_requirements.scheduler,
                 scheduler_options=to_struct(
                     machine_requirements.scheduler_options or {}
@@ -1188,6 +1190,7 @@ class FalServerlessConnection:
                 keep_alive=machine_requirements.keep_alive,
                 base_image=machine_requirements.base_image,
                 exposed_port=machine_requirements.exposed_port,
+                metrics_port=machine_requirements.metrics_port,
                 scheduler=machine_requirements.scheduler,
                 scheduler_options=to_struct(
                     machine_requirements.scheduler_options or {}

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -257,10 +257,9 @@ def _load_from_python_entry_point(
     _parse_python_entry_point(python_entry_point)
 
     merged_options = deepcopy(options) if options is not None else ApiOptions()
-    exposed_port_defaulted = "exposed_port" not in merged_options.gateway
     merged_options.gateway.setdefault("exposed_port", 8080)
-    # The entry-point path bypasses Host.parse_options (which is where ``kind``
-    # would normally be defaulted for ``@fal.function``/``wrap_app``), so set
+    # The entry-point path bypasses Host.parse_options (which normally fills in
+    # ``kind`` for ``@fal.function``/``wrap_app``), so set
     # the virtualenv default here. Users who want a container-based env can
     # still configure that explicitly via the toml options downstream.
     merged_options.environment.setdefault("kind", "virtualenv")
@@ -271,7 +270,6 @@ def _load_from_python_entry_point(
         app_name=app_name,
         app_auth=app_auth,
         entrypoint=python_entry_point,
-        _entrypoint_exposed_port_defaulted=exposed_port_defaulted,
     )
 
     return LoadedFunction(

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -127,6 +127,7 @@ def mock_parse_pyproject_toml():
                 "python_version": "3.12",
                 "requirements": ["fal"],
                 "exposed_port": 9000,
+                "metrics_port": 9001,
             },
         }
     }
@@ -212,6 +213,7 @@ def test_run_forwards_python_entry_point_to_loader(
     loaded = mocked_loaded_function(
         options=Options(
             environment={"python_version": "3.12", "requirements": ["fal"]},
+            host={"metrics_port": 9001},
             gateway={"exposed_port": 9000},
         ),
         func=None,
@@ -233,6 +235,7 @@ def test_run_forwards_python_entry_point_to_loader(
     assert call_kwargs["options"].environment["python_version"] == "3.12"
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
     assert call_kwargs["options"].gateway["exposed_port"] == 9000
+    assert call_kwargs["options"].host["metrics_port"] == 9001
 
 
 @patch("fal.cli._utils.find_pyproject_toml")
@@ -254,6 +257,7 @@ def test_run_image_only_forwards_no_ref_to_loader(
             "container-app": {
                 "image": {"dockerfile": "Dockerfile"},
                 "exposed_port": 8080,
+                "metrics_port": 9091,
             }
         }
     }
@@ -270,6 +274,7 @@ def test_run_image_only_forwards_no_ref_to_loader(
                     "use_isolate": False,
                 },
             },
+            host={"metrics_port": 9091},
             gateway={"exposed_port": 8080},
         ),
         func=None,
@@ -295,6 +300,7 @@ def test_run_image_only_forwards_no_ref_to_loader(
     assert call_kwargs["options"].environment["image"]["dockerfile_str"] == dockerfile
     assert call_kwargs["options"].environment["image"]["use_isolate"] is False
     assert call_kwargs["options"].gateway["exposed_port"] == 8080
+    assert call_kwargs["options"].host["metrics_port"] == 9091
 
 
 @patch("fal.api.run.run")

--- a/projects/fal/tests/unit/test_api_run.py
+++ b/projects/fal/tests/unit/test_api_run.py
@@ -100,6 +100,47 @@ def test_options_get_exposed_port_prefers_configured_port_for_serve_true():
     assert options.get_exposed_port() == 3000
 
 
+def test_options_get_metrics_port_defaults_for_served_apps():
+    assert Options().get_metrics_port() is None
+    assert Options(gateway={"serve": True}).get_metrics_port() == 9090
+    assert Options(gateway={"exposed_port": 8080}).get_metrics_port() == 9090
+    assert (
+        Options(
+            environment={
+                "kind": "container",
+                "image": {"use_isolate": True},
+            },
+            gateway={"exposed_port": 8080},
+        ).get_metrics_port()
+        == 9090
+    )
+    assert (
+        Options(
+            environment={
+                "kind": "container",
+                "image": {"use_isolate": False},
+            },
+            gateway={"exposed_port": 8080},
+        ).get_metrics_port()
+        is None
+    )
+    assert (
+        Options(host={"metrics_port": 3001}, gateway={"serve": True}).get_metrics_port()
+        == 3001
+    )
+    assert (
+        Options(
+            environment={
+                "kind": "container",
+                "image": {"use_isolate": False},
+            },
+            host={"metrics_port": 3001},
+            gateway={"exposed_port": 8080},
+        ).get_metrics_port()
+        == 3001
+    )
+
+
 def test_run_local_with_entrypoint_resolves_user_symbol(monkeypatch):
     sentinel = MagicMock(name="user_module.UserApp.run_local")
     sentinel.return_value = "ran"
@@ -220,6 +261,80 @@ def test_run_local_forwards_exposed_ports_to_entrypoint_app(monkeypatch):
     )
 
 
+def test_run_local_entrypoint_app_uses_target_metrics_port(monkeypatch):
+    sentinel = MagicMock(name="user_module.UserApp.run_local")
+    sentinel.return_value = "ran"
+
+    class UserApp(App):
+        metrics_port = 9100
+
+        @endpoint("/")
+        def run(self):
+            return "ok"
+
+    UserApp.run_local = sentinel
+
+    fake_module = MagicMock()
+    fake_module.UserApp = UserApp
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:UserApp",
+    )
+
+    result = run_api(iso, local=True)
+
+    assert result == "ran"
+    sentinel.assert_called_once_with()
+
+
+def test_run_local_entrypoint_app_uses_target_metrics_port_with_outer_port(
+    monkeypatch,
+):
+    sentinel = MagicMock(name="user_module.UserApp.run_local")
+    sentinel.return_value = "ran"
+
+    class UserApp(App):
+        metrics_port = 9100
+
+        @endpoint("/")
+        def run(self):
+            return "ok"
+
+    UserApp.run_local = sentinel
+
+    fake_module = MagicMock()
+    fake_module.UserApp = UserApp
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:UserApp",
+    )
+
+    result = run_api(iso, local=True)
+
+    assert result == "ran"
+    sentinel.assert_called_once_with()
+
+
 def test_run_local_rejects_exposed_ports_for_plain_function():
     iso = IsolatedFunction(
         host=_FakeHost(),
@@ -258,6 +373,33 @@ def test_run_local_forwards_exposed_ports_to_served_function(monkeypatch):
     run_api(iso, local=True, exposed_port=3000, exposed_metrics_port=3001)
 
     assert called_port == 3000
+    assert called_metrics_port == 3001
+
+
+def test_run_local_forwards_configured_metrics_port_to_served_function(monkeypatch):
+    from fal.api.api import ServeWrapper
+
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_metrics_port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(host={"metrics_port": 3001}, gateway={"serve": True}),
+    )
+
+    run_api(iso, local=True)
+
     assert called_metrics_port == 3001
 
 
@@ -307,7 +449,7 @@ def test_run_local_forwards_exposed_ports_to_entrypoint_served_function(monkeypa
     assert called_metrics_port == 3001
 
 
-def test_run_local_entrypoint_served_function_keeps_configured_port(monkeypatch):
+def test_run_local_entrypoint_served_function_uses_target_port(monkeypatch):
     from fal.api.api import ServeWrapper
 
     called_ports: list[int] = []
@@ -342,7 +484,6 @@ def test_run_local_entrypoint_served_function_keeps_configured_port(monkeypatch)
         host=_FakeHost(),
         options=Options(gateway={"exposed_port": 8080}),
         entrypoint="user_module:served_function",
-        _entrypoint_exposed_port_defaulted=True,
     )
 
     run_api(iso, local=True)
@@ -350,7 +491,142 @@ def test_run_local_entrypoint_served_function_keeps_configured_port(monkeypatch)
     assert called_ports == [9000]
 
 
-def test_run_local_entrypoint_served_function_honors_explicit_default_port(
+def test_run_local_entrypoint_served_function_uses_target_metrics_port_config(
+    monkeypatch,
+):
+    from fal.api.api import ServeWrapper
+
+    called_metrics_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_metrics_ports.append(metrics_port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(host={"metrics_port": 9100}, gateway={"serve": True}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True)
+
+    assert called_metrics_ports == [9100]
+
+
+def test_run_local_entrypoint_served_function_uses_target_metrics_with_outer_port(
+    monkeypatch,
+):
+    from fal.api.api import ServeWrapper
+
+    called_ports: list[int] = []
+    called_metrics_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_ports.append(port)
+        called_metrics_ports.append(metrics_port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(host={"metrics_port": 9100}, gateway={"serve": True}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True)
+
+    assert called_ports == [8080]
+    assert called_metrics_ports == [9100]
+
+
+def test_run_local_entrypoint_served_function_uses_target_metrics_port(
+    monkeypatch,
+):
+    from fal.api.api import ServeWrapper
+
+    called_metrics_ports: list[int] = []
+
+    async def fake_serve(
+        self,
+        *,
+        port: int = 8080,
+        metrics_port: int = 9090,
+    ):
+        called_metrics_ports.append(metrics_port)
+
+    monkeypatch.setattr(ServeWrapper, "serve", fake_serve)
+
+    served_function = IsolatedFunction(
+        host=_FakeHost(),
+        raw_func=lambda: "local",
+        options=Options(host={"metrics_port": 9100}, gateway={"serve": True}),
+    )
+    fake_module = MagicMock()
+    fake_module.served_function = served_function
+
+    import importlib
+
+    def fake_import_module(name):
+        assert name == "user_module"
+        return fake_module
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    iso = IsolatedFunction(
+        host=_FakeHost(),
+        options=Options(host={"metrics_port": 3001}, gateway={"exposed_port": 8080}),
+        entrypoint="user_module:served_function",
+    )
+
+    run_api(iso, local=True)
+
+    assert called_metrics_ports == [9100]
+
+
+def test_run_local_entrypoint_served_function_uses_target_port_with_outer_port(
     monkeypatch,
 ):
     from fal.api.api import ServeWrapper
@@ -391,7 +667,7 @@ def test_run_local_entrypoint_served_function_honors_explicit_default_port(
 
     run_api(iso, local=True)
 
-    assert called_ports == [8080]
+    assert called_ports == [9000]
 
 
 def test_run_local_exposed_port_override_does_not_mutate_options(monkeypatch):

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -92,6 +92,68 @@ def test_app_regions_propagate_to_function_options():
     assert fn.options.host.get("regions") == ["us-east", "eu-west"]
 
 
+def test_app_metrics_port_propagates_to_function_options():
+    from fal.app import wrap_app
+
+    class MetricsApp(App):
+        metrics_port = 9091
+
+        @endpoint("/")
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    fn = wrap_app(MetricsApp)
+    assert fn.options.host.get("metrics_port") == 9091
+
+
+def test_machine_requirements_preserves_positional_field_order():
+    from dataclasses import fields
+
+    from fal.sdk import MachineRequirements
+
+    assert [field.name for field in fields(MachineRequirements)] == [
+        "machine_types",
+        "num_gpus",
+        "keep_alive",
+        "base_image",
+        "exposed_port",
+        "scheduler",
+        "scheduler_options",
+        "max_concurrency",
+        "max_multiplexing",
+        "min_concurrency",
+        "concurrency_buffer",
+        "concurrency_buffer_perc",
+        "scaling_delay",
+        "request_timeout",
+        "startup_timeout",
+        "valid_regions",
+        "metrics_port",
+    ]
+
+    requirements = MachineRequirements(
+        ["GPU"],
+        None,
+        0,
+        "base-image",
+        8080,
+        "scheduler",
+        {"foo": "bar"},
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        ["us-east"],
+        9090,
+    )
+    assert requirements.scheduler == "scheduler"
+    assert requirements.metrics_port == 9090
+
+
 def test_run_forwards_regions_to_machine_requirements():
     from fal.api.api import FalServerlessHost, Options, ResultHandler
     from fal.sdk import HostedRunState
@@ -99,6 +161,7 @@ def test_run_forwards_regions_to_machine_requirements():
     host = FalServerlessHost()
     options = Options()
     options.host["regions"] = ["us-east"]
+    options.host["metrics_port"] = 3001
 
     connection = MagicMock()
     connection.define_environment.return_value = object()
@@ -121,7 +184,227 @@ def test_run_forwards_regions_to_machine_requirements():
 
     assert result == "ok"
     _, call_kwargs = connection.run.call_args
-    assert call_kwargs["machine_requirements"].valid_regions == ["us-east"]
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.valid_regions == ["us-east"]
+    assert machine_requirements.metrics_port == 3001
+
+
+def test_register_defaults_metrics_port_for_served_app():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    host = FalServerlessHost()
+    options = Options(gateway={"exposed_port": 8080})
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            lambda: "ok",
+            options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port == 9090
+
+
+def test_register_forwards_metrics_port_to_wrapped_app_machine_requirements():
+    from fal.api.api import FalServerlessHost
+    from fal.app import wrap_app
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    class MetricsFromOptionsApp(App):
+        @endpoint("/")
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    host = FalServerlessHost()
+    fn = wrap_app(MetricsFromOptionsApp)
+    fn.options.host["metrics_port"] = 3001
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            fn.func,
+            fn.options,
+            application_name="example-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port == 3001
+
+
+def test_plain_function_exposed_port_defaults_metrics_port_to_machine_requirements():
+    from fal.api.api import FalServerlessHost
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    @fal.function(exposed_port=8080)
+    def plain_function():
+        return "ok"
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = plain_function.host.register(
+            lambda: "ok",
+            plain_function.options,
+            application_name="example-function",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port == 9090
+
+
+def test_no_isolate_container_exposed_port_does_not_default_metrics_port():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+
+    host = FalServerlessHost()
+    options = Options(
+        environment={"kind": "container", "image": {"use_isolate": False}},
+        gateway={"exposed_port": 8080},
+    )
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            None,
+            options,
+            application_name="container-app",
+            deployment_strategy="recreate",
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port is None
+
+
+def test_register_entrypoint_defaults_metrics_port():
+    from fal.api.api import FalServerlessHost, Options
+    from fal.sdk import RegisterApplicationResult, RegisterApplicationResultType
+    from fal.utils import _load_from_python_entry_point
+
+    host = FalServerlessHost()
+    loaded = _load_from_python_entry_point(
+        host,
+        "simple.app:SimpleApp",
+        options=Options(),
+    )
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id")
+    )
+    connection.register.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host.register(
+            None,
+            loaded.function.options,
+            application_name="entrypoint-app",
+            deployment_strategy="recreate",
+            entrypoint=loaded.function.run_entrypoint,
+        )
+
+    assert result == partial_result
+    _, call_kwargs = connection.register.call_args
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port == 9090
+
+
+def test_run_entrypoint_forwards_metrics_port_with_entrypoint_port():
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import HostedRunState
+    from fal.utils import _load_from_python_entry_point
+
+    host = FalServerlessHost()
+    loaded = _load_from_python_entry_point(
+        host,
+        "simple.app:SimpleApp",
+        options=Options(host={"metrics_port": 3001}),
+    )
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "ok"
+    connection.run.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        result = host._run(
+            None,
+            loaded.function.options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+            entrypoint=loaded.function.run_entrypoint,
+        )
+
+    assert result == "ok"
+    _, call_kwargs = connection.run.call_args
+    assert call_kwargs["entrypoint"] == loaded.function.run_entrypoint
+    machine_requirements = call_kwargs["machine_requirements"]
+    assert machine_requirements.exposed_port == 8080
+    assert machine_requirements.metrics_port == 3001
 
 
 def test_build_environment_forwards_force_environment_option():
@@ -688,6 +971,74 @@ def test_wrap_app_exposed_ports_propagate_to_serve(
     assert called_metrics_port == 3001
 
 
+def test_wrap_app_uses_app_metrics_port_when_not_overridden(
+    isolate_agent_env, monkeypatch: pytest.MonkeyPatch
+):
+    import asyncio
+
+    from fal import ref
+    from fal.app import wrap_app
+
+    class MetricsPortApp(App):
+        metrics_port = 9100
+
+        @endpoint("/")
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        limit_max_requests: int | None = None,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_metrics_port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(MetricsPortApp, "serve", fake_serve)
+    monkeypatch.setattr(ref, "current_app", None)
+
+    fn = wrap_app(MetricsPortApp)
+    asyncio.run(fn.func())
+
+    assert called_metrics_port == 9100
+
+
+def test_wrap_app_uses_app_metrics_port_from_class_keyword(
+    isolate_agent_env, monkeypatch: pytest.MonkeyPatch
+):
+    import asyncio
+
+    from fal import ref
+    from fal.app import wrap_app
+
+    class MetricsPortApp(App, metrics_port=9100):
+        @endpoint("/")
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    called_metrics_port: int | None = None
+
+    async def fake_serve(
+        self,
+        *,
+        limit_max_requests: int | None = None,
+        metrics_port: int = 9090,
+    ):
+        nonlocal called_metrics_port
+        called_metrics_port = metrics_port
+
+    monkeypatch.setattr(MetricsPortApp, "serve", fake_serve)
+    monkeypatch.setattr(ref, "current_app", None)
+
+    fn = wrap_app(MetricsPortApp)
+    asyncio.run(fn.func())
+
+    assert called_metrics_port == 9100
+
+
 def test_wrap_app_raises_for_virtualenv_only_keys_with_conda_kind():
     from fal.app import wrap_app
 
@@ -937,6 +1288,13 @@ def test_data_mounts_not_in_host_kwargs_when_none():
         pass
 
     assert "data_mounts" not in NoMountsApp.host_kwargs
+
+
+def test_metrics_port_not_in_host_kwargs_when_none():
+    class NoMetricsApp(App):
+        pass
+
+    assert "metrics_port" not in NoMetricsApp.host_kwargs
 
 
 def test_data_mounts_empty_list_propagates():

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -170,7 +170,7 @@ def test_load_function_from_applies_toml_app_files_for_fal_app(tmp_path):
     assert wrapped_cls.app_files_context_dir == "."
 
 
-def test_load_function_from_applies_toml_exposed_port_for_fal_app(tmp_path):
+def test_load_function_from_applies_toml_ports_for_fal_app(tmp_path):
     app_file = tmp_path / "app.py"
     app_file.write_text(
         "import fal\n"
@@ -183,11 +183,12 @@ def test_load_function_from_applies_toml_exposed_port_for_fal_app(tmp_path):
 
     client = SyncServerlessClient(host="api.alpha.fal.ai")
     host = client._create_host(local_file_path=str(app_file))
-    options = Options(gateway={"exposed_port": 9000})
+    options = Options(host={"metrics_port": 9001}, gateway={"exposed_port": 9000})
 
     loaded = load_function_from(host, str(app_file), "MyApp", options=options)
 
     assert loaded.function.options.gateway["exposed_port"] == 9000
+    assert loaded.function.options.host["metrics_port"] == 9001
 
 
 def test_load_function_from_applies_toml_host_options_over_app_defaults(tmp_path):
@@ -389,6 +390,20 @@ def test_load_from_python_entry_point_keeps_pyproject_exposed_port():
     )
 
     assert loaded.function.options.gateway["exposed_port"] == 9000
+
+
+def test_load_from_python_entry_point_keeps_pyproject_metrics_port():
+    from fal.utils import _load_from_python_entry_point
+
+    host = MagicMock(spec=["run"])
+    options = Options(host={"metrics_port": 9001})
+    loaded = _load_from_python_entry_point(
+        host,
+        "simple.app:SimpleApp",
+        options=options,
+    )
+
+    assert loaded.function.options.host["metrics_port"] == 9001
 
 
 def test_isolated_function_endpoints_from_metadata():


### PR DESCRIPTION
Add `metrics_port` as a serverless host/machine config for internal metrics scrapes. Default isolate-backed served/exposed deployments to metrics port `9090`, no-isolate containers default to no metrics port unless `metrics_port` is explicitly configured.