### PR TITLE
chore: add max_size param to read_image_from_url

### DIFF
--- a/projects/fal/src/fal/toolkit/image/__init__.py
+++ b/projects/fal/src/fal/toolkit/image/__init__.py
@@ -59,6 +59,7 @@ def read_image_from_url(
     url: str,
     convert_to_rgb: bool = True,
     fix_orientation: bool = True,
+    max_size: int = MAX_IMAGE_DOWNLOAD_SIZE,
 ):
     from fastapi import HTTPException
     from PIL import Image
@@ -66,15 +67,15 @@ def read_image_from_url(
     try:
         if urlparse(url).scheme == "data":
             with urlopen(url, timeout=30) as response:
-                content = response.read(MAX_IMAGE_DOWNLOAD_SIZE + 1)
-            if len(content) > MAX_IMAGE_DOWNLOAD_SIZE:
+                content = response.read(max_size + 1)
+            if len(content) > max_size:
                 raise ValueError("Image body exceeded size limit")
         else:
             response = ssrf_safe_get(
                 url,
                 headers=TEMP_HEADERS,
                 timeout=30,
-                max_size=MAX_IMAGE_DOWNLOAD_SIZE,
+                max_size=max_size,
             )
             content = response.content
         image_pil = Image.open(io.BytesIO(content))

--- a/projects/fal/tests/unit/toolkit/utils/test_ssrf.py
+++ b/projects/fal/tests/unit/toolkit/utils/test_ssrf.py
@@ -576,6 +576,23 @@ def test_read_image_from_url_applies_download_limit() -> None:
     assert exc_info.value.status_code == 422
 
 
+def test_read_image_from_url_respects_custom_max_size() -> None:
+    custom_max_size = 1024
+
+    def fake_get(url: str, **kwargs: Any) -> ssrf.SafeResponse:
+        assert kwargs["max_size"] == custom_max_size
+        raise ssrf.SSRFError("too large")
+
+    with patch.object(image_toolkit, "ssrf_safe_get", fake_get):
+        with pytest.raises(HTTPException) as exc_info:
+            read_image_from_url(
+                "https://attacker.example/custom-limit.png",
+                max_size=custom_max_size,
+            )
+
+    assert exc_info.value.status_code == 422
+
+
 def test_read_image_from_url_preserves_data_uri() -> None:
     image = read_image_from_url(
         "data:image/png;base64,"


### PR DESCRIPTION
The earlier change to read_image_from_url for ssrf safety was a breaking change in that there wasn't an explicit max limit prior to it. To somewhat allow the older behaviour, this PR simply allows passing a custom max_size.