### PR TITLE
fix(cli): respect toml team for app commands

### DIFF
--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -52,6 +52,17 @@ def is_app_name(app_ref: tuple[str, str | None]) -> bool:
     return is_single_file and not is_python_file
 
 
+def resolve_team_from_app_name(app_name: str, team: str | None) -> str | None:
+    if not is_app_name((app_name, None)):
+        return team
+
+    try:
+        toml_data = get_app_data_from_toml(app_name, emit_deprecation_warnings=False)
+        return team or toml_data.team
+    except (ValueError, FileNotFoundError):
+        return team
+
+
 def get_app_data_from_toml(
     app_name: str, *, emit_deprecation_warnings: bool = True
 ) -> AppData:

--- a/projects/fal/src/fal/cli/apps.py
+++ b/projects/fal/src/fal/cli/apps.py
@@ -8,7 +8,7 @@ import fal.cli.runners as runners
 from fal.api.client import SyncServerlessClient
 from fal.sdk import RunnerState, deconstruct_alias
 
-from ._utils import VALID_REGIONS, get_client
+from ._utils import VALID_REGIONS, get_client, resolve_team_from_app_name
 from .parser import FalClientParser, SinceAction, add_env_argument, get_output_parser
 
 if TYPE_CHECKING:
@@ -165,7 +165,10 @@ def _app_rev_table(revs: list[ApplicationInfo]):
 
 
 def _list_rev(args):
-    client = get_client(args.host, args.team)
+    team = None
+    if args.app_name is not None:
+        team = resolve_team_from_app_name(args.app_name, args.team)
+    client = get_client(args.host, team)
     with client.connect() as connection:
         revs = connection.list_applications(args.app_name, environment_name=args.env)
         table = _app_rev_table(revs)
@@ -191,7 +194,8 @@ def _add_list_rev_parser(subparsers, parents):
 
 
 def _scale(args):
-    client = SyncServerlessClient(host=args.host, team=args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)
     if (
         args.keep_alive is None
         and args.max_multiplexing is None
@@ -315,7 +319,8 @@ def _add_scale_parser(subparsers, parents):
 
 
 def _rollout(args):
-    client = SyncServerlessClient(host=args.host, team=args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)
     client.apps.rollout(args.app_name, force=args.force, environment_name=args.env)
     args.console.log(f"Rolled out application {args.app_name}")
 
@@ -343,7 +348,8 @@ def _add_rollout_parser(subparsers, parents):
 
 
 def _set_rev(args):
-    client = get_client(args.host, args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = get_client(args.host, team)
     with client.connect() as connection:
         alias_info = connection.create_alias(
             args.app_name,
@@ -392,7 +398,8 @@ def _add_set_rev_parser(subparsers, parents):
 
 
 def _runners(args):
-    client = SyncServerlessClient(host=args.host, team=args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)
     start_time = args.since
     alias_runners = client.apps.runners(
         args.app_name, since=start_time, state=args.state, environment_name=args.env
@@ -478,7 +485,8 @@ def _add_runners_parser(subparsers, parents):
 
 
 def _gpus(args):
-    client = SyncServerlessClient(host=args.host, team=args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)
     usage = client.apps.gpus(args.app_name)
     runners.render_gpus(args, usage["gpus"], usage["total"])
 
@@ -499,7 +507,8 @@ def _add_gpus_parser(subparsers, parents):
 
 
 def _delete(args):
-    client = get_client(args.host, args.team)
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = get_client(args.host, team)
     with client.connect() as connection:
         res = connection.delete_alias(args.app_name, environment_name=args.env)
         if res is None:

--- a/projects/fal/src/fal/cli/queue.py
+++ b/projects/fal/src/fal/cli/queue.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 import httpx
 
+from ._utils import resolve_team_from_app_name
 from .parser import FalClientParser, get_output_parser
 
 
@@ -12,7 +13,8 @@ def _queue_size(args):
     from fal.api.client import SyncServerlessClient
     from fal.api.deploy import _get_user
 
-    client = SyncServerlessClient(host=args.host, team=args.team)._create_rest_client()
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)._create_rest_client()
     user = _get_user(client)
 
     url = f"{client.base_url}/applications/{user.username}/{args.app_name}/queue"
@@ -61,7 +63,8 @@ def _queue_flush(args):
     from fal.api.client import SyncServerlessClient
     from fal.api.deploy import _get_user
 
-    client = SyncServerlessClient(host=args.host, team=args.team)._create_rest_client()
+    team = resolve_team_from_app_name(args.app_name, args.team)
+    client = SyncServerlessClient(host=args.host, team=team)._create_rest_client()
     user = _get_user(client)
     caller_user_id = args.caller_user_id
 

--- a/projects/fal/tests/unit/cli/test_apps.py
+++ b/projects/fal/tests/unit/cli/test_apps.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fal.cli._utils import AppData, resolve_team_from_app_name
 from fal.cli.apps import (
     _delete,
     _delete_rev,
@@ -145,6 +146,221 @@ def test_scale_with_env():
     assert args.app_name == "myapp"
     assert args.min_concurrency == 1
     assert args.env == "prod"
+
+
+@patch("fal.cli.apps._apps_table")
+@patch("fal.cli._utils.get_app_data_from_toml")
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_scale_with_team_from_toml(
+    mock_client_cls,
+    mock_get_app_data_from_toml,
+    mock_apps_table,
+):
+    mock_get_app_data_from_toml.return_value = AppData(team="internal")
+    mock_client = MagicMock()
+    mock_client.apps.scale.return_value = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_apps_table.return_value = "table-output"
+
+    args = parse_args(["apps", "scale", "team-app", "--min-concurrency", "1"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _scale(args)
+
+    mock_get_app_data_from_toml.assert_called_once_with(
+        "team-app", emit_deprecation_warnings=False
+    )
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")
+    mock_client.apps.scale.assert_called_once()
+
+
+@patch("fal.cli.apps._apps_table")
+@patch("fal.cli._utils.get_app_data_from_toml")
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_scale_cli_team_overrides_team_from_toml(
+    mock_client_cls,
+    mock_get_app_data_from_toml,
+    mock_apps_table,
+):
+    mock_get_app_data_from_toml.return_value = AppData(team="internal")
+    mock_client = MagicMock()
+    mock_client.apps.scale.return_value = MagicMock()
+    mock_client_cls.return_value = mock_client
+    mock_apps_table.return_value = "table-output"
+
+    args = parse_args(
+        [
+            "apps",
+            "scale",
+            "team-app",
+            "--min-concurrency",
+            "1",
+            "--team",
+            "cli-team",
+        ]
+    )
+    args.host = "my-host"
+    args.console = MagicMock()
+    _scale(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="cli-team")
+
+
+@patch("fal.cli._utils.get_app_data_from_toml")
+def test_resolve_team_from_app_name_uses_toml(mock_get_app_data_from_toml):
+    mock_get_app_data_from_toml.return_value = AppData(team="internal")
+
+    team = resolve_team_from_app_name("team-app", None)
+
+    assert team == "internal"
+    mock_get_app_data_from_toml.assert_called_once_with(
+        "team-app", emit_deprecation_warnings=False
+    )
+
+
+@patch("fal.cli._utils.get_app_data_from_toml")
+def test_resolve_team_from_app_name_keeps_cli_override(mock_get_app_data_from_toml):
+    mock_get_app_data_from_toml.return_value = AppData(team="internal")
+
+    assert resolve_team_from_app_name("team-app", "cli-team") == "cli-team"
+
+
+@patch("fal.cli._utils.get_app_data_from_toml")
+def test_resolve_team_from_app_name_ignores_missing_toml(mock_get_app_data_from_toml):
+    mock_get_app_data_from_toml.side_effect = ValueError(
+        "App team-app not found in pyproject.toml"
+    )
+
+    assert resolve_team_from_app_name("team-app", None) is None
+
+
+@patch("fal.cli._utils.get_app_data_from_toml")
+def test_resolve_team_from_app_name_ignores_python_files(mock_get_app_data_from_toml):
+    assert resolve_team_from_app_name("app.py", None) is None
+
+    mock_get_app_data_from_toml.assert_not_called()
+
+
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_rollout_with_team_from_toml(mock_client_cls, mock_get_app_data_from_toml):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+
+    args = parse_args(["apps", "rollout", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _rollout(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")
+    mock_client.apps.rollout.assert_called_once_with(
+        "team-app", force=False, environment_name=None
+    )
+
+
+@patch(
+    "fal.cli.apps.runners.runners_table",
+    return_value=SimpleNamespace(columns=[object()]),
+)
+@patch(
+    "fal.cli.apps.runners.runners_requests_table",
+    return_value=SimpleNamespace(rows=[]),
+)
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_runners_with_team_from_toml(
+    mock_client_cls,
+    mock_get_app_data_from_toml,
+    mock_requests_table,
+    mock_runners_table,
+):
+    mock_client = MagicMock()
+    mock_client.apps.runners.return_value = []
+    mock_client_cls.return_value = mock_client
+
+    args = parse_args(["apps", "runners", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _runners(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")
+    mock_client.apps.runners.assert_called_once_with(
+        "team-app", since=None, state=None, environment_name=None
+    )
+
+
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.SyncServerlessClient")
+def test_gpus_with_team_from_toml(mock_client_cls, mock_get_app_data_from_toml):
+    mock_client_cls.return_value = _mock_gpus_client(_GPUS_PAYLOAD)
+
+    args = parse_args(["apps", "gpus", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _gpus(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")
+
+
+@patch("fal.cli.apps._apps_table", return_value="table-output")
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.get_client")
+def test_list_rev_with_team_from_toml(
+    mock_get_client,
+    mock_get_app_data_from_toml,
+    mock_apps_table,
+):
+    mock_connection = MagicMock()
+    mock_connection.list_applications.return_value = []
+    mock_get_client.return_value.connect.return_value.__enter__.return_value = (
+        mock_connection
+    )
+
+    args = parse_args(["apps", "list-rev", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _list_rev(args)
+
+    mock_get_client.assert_called_once_with("my-host", "internal")
+
+
+@patch("fal.cli.apps._apps_table", return_value="table-output")
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.get_client")
+def test_set_rev_with_team_from_toml(
+    mock_get_client,
+    mock_get_app_data_from_toml,
+    mock_apps_table,
+):
+    mock_connection = MagicMock()
+    mock_connection.create_alias.return_value = MagicMock()
+    mock_get_client.return_value.connect.return_value.__enter__.return_value = (
+        mock_connection
+    )
+
+    args = parse_args(["apps", "set-rev", "team-app", "app-rev"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _set_rev(args)
+
+    mock_get_client.assert_called_once_with("my-host", "internal")
+
+
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.cli.apps.get_client")
+def test_delete_with_team_from_toml(mock_get_client, mock_get_app_data_from_toml):
+    mock_connection = MagicMock()
+    mock_connection.delete_alias.return_value = "deleted"
+    mock_get_client.return_value.connect.return_value.__enter__.return_value = (
+        mock_connection
+    )
+
+    args = parse_args(["apps", "delete", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _delete(args)
+
+    mock_get_client.assert_called_once_with("my-host", "internal")
 
 
 def test_rollout():

--- a/projects/fal/tests/unit/cli/test_queue.py
+++ b/projects/fal/tests/unit/cli/test_queue.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fal.cli._utils import AppData
+from fal.cli.main import parse_args
+from fal.cli.queue import _queue_flush, _queue_size
+
+
+def test_queue_size_parser():
+    args = parse_args(["queue", "size", "team-app"])
+
+    assert args.func == _queue_size
+    assert args.app_name == "team-app"
+
+
+def test_queue_flush_parser():
+    args = parse_args(["queue", "flush", "team-app"])
+
+    assert args.func == _queue_flush
+    assert args.app_name == "team-app"
+
+
+def _mock_rest_client():
+    rest_client = MagicMock()
+    rest_client.base_url = "https://api.example"
+    rest_client.get_headers.return_value = {"authorization": "Bearer token"}
+    return rest_client
+
+
+@patch("fal.cli.queue.httpx.Client")
+@patch("fal.api.deploy._get_user", return_value=SimpleNamespace(username="owner"))
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.api.client.SyncServerlessClient")
+def test_queue_size_with_team_from_toml(
+    mock_client_cls,
+    mock_get_app_data_from_toml,
+    mock_get_user,
+    mock_httpx_client,
+):
+    rest_client = _mock_rest_client()
+    mock_client_cls.return_value._create_rest_client.return_value = rest_client
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {"size": 3}
+    mock_httpx_client.return_value.__enter__.return_value.get.return_value = (
+        mock_response
+    )
+
+    args = parse_args(["queue", "size", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _queue_size(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")
+
+
+@patch("fal.cli.queue.httpx.Client")
+@patch("fal.api.deploy._get_user", return_value=SimpleNamespace(username="owner"))
+@patch("fal.cli._utils.get_app_data_from_toml", return_value=AppData(team="internal"))
+@patch("fal.api.client.SyncServerlessClient")
+def test_queue_flush_with_team_from_toml(
+    mock_client_cls,
+    mock_get_app_data_from_toml,
+    mock_get_user,
+    mock_httpx_client,
+):
+    rest_client = _mock_rest_client()
+    mock_client_cls.return_value._create_rest_client.return_value = rest_client
+    mock_response = MagicMock(status_code=200)
+    mock_httpx_client.return_value.__enter__.return_value.delete.return_value = (
+        mock_response
+    )
+
+    args = parse_args(["queue", "flush", "team-app"])
+    args.host = "my-host"
+    args.console = MagicMock()
+    _queue_flush(args)
+
+    mock_client_cls.assert_called_once_with(host="my-host", team="internal")


### PR DESCRIPTION
## Summary
- add a shared CLI resolver for TOML app team config
- apply it to app-name commands under `fal apps` and `fal queue`
- add unit coverage for TOML team resolution and CLI `--team` precedence

## Why
`fal apps scale` and several adjacent app-name commands built clients directly from `args.team`, so aliases configured with `team` in `pyproject.toml` could resolve under the personal account instead of the intended team.