### PR TITLE
fix(file_sync): prune ignored paths before symlink validation

### DIFF
--- a/projects/fal/src/fal/file_sync.py
+++ b/projects/fal/src/fal/file_sync.py
@@ -93,8 +93,10 @@ def sanitize_relative_path(rel_path: str, original_path: Path) -> str:
         raise FalServerlessException(
             "Parent directory reference is not allowed: "
             + f"{rel_path} for {original_path}\n"
-            + "If you didn't mean to sync this file, please ignore it using "
-            + "`app_files_ignore`."
+            + "This usually means a symlink resolves outside the build context. "
+            + "To skip it, add the path to your ignore patterns: `app_files_ignore` "
+            + "for app files, or `.dockerignore`/`dockerignore=[...]` for container "
+            + "builds."
         )
 
     return pure_path.as_posix()
@@ -115,10 +117,9 @@ def compute_hash(file_path: Path, mode: int) -> str:
     return file_hash.hexdigest()
 
 
-def normalize_path(
-    path_str: str, base_path_str: str, files_context_dir: Optional[str] = None
-) -> Tuple[str, str]:
-    path = Path(path_str)
+def _get_script_dir(
+    base_path_str: str, files_context_dir: Optional[str] = None
+) -> Path:
     base_path = Path(base_path_str).resolve()
 
     if base_path.is_dir():
@@ -133,17 +134,60 @@ def normalize_path(
         else:
             script_dir = (script_dir / context_path).resolve()
 
+    return script_dir
+
+
+def normalize_path(
+    path_str: str, base_path_str: str, files_context_dir: Optional[str] = None
+) -> Tuple[str, str]:
+    context_dir = _get_script_dir(base_path_str, files_context_dir)
+    return _normalize_path(path_str, context_dir)
+
+
+def _normalize_path(path_str: str, context_dir: Path) -> Tuple[str, str]:
+    path = Path(path_str)
+
     absolute_path = (
-        path.resolve() if path.is_absolute() else (script_dir / path).resolve()
+        path.resolve() if path.is_absolute() else (context_dir / path).resolve()
     )
 
     try:
-        relative_path = os.path.relpath(absolute_path, script_dir)
+        relative_path = os.path.relpath(absolute_path, context_dir)
         relative_path = sanitize_relative_path(relative_path, path)
     except ValueError:
         raise ValueError(f"Invalid relative path: {absolute_path}")
 
     return absolute_path.as_posix(), relative_path
+
+
+def _lexical_path(path_str: str, context_dir: Path) -> Tuple[Path, str]:
+    path = Path(path_str)
+    lexical_path = path if path.is_absolute() else context_dir / path
+
+    try:
+        relative_path = os.path.relpath(lexical_path, context_dir)
+    except ValueError:
+        raise ValueError(f"Invalid relative path: {lexical_path}")
+
+    return lexical_path, Path(relative_path).as_posix()
+
+
+def _has_symlink(path: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts:
+        if part == path.anchor:
+            continue
+        current /= part
+        if current.is_symlink():
+            return True
+
+    return False
+
+
+def _join_relative_path(prefix: str, path: str) -> str:
+    if prefix in ("", "."):
+        return path
+    return f"{prefix.rstrip('/')}/{path}"
 
 
 @dataclass
@@ -222,37 +266,91 @@ class FileSync:
             raise FalServerlessException(detail)
         return response
 
-    def collect_files(self, paths: List[str], files_context_dir: Optional[str] = None):
+    def _should_ignore_explicit_path(
+        self, path: Path, relative_path: str, patterns: List[re.Pattern]
+    ) -> bool:
+        has_symlink = _has_symlink(path)
+        if has_symlink:
+            if self._matches_patterns(relative_path, patterns):
+                return True
+            try:
+                is_file = path.is_file()
+            except OSError:
+                is_file = False
+            return not is_file and self._matches_patterns(
+                f"{relative_path.rstrip('/')}/", patterns
+            )
+        return not path.is_dir() and self._matches_patterns(relative_path, patterns)
+
+    def _collect_directory(
+        self,
+        root: Path,
+        lexical_root: str,
+        context_dir: Path,
+        patterns: List[re.Pattern],
+    ) -> List[FileMetadata]:
+        files: List[FileMetadata] = []
+
+        for current, _, filenames in os.walk(root, followlinks=False):
+            current_path = Path(current)
+            for filename in filenames:
+                file_path = current_path / filename
+                relative = _join_relative_path(
+                    lexical_root, file_path.relative_to(root).as_posix()
+                )
+                if self._matches_patterns(relative, patterns):
+                    if flags.DEBUG:
+                        console.print(f"Ignoring file: {relative}")
+                    continue
+                if not file_path.is_file():
+                    continue
+
+                absolute, resolved_relative = _normalize_path(
+                    str(file_path), context_dir
+                )
+                files.append(
+                    FileMetadata.from_path(
+                        Path(absolute), relative=resolved_relative, absolute=absolute
+                    )
+                )
+
+        return files
+
+    def collect_files(
+        self,
+        paths: List[str],
+        files_context_dir: Optional[str] = None,
+        files_ignore: Optional[List[re.Pattern]] = None,
+    ) -> List[FileMetadata]:
         collected_files: List[FileMetadata] = []
+        context_dir = _get_script_dir(self.local_file_path, files_context_dir)
+        patterns = files_ignore or []
 
         for path in paths:
-            abs_path_str, rel_path = normalize_path(
-                path, self.local_file_path, files_context_dir
-            )
-            abs_path = Path(abs_path_str)
-            if not abs_path.exists():
-                console.print(f"{abs_path} was not found, it will be skipped")
+            lexical_path, lexical_relative = _lexical_path(path, context_dir)
+            if patterns and self._should_ignore_explicit_path(
+                lexical_path, lexical_relative, patterns
+            ):
+                if flags.DEBUG:
+                    console.print(f"Ignoring path: {lexical_relative}")
                 continue
 
-            if abs_path.is_file():
-                metadata = FileMetadata.from_path(
-                    abs_path, relative=rel_path, absolute=abs_path_str
+            absolute, relative = _normalize_path(path, context_dir)
+            resolved_path = Path(absolute)
+            if not resolved_path.exists():
+                console.print(f"{resolved_path} was not found, it will be skipped")
+            elif resolved_path.is_file():
+                collected_files.append(
+                    FileMetadata.from_path(
+                        resolved_path, relative=relative, absolute=absolute
+                    )
                 )
-                collected_files.append(metadata)
-
-            elif abs_path.is_dir():
-                # Recursively walk directory tree
-                for file_path in abs_path.rglob("*"):
-                    if file_path.is_file():
-                        file_abs_str, file_rel_path = normalize_path(
-                            str(file_path), self.local_file_path, files_context_dir
-                        )
-                        metadata = FileMetadata.from_path(
-                            Path(file_abs_str),
-                            relative=file_rel_path,
-                            absolute=file_abs_str,
-                        )
-                        collected_files.append(metadata)
+            elif resolved_path.is_dir():
+                collected_files.extend(
+                    self._collect_directory(
+                        resolved_path, lexical_relative, context_dir, patterns
+                    )
+                )
 
         return collected_files
 
@@ -299,7 +397,7 @@ class FileSync:
         files_ignore: List[re.Pattern] = [],
         files_context_dir: Optional[str] = None,
     ) -> Tuple[List[FileMetadata], List[AppFileUploadException]]:
-        files = self.collect_files(paths, files_context_dir)
+        files = self.collect_files(paths, files_context_dir, files_ignore=files_ignore)
 
         # Filter out ignored files
         if files_ignore:

--- a/projects/fal/tests/unit/test_file_sync.py
+++ b/projects/fal/tests/unit/test_file_sync.py
@@ -1,3 +1,4 @@
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -24,6 +25,30 @@ def file_sync(temp_dir, monkeypatch):
     monkeypatch.setenv("FAL_HOST", "api.localhost")
     monkeypatch.setenv("ISOLATE_TEST_MODE", "1")
     return FileSync(local_file_path=str(Path(temp_dir) / "app.py"))
+
+
+@pytest.fixture
+def collection_context(tmp_path):
+    context = tmp_path / "ctx"
+    context.mkdir()
+    (context / "app.py").write_text("# app")
+    fs = FileSync.__new__(FileSync)
+    fs.local_file_path = str(context / "app.py")
+    return fs, context
+
+
+@pytest.fixture
+def escaping_symlink_context(collection_context):
+    fs, context = collection_context
+    outside = context.parent / "outside"
+    (outside / "bin").mkdir(parents=True)
+    (outside / "python3.12").write_text("binary")
+
+    venv_bin = context / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    os.symlink(outside / "python3.12", venv_bin / "python3")
+    os.symlink(outside, context / ".venv-link", target_is_directory=True)
+    return fs, context
 
 
 def test_file_sync_init(temp_dir):
@@ -204,6 +229,193 @@ def test_collect_files_handles_nonexistent_gracefully(temp_dir):
     files = fs.collect_files(["nonexistent.txt", "missing_dir/"])
 
     assert len(files) == 0
+
+
+def test_collect_files_prunes_ignored_symlink_before_validation(
+    escaping_symlink_context,
+):
+    from fal.exceptions import FalServerlessException
+
+    fs, context = escaping_symlink_context
+
+    with pytest.raises(FalServerlessException, match="Parent directory reference"):
+        fs.collect_files(["."], files_context_dir=str(context))
+
+    files = fs.collect_files(
+        ["."],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"\.venv/")],
+    )
+    rel_paths = [f.relative_path for f in files]
+    assert "app.py" in rel_paths
+    assert not any(p.startswith(".venv/") for p in rel_paths)
+
+
+@pytest.mark.parametrize(
+    ("path", "pattern"),
+    [
+        (".venv/bin/python3", r"\.venv/"),
+        (".venv-link", r"\.venv-link/"),
+        (".venv-link", r"^\.venv-link$"),
+        (".venv-link/bin", r"\.venv-link/"),
+    ],
+)
+def test_collect_files_ignores_explicit_symlink_path(
+    escaping_symlink_context, path, pattern
+):
+    fs, context = escaping_symlink_context
+    files = fs.collect_files(
+        [path],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(pattern)],
+    )
+    assert files == []
+
+
+def test_collect_files_matches_lexical_prefix_for_symlinked_dir(collection_context):
+    fs, context = collection_context
+    target = context / "target"
+    (target / "bin").mkdir(parents=True)
+    (target / "bin" / "tool").write_text("tool")
+    os.symlink("target", context / "link", target_is_directory=True)
+
+    files = fs.collect_files(
+        ["link"],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"^link/bin/")],
+    )
+    assert files == []
+
+
+def test_collect_files_skips_unreadable_directory(collection_context, monkeypatch):
+    fs, context = collection_context
+    unreadable = context / "private"
+    unreadable.mkdir()
+    real_scandir = os.scandir
+
+    def guarded_scandir(path):
+        if Path(path) == unreadable:
+            raise PermissionError(path)
+        return real_scandir(path)
+
+    monkeypatch.setattr(file_sync_mod.os, "scandir", guarded_scandir)
+
+    files = fs.collect_files(["."], files_context_dir=str(context))
+
+    assert [file.relative_path for file in files] == ["app.py"]
+
+
+def test_collect_files_prunes_ignored_cyclic_symlink(collection_context):
+    fs, context = collection_context
+    os.symlink("loop", context / "loop", target_is_directory=True)
+
+    files = fs.collect_files(
+        ["loop"],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"^loop/")],
+    )
+
+    assert files == []
+
+
+def test_collect_files_skips_nested_cyclic_symlink(collection_context):
+    fs, context = collection_context
+    os.symlink("loop", context / "loop", target_is_directory=True)
+
+    files = fs.collect_files(
+        ["."],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"^loop/$")],
+    )
+
+    assert [file.relative_path for file in files] == ["app.py"]
+
+
+def test_collect_files_does_not_apply_directory_pattern_to_symlinked_file(
+    collection_context,
+):
+    fs, context = collection_context
+    target = context / "target"
+    target.write_text("content")
+    os.symlink(target, context / "asset")
+
+    files = fs.collect_files(
+        ["asset"],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"^asset/$")],
+    )
+
+    assert [file.relative_path for file in files] == ["target"]
+
+
+def test_collect_files_matches_symlink_ignore_before_target_inspection(
+    collection_context, monkeypatch
+):
+    fs, context = collection_context
+    target = context / "target"
+    target.write_text("content")
+    alias = context / "alias"
+    os.symlink(target, alias)
+
+    real_is_dir = Path.is_dir
+
+    def guarded_is_dir(path):
+        if path == alias:
+            raise PermissionError(path)
+        return real_is_dir(path)
+
+    monkeypatch.setattr(Path, "is_dir", guarded_is_dir)
+
+    files = fs.collect_files(
+        ["alias"],
+        files_context_dir=str(context),
+        files_ignore=[re.compile(r"^alias$")],
+    )
+
+    assert files == []
+
+
+def test_collect_files_skips_dangling_symlink(collection_context):
+    fs, context = collection_context
+    os.symlink("missing-target", context / "broken")
+
+    files = fs.collect_files(["."], files_context_dir=str(context))
+
+    assert [f.relative_path for f in files] == ["app.py"]
+
+
+@pytest.mark.parametrize("pattern", [r"^src$", r"^src/$"])
+@pytest.mark.parametrize("paths", [["."], ["src"]])
+def test_collect_files_keeps_directory_contents_for_exact_directory_pattern(
+    collection_context, pattern, paths
+):
+    fs, context = collection_context
+    source = context / "src"
+    source.mkdir()
+    (source / "main.py").write_text("# main")
+
+    files = fs.collect_files(
+        paths,
+        files_context_dir=str(context),
+        files_ignore=[re.compile(pattern)],
+    )
+
+    assert "src/main.py" in [file.relative_path for file in files]
+
+
+def test_collect_files_skips_symlinked_directory(collection_context):
+    fs, context = collection_context
+    nested = context / "nested"
+    nested.mkdir()
+    (nested / "deep.txt").write_text("deep")
+    os.symlink(nested, context / "linkdir", target_is_directory=True)
+
+    files = fs.collect_files(["."], files_context_dir=str(context))
+    rel_paths = sorted(f.relative_path for f in files)
+    assert "app.py" in rel_paths
+    assert "nested/deep.txt" in rel_paths
+    assert "linkdir" not in rel_paths
+    assert "linkdir/deep.txt" not in rel_paths
 
 
 def test_should_ignore_file_basic_patterns(file_sync):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which local files are collected and uploaded (symlinks, ignores, walk semantics); wrong behavior could omit needed files or still leak paths, but scope is client-side sync with broad new tests.
> 
> **Overview**
> **File sync** now applies `files_ignore` / `app_files_ignore` while collecting paths, **before** resolving symlinks and running parent-directory checks, so ignored trees like `.venv/` no longer trigger failures when they symlink outside the build context.
> 
> Collection is refactored: context dir comes from `_get_script_dir`, lexical paths drive ignore matching (`_lexical_path`, `_has_symlink`, `_should_ignore_explicit_path`), and directory walks use `os.walk(..., followlinks=False)` via `_collect_directory` instead of following symlinked dirs with `rglob`. `sync_files` passes ignore patterns into `collect_files` as well as the existing post-filter.
> 
> The **parent directory reference** error text now calls out escaping symlinks and documents `app_files_ignore` vs `.dockerignore` / `dockerignore`.
> 
> Unit tests cover escaping/cyclic/dangling symlinks, explicit ignore paths, unreadable dirs, and exact-directory ignore patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7112525d037ea183b1df1c729e343a975d8c815f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->