### PR TITLE
fix(cli): add version update notification opt-out

### DIFF
--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -28,6 +28,8 @@ from . import (
 from .debug import debugtools, get_debug_parser
 from .parser import FalParser, FalParserExit
 
+_CHECK_UPDATES_CONFIG_KEY = "check_updates"
+
 
 def _get_main_parser() -> argparse.ArgumentParser:
     parents = [get_debug_parser()]
@@ -84,6 +86,15 @@ def _print_error(msg):
     console.print(f"{get_cross_icon(console)} {msg}")
 
 
+def _get_check_updates_config() -> bool:
+    from fal.config import Config
+
+    try:
+        return Config().get_global(_CHECK_UPDATES_CONFIG_KEY) is not False
+    except (OSError, ValueError):
+        return True
+
+
 def _check_latest_version():
     from packaging.version import parse
     from rich.panel import Panel
@@ -91,19 +102,22 @@ def _check_latest_version():
 
     from fal._version import get_latest_version, version_tuple
 
-    latest_version = get_latest_version()
-    parsed = parse(latest_version)
-    latest_version_tuple = (parsed.major, parsed.minor, parsed.micro)
-
     # If we have a dev version, we don't want to check for updates
     if len(version_tuple) >= 4:
         if "dev" in str(version_tuple[3]):
             return
 
-    if latest_version_tuple <= version_tuple:
+    if not console.is_terminal:
         return
 
-    if not console.is_terminal:
+    if not _get_check_updates_config():
+        return
+
+    latest_version = get_latest_version()
+    parsed = parse(latest_version)
+    latest_version_tuple = (parsed.major, parsed.minor, parsed.micro)
+
+    if latest_version_tuple <= version_tuple:
         return
 
     line1 = Text.assemble(

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -11,6 +11,7 @@ import fal.api.api as api_module
 from fal.api.api import UserFunctionException, _handle_grpc_error
 
 cli_main = importlib.import_module("fal.cli.main")
+fal_version = importlib.import_module("fal._version")
 
 
 def test_main_shows_synthetic_remote_exception_for_deserialization_error(
@@ -99,3 +100,22 @@ def test_remote_exception_deserialization_is_user_function_exception() -> None:
         assert exc.__cause__.__cause__ is None
     else:
         raise AssertionError("expected UserFunctionException")
+
+
+def test_update_check_can_be_disabled(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("check_updates = false\n")
+    monkeypatch.setenv("FAL_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("FAL_PROFILE", raising=False)
+
+    get_latest_version = MagicMock(return_value="99.0.0")
+    monkeypatch.setattr(fal_version, "get_latest_version", get_latest_version)
+    monkeypatch.setattr(fal_version, "version_tuple", (1, 0, 0))
+
+    test_console = SimpleNamespace(is_terminal=True, print=MagicMock())
+    monkeypatch.setattr(cli_main, "console", test_console)
+
+    cli_main._check_latest_version()
+
+    get_latest_version.assert_not_called()
+    test_console.print.assert_not_called()


### PR DESCRIPTION
Adds a persistent opt-out for the fal CLI version update notification.

Users can add the following top-level option to `~/.fal/config.toml` (or their `FAL_CONFIG_PATH` file):

```toml
check_updates = false
```

The CLI checks this setting before contacting PyPI. The existing notification cadence is unchanged.

This PR is stacked on [#1111](https://github.com/fal-ai/fal/pull/1111), which adds first-class top-level config options and protects profile commands from scalar-option collisions.

`pre-commit run --all-files` passes, along with the 5 focused CLI and config tests. A broader unit run reached 829 passed and 3 skipped; 12 existing `test_file_sync.py` setups failed because dummy credentials received HTTP 401.

Linear: [SERV-880](https://linear.app/features-and-labels/issue/SERV-880/add-opt-out-for-fal-version-update-message)
