### PR TITLE
feat: support Namespace container builder

### DIFF
--- a/projects/fal/src/fal/container.py
+++ b/projects/fal/src/fal/container.py
@@ -7,9 +7,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
 
-Builder = Literal["depot", "service", "worker"]
+Builder = Literal["depot", "namespace", "service", "worker"]
 CommandOverride = Union[str, List[str]]
-BUILDERS = {"depot", "service", "worker"}
+BUILDERS = {"depot", "namespace", "service", "worker"}
 DEFAULT_COMPRESSION: str = "gzip"
 DEFAULT_FORCE_COMPRESSION: bool = False
 
@@ -103,9 +103,10 @@ class ContainerImage:
                 "\033[1;33mWarning:\033[0m " if sys.stderr.isatty() else "Warning: "
             )
             print(
-                f"{prefix}builder='{self.builder}' is deprecated and has "
-                "been removed. All builds now use Depot. You can safely "
-                "remove the builder parameter or set builder='depot'.",
+                f"{prefix}builder='{self.builder}' is deprecated and no longer "
+                "selects that backend. Remove the builder parameter to use the "
+                "platform default, or explicitly set builder='depot' or "
+                "builder='namespace'.",
                 file=sys.stderr,
             )
 

--- a/projects/fal/tests/unit/test_container.py
+++ b/projects/fal/tests/unit/test_container.py
@@ -443,11 +443,30 @@ class TestContainerImageValidation:
         with pytest.raises(ValueError, match="Invalid builder"):
             ContainerImage(dockerfile_str="FROM python:3.11", builder="invalid")  # type: ignore
 
-    def test_valid_builders_accepted(self):
+    @pytest.mark.parametrize("builder", ["depot", "namespace", "service", "worker"])
+    def test_valid_builders_accepted(self, builder):
         """Valid builders should be accepted."""
-        for builder in ["depot", "service", "worker"]:
-            img = ContainerImage(dockerfile_str="FROM python:3.11", builder=builder)  # type: ignore
-            assert img.builder == builder
+        img = ContainerImage(dockerfile_str="FROM python:3.11", builder=builder)
+        assert img.builder == builder
+
+    def test_namespace_builder_is_serialized(self):
+        """Namespace should be preserved in the image sent to the server."""
+        img = ContainerImage(
+            dockerfile_str="FROM python:3.11",
+            builder="namespace",
+        )
+
+        assert img.to_dict()["builder"] == "namespace"
+
+    @pytest.mark.parametrize("builder", ["service", "worker"])
+    def test_legacy_builder_warning_uses_platform_default(self, builder, capsys):
+        """Legacy builder warnings should not claim every build uses Depot."""
+        ContainerImage(dockerfile_str="FROM python:3.11", builder=builder)
+
+        warning = capsys.readouterr().err
+        assert f"builder='{builder}' is deprecated" in warning
+        assert "use the platform default" in warning
+        assert "All builds now use Depot" not in warning
 
     def test_registry_missing_username_raises_valueerror(self):
         """Registry without username should raise ValueError."""


### PR DESCRIPTION
## What changed

- allow `ContainerImage(..., builder="namespace")` in the public type and runtime validation
- preserve `namespace` when serializing the image configuration sent to the controller
- update deprecated `service`/`worker` warnings to point to the platform default or an explicit supported builder
- add focused acceptance, serialization, and warning regression tests

## Why

SERV-187, customer-choice decision (2026-07-16): customers select the builder with an explicit pin. The controller side (fal-ai/isolate-cloud#8444) resolves `builder="namespace"`/`"depot"` pins before any server config; this PR is the client-side half that stops the SDK from rejecting the value. Without it, no customer can pin.

## CI triage

The failing `e2e (ubuntu, py3.9/3.10/3.12/3.13/3.14)` jobs all fail on `tests/e2e/test_apps.py::test_rollout_application` (`assert not runner_ids_after.intersection(runner_ids_final)`), a runner-lifecycle assertion unrelated to this diff (two files: the `Builder` literal + unit tests). The same test is red on `main`'s nightly e2e for three consecutive days (Jul 13-15), i.e. a pre-existing environment/rollout issue, not introduced here. Unit + integration + container checks are green.
