### PR TITLE
feat(fal): support health check method

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.26.9,<0.27.0",
-    "isolate-proto>=0.33.0,<1",
+    "isolate-proto>=0.34.0,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle>=3.0.0,<3.2",

--- a/projects/fal/src/fal/app.py
+++ b/projects/fal/src/fal/app.py
@@ -779,6 +779,7 @@ class App(BaseServable):
             timeout_seconds=health_check.timeout_seconds,
             failure_threshold=health_check.failure_threshold,
             call_regularly=health_check.call_regularly,
+            method=health_check.method or "POST",
         )
 
     def collect_routes(self) -> dict[RouteSignature, Callable[..., Any]]:

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Optional, get_args
 
@@ -269,6 +269,13 @@ def get_app_data_from_toml(
         )
         options.environment["kind"] = "container"
         options.environment["image"] = image
+        if (
+            image_uses_isolate is False
+            and health_check_config
+            and not health_check_config.method
+        ):
+            health_check_config = replace(health_check_config, method="GET")
+            options.host["health_check_config"] = health_check_config
 
     pyproject_dir = Path(toml_path).parent.resolve()
     resolved_requirements_context_dir = pyproject_dir
@@ -393,6 +400,7 @@ def _build_health_check_config_from_toml(
     timeout_seconds = health_check_data.pop("timeout_seconds", None)
     failure_threshold = health_check_data.pop("failure_threshold", None)
     call_regularly = health_check_data.pop("call_regularly", None)
+    method = health_check_data.pop("method", None)
 
     if start_period_seconds is not None:
         _validate_int("health_check.start_period_seconds", start_period_seconds)
@@ -414,6 +422,7 @@ def _build_health_check_config_from_toml(
         timeout_seconds=timeout_seconds,
         failure_threshold=failure_threshold,
         call_regularly=call_regularly,
+        method=method,
     )
 
 

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -744,6 +744,7 @@ class HealthCheck:
     timeout_seconds: Optional[int] = None
     failure_threshold: Optional[int] = None
     call_regularly: Optional[bool] = None
+    method: Optional[str] = None
 
     def __init__(
         self,
@@ -752,10 +753,12 @@ class HealthCheck:
         timeout_seconds: Optional[int] = None,
         failure_threshold: Optional[int] = None,
         call_regularly: Optional[bool] = None,
+        method: Optional[str] = None,
     ):
         """Health check configuration for a runner.
 
         Args:
+            method: HTTP method to use for the health check request.
             start_period_seconds: Minimum time the runner has been running \
             before considering the runner unhealthy when health check fails. \
             To prevent the health check from failing too early, \
@@ -783,10 +786,12 @@ class HealthCheck:
         self.timeout_seconds = timeout_seconds
         self.failure_threshold = failure_threshold
         self.call_regularly = call_regularly
+        self.method = method
 
     def __hash__(self):
         return hash(
             (
+                self.method,
                 self.start_period_seconds,
                 self.timeout_seconds,
                 self.failure_threshold,
@@ -802,6 +807,17 @@ class ApplicationHealthCheckConfig:
     timeout_seconds: Optional[int]
     failure_threshold: Optional[int]
     call_regularly: Optional[bool]
+    method: Optional[str] = None
+
+    def to_proto(self) -> isolate_proto.ApplicationHealthCheckConfig:
+        return isolate_proto.ApplicationHealthCheckConfig(
+            path=self.path,
+            start_period_seconds=self.start_period_seconds,
+            timeout_seconds=self.timeout_seconds,
+            failure_threshold=self.failure_threshold,
+            call_regularly=self.call_regularly,
+            method=self.method.upper() if self.method else None,
+        )
 
 
 @dataclass
@@ -995,16 +1011,9 @@ class FalServerlessConnection:
             deployment_strategy.upper()
         ].to_proto()
 
-        if health_check_config:
-            wrapped_health_check_config = isolate_proto.ApplicationHealthCheckConfig(
-                path=health_check_config.path,
-                start_period_seconds=health_check_config.start_period_seconds,
-                timeout_seconds=health_check_config.timeout_seconds,
-                failure_threshold=health_check_config.failure_threshold,
-                call_regularly=health_check_config.call_regularly,
-            )
-        else:
-            wrapped_health_check_config = None
+        wrapped_health_check_config = (
+            health_check_config.to_proto() if health_check_config else None
+        )
 
         if skip_retry_conditions:
             wrapped_skip_retry_conditions = [

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -243,6 +243,7 @@ def mock_parse_pyproject_toml():
                 "data_mounts": ["/data", "/data/.cache"],
                 "health_check": {
                     "path": "/health",
+                    "method": "get",
                     "start_period_seconds": 30,
                     "timeout_seconds": 5,
                     "failure_threshold": 3,
@@ -1220,6 +1221,7 @@ def test_get_app_data_from_toml_with_advanced_runtime_options(
             timeout_seconds=5,
             failure_threshold=3,
             call_regularly=True,
+            method="get",
         ),
     }
 
@@ -1581,6 +1583,7 @@ def test_get_app_data_from_toml_with_image_without_ref(
                 "auth": "public",
                 "machine_type": "GPU-H100",
                 "image": {"dockerfile": "Dockerfile"},
+                "health_check": {"path": "/health/ready"},
             }
         }
     }
@@ -1591,6 +1594,16 @@ def test_get_app_data_from_toml_with_image_without_ref(
     assert toml_data.python_entry_point is None
     assert toml_data.auth == "public"
     assert toml_data.options.host["machine_type"] == "GPU-H100"
+    assert toml_data.options.host[
+        "health_check_config"
+    ] == ApplicationHealthCheckConfig(
+        path="/health/ready",
+        start_period_seconds=None,
+        timeout_seconds=None,
+        failure_threshold=None,
+        call_regularly=None,
+        method="GET",
+    )
     assert toml_data.options.environment["kind"] == "container"
     assert toml_data.options.environment["image"]["dockerfile_str"] == dockerfile
     assert toml_data.options.environment["image"]["use_isolate"] is False
@@ -1610,6 +1623,7 @@ def test_get_app_data_from_toml_with_image_reference_without_ref(
                 "auth": "public",
                 "machine_type": "GPU-H100",
                 "image": {"image": "ghcr.io/fal-ai/container-app:latest"},
+                "health_check": {"path": "/health/ready"},
             }
         }
     }
@@ -1620,6 +1634,16 @@ def test_get_app_data_from_toml_with_image_reference_without_ref(
     assert toml_data.python_entry_point is None
     assert toml_data.auth == "public"
     assert toml_data.options.host["machine_type"] == "GPU-H100"
+    assert toml_data.options.host[
+        "health_check_config"
+    ] == ApplicationHealthCheckConfig(
+        path="/health/ready",
+        start_period_seconds=None,
+        timeout_seconds=None,
+        failure_threshold=None,
+        call_regularly=None,
+        method="GET",
+    )
     assert toml_data.options.environment["kind"] == "container"
     assert (
         toml_data.options.environment["image"]["image"]

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -106,6 +106,19 @@ def test_app_metrics_port_propagates_to_function_options():
     assert fn.options.host.get("metrics_port") == 9091
 
 
+def test_app_health_check_defaults_method_to_post():
+    from fal.app import wrap_app
+
+    class HealthCheckApp(App):
+        @endpoint("/", health_check=fal.HealthCheck())
+        def hello(self) -> str:
+            return "Hello, world!"
+
+    fn = wrap_app(HealthCheckApp)
+
+    assert fn.options.host["health_check_config"].method == "POST"
+
+
 def test_machine_requirements_preserves_positional_field_order():
     from dataclasses import fields
 

--- a/projects/fal/tests/unit/test_sdk.py
+++ b/projects/fal/tests/unit/test_sdk.py
@@ -3,10 +3,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fal.sdk import (
+    ApplicationHealthCheckConfig,
     FalServerlessConnection,
     FalServerlessKeyCredentials,
     RetryConfig,
     get_credentials,
+    isolate_proto,
     validate_retry_config_dict,
 )
 
@@ -141,6 +143,124 @@ def test_connection_register_forwards_container_image_reference():
     )
     assert image["image"].string_value == "ghcr.io/fal-ai/container-app:latest"
     assert image["use_isolate"].bool_value is False
+
+
+def test_connection_register_forwards_health_check_method():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+            health_check_config=ApplicationHealthCheckConfig(
+                path="/health/ready",
+                start_period_seconds=30,
+                timeout_seconds=5,
+                failure_threshold=3,
+                call_regularly=True,
+                method="get",
+            ),
+        )
+    )
+
+    assert stub.register_request is not None
+    health_check_config = stub.register_request.health_check_config
+    assert health_check_config.path == "/health/ready"
+    assert health_check_config.method == isolate_proto.ApplicationHealthCheckConfig.GET
+
+
+def test_connection_register_preserves_explicit_pure_docker_health_check_method():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    list(
+        connection.register(
+            None,
+            [environment],
+            application_name="container-app",
+            deployment_strategy="rolling",
+            health_check_config=ApplicationHealthCheckConfig(
+                path="/health/ready",
+                start_period_seconds=30,
+                timeout_seconds=5,
+                failure_threshold=3,
+                call_regularly=True,
+                method="POST",
+            ),
+        )
+    )
+
+    assert stub.register_request is not None
+    health_check_config = stub.register_request.health_check_config
+    assert health_check_config.method == isolate_proto.ApplicationHealthCheckConfig.POST
+
+
+def test_connection_register_leaves_isolate_health_check_method_unset():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment("virtualenv")
+
+    list(
+        connection.register(
+            lambda: None,
+            [environment],
+            application_name="function-app",
+            deployment_strategy="rolling",
+            health_check_config=ApplicationHealthCheckConfig(
+                path="/health/ready",
+                start_period_seconds=30,
+                timeout_seconds=5,
+                failure_threshold=3,
+                call_regularly=True,
+            ),
+        )
+    )
+
+    assert stub.register_request is not None
+    health_check_config = stub.register_request.health_check_config
+    assert not health_check_config.HasField("method")
+
+
+def test_connection_register_rejects_invalid_health_check_method():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment(
+        "container",
+        image={"dockerfile_str": "FROM debian:bookworm-slim", "use_isolate": False},
+    )
+
+    with pytest.raises(ValueError, match='unknown enum label "TRACE"'):
+        list(
+            connection.register(
+                None,
+                [environment],
+                application_name="container-app",
+                deployment_strategy="rolling",
+                health_check_config=ApplicationHealthCheckConfig(
+                    path="/health/ready",
+                    start_period_seconds=30,
+                    timeout_seconds=5,
+                    failure_threshold=3,
+                    call_regularly=True,
+                    method="TRACE",
+                ),
+            )
+        )
 
 
 def test_connection_register_rejects_isolate_container_without_callable():

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -384,6 +384,7 @@ def test_load_function_from_applies_toml_host_options_over_app_defaults(tmp_path
         timeout_seconds=5,
         failure_threshold=3,
         call_regularly=True,
+        method="GET",
     )
     options = Options(
         host={
@@ -414,7 +415,9 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
         "    _scheduler_options={'storage_region': 'us-east'},\n"
         "):\n"
         "\n"
-        "    @fal.endpoint('/', health_check=fal.HealthCheck(timeout_seconds=9))\n"
+        "    @fal.endpoint(\n"
+        "        '/', health_check=fal.HealthCheck(timeout_seconds=9, method='GET')\n"
+        "    )\n"
         "    def run(self):\n"
         "        return {'ok': True}\n"
     )
@@ -432,6 +435,7 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
                 timeout_seconds=5,
                 failure_threshold=3,
                 call_regularly=True,
+                method="GET",
             ),
         }
     )
@@ -446,6 +450,7 @@ def test_load_function_from_preserves_explicit_app_host_options_over_toml(tmp_pa
     }
     assert health_check_config.path == "/"
     assert health_check_config.timeout_seconds == 9
+    assert health_check_config.method == "GET"
 
 
 def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
@@ -601,6 +606,23 @@ def test_isolated_function_endpoints_fallback_to_routes():
 def test_isolated_function_endpoints_default():
     iso = IsolatedFunction(host=DummyHost(), entrypoint="pkg:Sym")
     assert iso.endpoints == ["/"]
+
+
+def test_isolated_function_preserves_explicit_health_check_method():
+    health_check_config = ApplicationHealthCheckConfig(
+        path="/health/ready",
+        start_period_seconds=None,
+        timeout_seconds=None,
+        failure_threshold=None,
+        call_regularly=None,
+        method="GET",
+    )
+    options = Options(host={"health_check_config": health_check_config})
+
+    iso = IsolatedFunction(host=DummyHost(), raw_func=lambda: None, options=options)
+
+    assert iso.options.host["health_check_config"] is health_check_config
+    assert iso.options.host["health_check_config"].method == "GET"
 
 
 def test_isolated_function_fetch_metadata_no_op_without_entrypoint():


### PR DESCRIPTION
Adds health check HTTP method support to the fal SDK and pyproject app config.

Users can now set method on ApplicationHealthCheckConfig, fal.HealthCheck, or [tool.fal.apps.<name>.health_check]. TOML values are validated and normalized to uppercase, matching the Python API behavior.
