### PR TITLE
refactor(config): support top-level options

### DIFF
--- a/projects/fal/src/fal/cli/profile.py
+++ b/projects/fal/src/fal/cli/profile.py
@@ -43,7 +43,14 @@ def _set(args):
     config = Config()
 
     # Check if the profile exists
-    if args.PROFILE not in config._config:
+    if args.PROFILE not in config.profiles():
+        if config.get_global(args.PROFILE) is not None:
+            args.console.print(
+                f"Global setting [cyan]{args.PROFILE}[/] cannot be used "
+                "as a profile name."
+            )
+            return
+
         # Profile doesn't exist, offer to create it
         args.console.print(f"Profile [cyan]{args.PROFILE}[/] does not exist.")
         create_profile = input("Would you like to create it? (y/N): ").strip().lower()
@@ -113,8 +120,14 @@ def _create(args):
     config = Config()
 
     # Check if the profile already exists
-    if args.PROFILE in config._config:
+    if args.PROFILE in config.profiles():
         args.console.print(f"Profile [cyan]{args.PROFILE}[/] already exists.")
+        return
+
+    if config.get_global(args.PROFILE) is not None:
+        args.console.print(
+            f"Global setting [cyan]{args.PROFILE}[/] cannot be used as a profile name."
+        )
         return
 
     # Create the profile
@@ -128,7 +141,12 @@ def _create(args):
 
 
 def _delete(args):
-    with Config().edit() as config:
+    config = Config()
+    if args.PROFILE not in config.profiles():
+        args.console.print(f"Profile [cyan]{args.PROFILE}[/] does not exist.")
+        return
+
+    with config.edit() as config:
         if config.profile == args.PROFILE:
             config.set_internal("profile", None)
 

--- a/projects/fal/src/fal/config.py
+++ b/projects/fal/src/fal/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 SETTINGS_SECTION = "__internal__"
 
@@ -12,7 +12,7 @@ NO_PROFILE_ERROR = ValueError(
 
 
 class Config:
-    _config: Dict[str, Dict[str, str]]
+    _config: Dict[str, Any]
     _profile: Optional[str]
     _editing: bool = False
 
@@ -55,7 +55,7 @@ class Config:
 
     @profile.setter
     def profile(self, value: Optional[str]) -> None:
-        if value and value not in self._config:
+        if value and value not in self.profiles():
             # Don't automatically create profiles - they should be created explicitly
             raise ValueError(
                 f"Profile '{value}' does not exist. Create it first or use the profile set command."  # noqa: E501
@@ -67,8 +67,8 @@ class Config:
 
     def profiles(self) -> List[str]:
         keys: List[str] = []
-        for key in self._config:
-            if key != SETTINGS_SECTION:
+        for key, value in self._config.items():
+            if key != SETTINGS_SECTION and isinstance(value, dict):
                 keys.append(key)
 
         return keys
@@ -103,6 +103,9 @@ class Config:
 
         return self._config[SETTINGS_SECTION].get(key)
 
+    def get_global(self, key: str) -> Optional[Any]:
+        return self._config.get(key)
+
     def set_internal(self, key: str, value: Optional[str]) -> None:
         if SETTINGS_SECTION not in self._config:
             self._config[SETTINGS_SECTION] = {}
@@ -116,6 +119,9 @@ class Config:
         self._config.get(SETTINGS_SECTION, {}).pop(key, None)
 
     def delete_profile(self, profile: str) -> None:
+        if profile not in self.profiles():
+            raise ValueError(f"Profile '{profile}' does not exist.")
+
         del self._config[profile]
 
     @contextmanager

--- a/projects/fal/tests/unit/cli/test_profile.py
+++ b/projects/fal/tests/unit/cli/test_profile.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import fal.cli.profile as profile
+
+
+def test_profile_commands_do_not_treat_global_options_as_profiles(
+    monkeypatch, tmp_path
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("check_updates = false\n")
+    monkeypatch.setenv("FAL_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("FAL_PROFILE", raising=False)
+
+    args = SimpleNamespace(PROFILE="check_updates", console=MagicMock())
+
+    profile._set(args)
+    profile._create(args)
+    profile._delete(args)
+
+    assert config_path.read_text() == "check_updates = false\n"
+    assert args.console.print.call_count == 3

--- a/projects/fal/tests/unit/test_config.py
+++ b/projects/fal/tests/unit/test_config.py
@@ -1,0 +1,18 @@
+from fal.config import Config
+
+
+def test_global_config_is_separate_from_profiles(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("check_updates = false\n\n[default]\n")
+    monkeypatch.setenv("FAL_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("FAL_PROFILE", raising=False)
+
+    config = Config()
+
+    assert config.get_global("check_updates") is False
+    assert config.profiles() == ["default"]
+
+    config.save()
+    reloaded_config = Config()
+    assert reloaded_config.get_global("check_updates") is False
+    assert reloaded_config.profiles() == ["default"]


### PR DESCRIPTION
Separates top-level scalar options from profile tables when loading `~/.fal/config.toml`.

This gives callers a typed `get_global()` path without widening the existing profile configuration to `Any`. Profile commands now distinguish scalar global options from profile dictionaries, so a global option cannot be overwritten or deleted as a profile. Saving the config preserves both globals and profiles.

This is a prerequisite for [SERV-880](https://linear.app/features-and-labels/issue/SERV-880/add-opt-out-for-fal-version-update-message), which uses a public top-level `check_updates` option.

Covered by focused config and profile-command tests. `pre-commit run --all-files` and all 3 prerequisite tests pass.
