### PR TITLE
feat: add requirements context dir

### DIFF
--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import sys
 import threading
+import warnings
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, suppress
@@ -12,6 +13,7 @@ from dataclasses import dataclass, field, replace
 from difflib import get_close_matches
 from functools import wraps
 from os import PathLike
+from pathlib import Path
 from queue import Queue
 from typing import (
     TYPE_CHECKING,
@@ -918,6 +920,7 @@ class FalServerlessHost(Host):
             "termination_grace_period_seconds",
             "secrets",
             "data_mounts",
+            "requirements_context_dir",
         }
     )
 
@@ -926,12 +929,24 @@ class FalServerlessHost(Host):
     local_project_root: str = ""
     credentials: Credentials = field(default_factory=get_credentials)
     environment_name: Optional[str] = None
+    requirements_context_dir: str = ""
 
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
     _thread_pool: ThreadPoolExecutor = field(
         default_factory=ThreadPoolExecutor, init=False
     )
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.local_project_root and not self.requirements_context_dir:
+            warnings.warn(
+                "FalServerlessHost(local_project_root=...) is deprecated; "
+                "use requirements_context_dir instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            self.requirements_context_dir = self.local_project_root
 
     def _runtime_config(self, options: Options) -> FunctionRuntimeConfig | None:
         return _runtime_config_from_options(options, self.local_file_path)
@@ -955,28 +970,38 @@ class FalServerlessHost(Host):
     def _materialize_local_requirements(
         self,
         environment_options: dict[str, Any],
+        requirements_context_dir: str | None = None,
         on_progress: ProgressCallback | None = None,
     ) -> None:
-        """Rewrite ``.``/``.[extras]`` in ``environment_options['requirements']``
-        to point at an uploaded sdist of ``self.local_project_root``.
+        """Rewrite ``.``, ``.[extras]``, and other local paths in
+        ``environment_options['requirements']`` to point at an uploaded sdist
+        of the configured requirements context.
 
         Mutates ``environment_options`` in place. No-op when there's no
-        project root or no local-path requirement to rewrite — keeps the
-        dispatch hot path quiet for users who don't use this feature.
+        local-path requirement to rewrite — keeps the dispatch hot path quiet
+        for users who don't use this feature.
         """
-        local_project_root = self.local_project_root
-        if not local_project_root:
-            return
+        if requirements_context_dir is None:
+            requirements_context_dir = self.requirements_context_dir
+        base_path = Path(self.local_file_path or os.getcwd()).expanduser().resolve()
+        base_dir = base_path if base_path.is_dir() else base_path.parent
+        context_path = Path(requirements_context_dir or ".").expanduser()
+        if context_path.is_absolute():
+            resolved_requirements_context_dir = str(context_path.resolve())
+        else:
+            resolved_requirements_context_dir = str((base_dir / context_path).resolve())
 
         requirements = environment_options.get("requirements")
         if not requirements:
             return
 
-        if not has_local_path(requirements, local_project_root):
+        if not has_local_path(requirements, resolved_requirements_context_dir):
             return
 
         environment_options["requirements"] = materialize_local_paths(
-            requirements, local_project_root, on_progress=on_progress
+            requirements,
+            resolved_requirements_context_dir,
+            on_progress=on_progress,
         )
 
     def prepare_options(
@@ -990,6 +1015,9 @@ class FalServerlessHost(Host):
 
         prepared_options = super().prepare_options(options)
         environment_options = prepared_options.environment
+        requirements_context_dir = prepared_options.host.pop(
+            "requirements_context_dir", None
+        )
 
         # An explicit ``python_version=None`` must still resolve to the local
         # interpreter: we ship local cloudpickled bytecode, so the remote
@@ -1003,7 +1031,9 @@ class FalServerlessHost(Host):
         )
 
         self._materialize_local_requirements(
-            environment_options, on_progress=on_progress
+            environment_options,
+            requirements_context_dir=requirements_context_dir,
+            on_progress=on_progress,
         )
 
         return prepared_options
@@ -1576,6 +1606,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,
@@ -1611,6 +1642,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,
@@ -1698,6 +1730,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,
@@ -1738,6 +1771,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,
@@ -1772,6 +1806,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,
@@ -1806,6 +1841,7 @@ def function(
     request_timeout: int | None = None,
     startup_timeout: int | None = None,
     setup_function: Callable[..., None] | None = None,
+    requirements_context_dir: str | None = None,
     force_env_build: bool = False,
     _base_image: str | None = None,
     _scheduler: str | None = None,

--- a/projects/fal/src/fal/api/client.py
+++ b/projects/fal/src/fal/api/client.py
@@ -443,13 +443,13 @@ class SyncServerlessClient:
         self,
         *,
         local_file_path: str = "",
-        local_project_root: str = "",
+        requirements_context_dir: str = "",
         environment_name: str | None = None,
     ) -> FalServerlessHost:
         return FalServerlessHost(
             self._grpc_host,
             local_file_path=local_file_path,
-            local_project_root=local_project_root,
+            requirements_context_dir=requirements_context_dir,
             credentials=self._credentials,
             environment_name=environment_name,
         )

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -188,7 +188,6 @@ def _prepare_deployment_from_reference(
     local_file_path = str(file_path) if file_path is not None else ""
     host = client._create_host(
         local_file_path=local_file_path,
-        local_project_root=app_data.local_project_root or "",
         environment_name=environment_name,
     )
     loaded = load_function_from(

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -497,6 +497,9 @@ class App(BaseServable):
             to install in multiple steps.
             Example: `["numpy==1.24.0", "torch>=2.0.0"]` or
             `[["setuptools", "wheel"], ["numpy==1.24.0"]]`
+        requirements_context_dir: Base directory for resolving local-path
+            requirements such as `.[extra]` or `../shared[extra]`.
+            Defaults to the directory containing the app file.
         local_python_modules: List of local Python module names to include
             in the deployment. Use for custom code not available on PyPI.
             Example: `["my_utils", "models"]`
@@ -546,6 +549,7 @@ class App(BaseServable):
     """
 
     requirements: ClassVar[list[str] | list[list[str]]] = []  # type: ignore[assignment]
+    requirements_context_dir: ClassVar[Optional[str]] = None
     local_python_modules: ClassVar[list[str]] = []
     machine_type: ClassVar[str | list[str]] = "S"
     num_gpus: ClassVar[int | None] = None
@@ -626,6 +630,9 @@ class App(BaseServable):
                 raise ValueError(
                     "app_files_context_dir is only supported when app_files is provided"
                 )
+
+        if cls.requirements_context_dir is not None:
+            cls.host_kwargs["requirements_context_dir"] = cls.requirements_context_dir
 
         if cls.min_concurrency is not None:
             cls.host_kwargs["min_concurrency"] = cls.min_concurrency

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -36,11 +36,6 @@ class AppData:
     team: Optional[str] = None
     name: Optional[str] = None
     options: Options = field(default_factory=Options)
-    # Directory of the pyproject.toml this app was loaded from. Used by
-    # ``FalServerlessHost`` to materialize ``.``/``.[extras]`` requirements
-    # into uploaded sdists. ``None`` when the app wasn't loaded from a
-    # pyproject (e.g. file::func ref directly).
-    local_project_root: Optional[str] = None
 
 
 def get_client(host: str, team: str | None = None):
@@ -115,6 +110,11 @@ def get_app_data_from_toml(
     requirements = app_data.pop("requirements", None)
     if requirements is not None:
         _validate_requirements(requirements)
+    requirements_context_dir = app_data.pop("requirements_context_dir", None)
+    if requirements_context_dir is not None and not isinstance(
+        requirements_context_dir, str
+    ):
+        raise ValueError("requirements_context_dir must be a string.")
     python_version = app_data.pop("python_version", None)
     if python_version is not None and not isinstance(python_version, str):
         raise ValueError(
@@ -270,6 +270,19 @@ def get_app_data_from_toml(
         options.environment["kind"] = "container"
         options.environment["image"] = image
 
+    pyproject_dir = Path(toml_path).parent.resolve()
+    resolved_requirements_context_dir = pyproject_dir
+    if requirements_context_dir is not None:
+        context_path = Path(requirements_context_dir).expanduser()
+        if context_path.is_absolute():
+            resolved_requirements_context_dir = context_path.resolve()
+        else:
+            resolved_requirements_context_dir = (pyproject_dir / context_path).resolve()
+    if requirements is not None or requirements_context_dir is not None:
+        options.host["requirements_context_dir"] = str(
+            resolved_requirements_context_dir
+        )
+
     app_reset_scale: bool
     if "no_scale" in app_data:
         # Deprecated
@@ -292,7 +305,6 @@ def get_app_data_from_toml(
         team=app_team,
         name=app_name_value,
         options=options,
-        local_project_root=str(Path(toml_path).parent),
     )
 
 

--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -62,7 +62,6 @@ def _run(args):
     client = SyncServerlessClient(host=args.host, team=team)
     host = client._create_host(
         local_file_path=file_path or "",
-        local_project_root=app_data.local_project_root or "",
         environment_name=args.env,
     )
 

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional, Tuple
 from unittest.mock import MagicMock, patch
@@ -271,6 +272,10 @@ def mock_parse_pyproject_toml():
     }
 
 
+def _default_requirements_context_dir() -> str:
+    return str(Path("pyproject.toml").parent.resolve())
+
+
 def mock_args(
     app_ref: Tuple[str, Optional[str]],
     app_name: Optional[str] = None,
@@ -331,7 +336,6 @@ def test_deploy_with_toml_success(
             reset_scale=False,
             team=None,
             name="my-app",
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -375,6 +379,10 @@ def test_deploy_python_entry_point_forwards_to_loader(
     assert call_kwargs["python_entry_point"] == "simple.app:SimpleApp"
     assert call_kwargs["options"].environment["python_version"] == "3.12"
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
+    assert (
+        call_kwargs["options"].host["requirements_context_dir"]
+        == _default_requirements_context_dir()
+    )
 
 
 @patch("fal.cli._utils.find_pyproject_toml")
@@ -415,7 +423,6 @@ def test_deploy_image_only_forwards_no_ref_to_loader(
     mock_create_host.assert_called_once()
     _, host_kwargs = mock_create_host.call_args
     assert host_kwargs["local_file_path"] == ""
-    assert host_kwargs["local_project_root"] == str(tmp_path)
 
     mock_load_function_from.assert_called_once()
     call_args, call_kwargs = mock_load_function_from.call_args
@@ -444,7 +451,10 @@ def test_deploy_with_toml_python_entry_point(
     cleanly without crashing on the absent ``ref``.
     """
     mock_parse_toml.return_value = mock_parse_pyproject_toml
-    options = Options(environment={"requirements": ["fal"], "python_version": "3.12"})
+    options = Options(
+        host={"requirements_context_dir": _default_requirements_context_dir()},
+        environment={"requirements": ["fal"], "python_version": "3.12"},
+    )
 
     args = mock_args(app_ref=("entrypoint-app", None))
 
@@ -462,7 +472,6 @@ def test_deploy_with_toml_python_entry_point(
             team=None,
             name="entrypoint-app",
             options=options,
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -500,7 +509,6 @@ def test_deploy_with_toml_no_auth(
             reset_scale=False,
             team=None,
             name="another-app",
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -541,10 +549,10 @@ def test_deploy_with_toml_overrides_applied(
                     "machine_type": "GPU-H100",
                     "num_gpus": 2,
                     "regions": ["us-east"],
+                    "requirements_context_dir": _default_requirements_context_dir(),
                 },
                 environment={"requirements": ["numpy==1.26.4"]},
             ),
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -678,7 +686,6 @@ def test_deploy_with_toml_deployment_strategy(
             reset_scale=False,
             team=None,
             name="my-app",
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -714,7 +721,6 @@ def test_deploy_with_toml_default_deployment_strategy(
             reset_scale=False,
             team=None,
             name="another-app",
-            local_project_root=".",
         ),
         force_env_build=False,
         environment_name=None,
@@ -1239,6 +1245,79 @@ def test_get_app_data_from_toml_resolves_app_files_context_dir_from_pyproject(
     toml_data = get_app_data_from_toml("app-with-files")
 
     assert toml_data.options.host["app_files_context_dir"] == str(tmp_path)
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_resolves_requirements_context_dir_from_pyproject(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "app-with-local-req": {
+                "ref": "src/app.py::App",
+                "requirements": [".[worker]"],
+                "requirements_context_dir": "apps/../packages/my_package",
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("app-with-local-req")
+
+    assert toml_data.options.host["requirements_context_dir"] == str(
+        tmp_path / "packages" / "my_package"
+    )
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_preserves_absolute_requirements_context_dir(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    context_dir = tmp_path / "packages" / "my_package"
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "app-with-local-req": {
+                "ref": "src/app.py::App",
+                "requirements": [".[worker]"],
+                "requirements_context_dir": str(context_dir),
+            }
+        }
+    }
+
+    toml_data = get_app_data_from_toml("app-with-local-req")
+
+    assert toml_data.options.host["requirements_context_dir"] == str(context_dir)
+
+
+@patch("fal.cli._utils.find_pyproject_toml")
+@patch("fal.cli._utils.parse_pyproject_toml")
+def test_get_app_data_from_toml_rejects_invalid_requirements_context_dir(
+    mock_parse_toml, mock_find_toml, tmp_path
+):
+    from fal.cli._utils import get_app_data_from_toml
+
+    mock_find_toml.return_value = str(tmp_path / "pyproject.toml")
+    mock_parse_toml.return_value = {
+        "apps": {
+            "app-with-local-req": {
+                "ref": "src/app.py::App",
+                "requirements": [".[worker]"],
+                "requirements_context_dir": ["packages/my_package"],
+            }
+        }
+    }
+
+    with pytest.raises(
+        ValueError, match=r"requirements_context_dir must be a string\."
+    ):
+        get_app_data_from_toml("app-with-local-req")
 
 
 @patch("fal.cli._utils.find_pyproject_toml")
@@ -2001,7 +2080,6 @@ def _prepared_deployment(
             reset_scale=reset_scale,
             deployment_strategy="rolling",
             name="my-app",
-            local_project_root=".",
         ),
     )
 

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -136,7 +136,7 @@ def mock_parse_pyproject_toml():
 def mocked_fal_serverless_host(host):
     mock = MagicMock()
     mock.host = host
-    mock.local_project_root = ""
+    mock.requirements_context_dir = ""
     mock.prepare_options.side_effect = lambda options, **_: options
     return mock
 
@@ -226,7 +226,6 @@ def test_run_forwards_python_entry_point_to_loader(
 
     mock_create_host.assert_called_once_with(
         local_file_path="",
-        local_project_root=str(Path("pyproject.toml").parent),
         environment_name=None,
     )
     mock_load_function_from.assert_called_once()
@@ -236,6 +235,9 @@ def test_run_forwards_python_entry_point_to_loader(
     assert call_kwargs["options"].environment["requirements"] == ["fal"]
     assert call_kwargs["options"].gateway["exposed_port"] == 9000
     assert call_kwargs["options"].host["metrics_port"] == 9001
+    assert call_kwargs["options"].host["requirements_context_dir"] == str(
+        Path("pyproject.toml").parent.resolve()
+    )
 
 
 @patch("fal.cli._utils.find_pyproject_toml")
@@ -288,7 +290,6 @@ def test_run_image_only_forwards_no_ref_to_loader(
 
     mock_create_host.assert_called_once_with(
         local_file_path="",
-        local_project_root=str(tmp_path),
         environment_name=None,
     )
     mock_load_function_from.assert_called_once()

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -533,7 +533,7 @@ def _exercise_local_path_cache_only_sequence(tmp_path, requirements, prepare_for
         fake_sdist.write_bytes(b"fake-sdist-bytes")
         return fake_sdist
 
-    host = FalServerlessHost(local_project_root=str(tmp_path))
+    host = FalServerlessHost(requirements_context_dir=str(tmp_path))
     options = Options(environment={"kind": "virtualenv", "requirements": requirements})
 
     connection = MagicMock()
@@ -665,7 +665,7 @@ def test_prepare_options_checks_python_version_before_materializing_requirements
         '[project]\nname = "simple"\nversion = "0.1.0"\n'
     )
 
-    host = FalServerlessHost(local_project_root=str(tmp_path))
+    host = FalServerlessHost(requirements_context_dir=str(tmp_path))
     options = Options(
         environment={
             "kind": "virtualenv",
@@ -682,6 +682,207 @@ def test_prepare_options_checks_python_version_before_materializing_requirements
     build_sdist.assert_not_called()
 
 
+def test_prepare_options_materializes_from_requirements_context_dir(tmp_path):
+    from fal.api.api import FalServerlessHost, Options
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = project_dir / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost(requirements_context_dir=str(project_dir))
+    options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = host.prepare_options(options)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    build.assert_called_once_with(project_dir.resolve())
+
+
+def test_function_materializes_from_requirements_context_dir(tmp_path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = project_dir / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    @fal.function(requirements=["."], requirements_context_dir=str(project_dir))
+    def fn():
+        return "ok"
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = fn.host.prepare_options(fn.options, func=fn.raw_func)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    assert "requirements_context_dir" not in prepared_options.host
+    build.assert_called_once_with(project_dir.resolve())
+
+
+def test_prepare_options_supports_local_project_root_alias(tmp_path):
+    from fal.api.api import FalServerlessHost, Options
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="FalServerlessHost\\(local_project_root=\\.\\.\\.\\) is deprecated",
+    ):
+        host = FalServerlessHost(local_project_root=str(tmp_path))
+    options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = host.prepare_options(options)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    assert host.requirements_context_dir == str(tmp_path)
+    build.assert_called_once_with(tmp_path.resolve())
+
+
+def test_prepare_options_defaults_requirements_context_dir_to_cwd(
+    tmp_path, monkeypatch
+):
+    from fal.api.api import FalServerlessHost, Options
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = tmp_path / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost()
+    options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = host.prepare_options(options)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    build.assert_called_once_with(tmp_path.resolve())
+
+
+def test_prepare_options_defaults_requirements_context_dir_to_local_file_dir(tmp_path):
+    from fal.api.api import FalServerlessHost, Options
+
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text("")
+    (app_dir / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = app_dir / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = host.prepare_options(options)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    build.assert_called_once_with(app_dir.resolve())
+
+
+def test_prepare_options_resolves_relative_requirements_context_dir_from_local_file(
+    tmp_path,
+):
+    from fal.api.api import FalServerlessHost, Options
+
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text("")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "simple"\nversion = "0.1.0"\n'
+    )
+    fake_sdist = project_dir / "build_out" / "simple-0.1.0.tar.gz"
+
+    def build_fake_sdist(_project_root):
+        fake_sdist.parent.mkdir()
+        fake_sdist.write_bytes(b"fake-sdist-bytes")
+        return fake_sdist
+
+    host = FalServerlessHost(local_file_path=str(app_file))
+    options = Options(
+        environment={"kind": "virtualenv", "requirements": ["."]},
+        host={"requirements_context_dir": "../project"},
+    )
+
+    with patch("fal.api._sdist._build_sdist", side_effect=build_fake_sdist) as build:
+        with patch(
+            "fal.api._sdist._upload_sdist",
+            return_value="https://cdn/simple-0.1.0.tar.gz",
+        ):
+            prepared_options = host.prepare_options(options)
+
+    assert prepared_options.environment["requirements"] == [
+        "simple @ https://cdn/simple-0.1.0.tar.gz"
+    ]
+    build.assert_called_once_with(project_dir.resolve())
+
+
 def test_build_environment_keeps_local_requirements_for_future_rebuilds(tmp_path):
     from fal.api.api import FalServerlessHost, Options
     from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus
@@ -696,7 +897,7 @@ def test_build_environment_keeps_local_requirements_for_future_rebuilds(tmp_path
         fake_sdist.write_bytes(b"fake-sdist-bytes")
         return fake_sdist
 
-    host = FalServerlessHost(local_project_root=str(tmp_path))
+    host = FalServerlessHost(requirements_context_dir=str(tmp_path))
     options = Options(environment={"kind": "virtualenv", "requirements": ["."]})
 
     connection = MagicMock()
@@ -1585,6 +1786,7 @@ def test_app_files_classvars_propagate_to_host_kwargs():
         app_files = ["a.py", "b.py"]
         app_files_ignore = [r"\\.venv/"]
         app_files_context_dir = "."
+        requirements_context_dir = "."
         min_concurrency = 2
         max_concurrency = 3
         concurrency_buffer = 4
@@ -1598,6 +1800,7 @@ def test_app_files_classvars_propagate_to_host_kwargs():
     assert hk["app_files"] == ["a.py", "b.py"]
     assert hk["app_files_ignore"] == [r"\\.venv/"]
     assert hk["app_files_context_dir"] == "."
+    assert hk["requirements_context_dir"] == "."
     assert hk["min_concurrency"] == 2
     assert hk["max_concurrency"] == 3
     assert hk["concurrency_buffer"] == 4
@@ -1952,6 +2155,7 @@ def test_non_host_classvars_do_not_leak_into_host_kwargs():
     assert "machine_type" not in hk
     assert "num_gpus" not in hk
     assert "app_auth" not in hk
+    assert "requirements_context_dir" not in hk
 
 
 @pytest.mark.asyncio

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -138,6 +138,180 @@ def _extract_wrapped_app_class(loaded):
     return loaded.function.raw_func.__closure__[cls_index].cell_contents
 
 
+def test_load_function_from_leaves_requirements_context_dir_unset_by_default(
+    tmp_path,
+):
+    app_dir = tmp_path / "src"
+    app_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    requirements = ['.[worker]']\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+
+    loaded = load_function_from(host, str(app_file), "MyApp")
+
+    assert "requirements_context_dir" not in loaded.function.options.host
+
+
+def test_load_function_from_preserves_app_requirements_context_dir(
+    tmp_path,
+):
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    package_dir = tmp_path / "packages" / "my_package"
+    package_dir.mkdir(parents=True)
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    requirements = ['.[worker]']\n"
+        "    requirements_context_dir = '../packages/my_package'\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+
+    loaded = load_function_from(host, str(app_file), "MyApp")
+
+    assert loaded.function.options.host["requirements_context_dir"] == (
+        "../packages/my_package"
+    )
+
+
+def test_load_function_from_preserves_pyproject_requirements_context(
+    tmp_path,
+):
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    pyproject_context_dir = tmp_path / "configured-context"
+    pyproject_context_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(host={"requirements_context_dir": str(pyproject_context_dir)})
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.host["requirements_context_dir"] == str(
+        pyproject_context_dir
+    )
+
+
+def test_load_function_from_preserves_pyproject_context_for_non_local_app_requirements(
+    tmp_path,
+):
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    pyproject_context_dir = tmp_path / "configured-context"
+    pyproject_context_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    requirements = ['requests']\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(host={"requirements_context_dir": str(pyproject_context_dir)})
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.host["requirements_context_dir"] == str(
+        pyproject_context_dir
+    )
+
+
+def test_load_function_from_preserves_pyproject_context_for_local_app_requirements(
+    tmp_path,
+):
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    pyproject_context_dir = tmp_path / "configured-context"
+    pyproject_context_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    requirements = ['.[worker]']\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(host={"requirements_context_dir": str(pyproject_context_dir)})
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.host["requirements_context_dir"] == str(
+        pyproject_context_dir
+    )
+
+
+def test_load_function_from_app_explicit_context_overrides_pyproject_context(
+    tmp_path,
+):
+    app_dir = tmp_path / "apps"
+    app_dir.mkdir()
+    app_context_dir = tmp_path / "app-context"
+    app_context_dir.mkdir()
+    pyproject_context_dir = tmp_path / "configured-context"
+    pyproject_context_dir.mkdir()
+    app_file = app_dir / "app.py"
+    app_file.write_text(
+        "import fal\n"
+        "\n"
+        "class MyApp(fal.App):\n"
+        "    requirements = ['.[worker]']\n"
+        "    requirements_context_dir = '../app-context'\n"
+        "\n"
+        "    @fal.endpoint('/')\n"
+        "    def run(self):\n"
+        "        return {'ok': True}\n"
+    )
+
+    client = SyncServerlessClient(host="api.alpha.fal.ai")
+    host = client._create_host(local_file_path=str(app_file))
+    options = Options(host={"requirements_context_dir": str(pyproject_context_dir)})
+
+    loaded = load_function_from(host, str(app_file), "MyApp", options=options)
+
+    assert loaded.function.options.host["requirements_context_dir"] == "../app-context"
+
+
 def test_load_function_from_applies_toml_app_files_for_fal_app(tmp_path):
     app_file = tmp_path / "app.py"
     app_file.write_text(


### PR DESCRIPTION
Adds `requirements_context_dir` for pyproject app entries and `fal.App` classes so local-path requirements like `.[extra]` or `../shared[extra]` are resolved from an explicit directory before sdist materialization. Pyproject apps use the pyproject directory by default, `fal.App` classes with local-path requirements use the app file directory by default, and the host falls back to the current working directory only when no context was set by either path.

This also keeps `FalServerlessHost(local_project_root=...)` working as a compatibility alias for the new internal context field and avoids mutating class-level `App.requirements` while wrapping apps. Tracks SERV-1044.

Examples:

Say you have a monorepo with `projects/`:

```
[tool.fal.apps.my_app]
...
requirements = ["myproject[extra]"]
requirements_context_dir = "projects"
```

```
import fal

class MyApp(fal.App):
    requirements = ["myfoo[extra]", "mybar[extra]"]
    requirements_context_dir = "../projects"
```