### PR TITLE
nudge users to fal run before fal deploy (SERV-1403)

### DIFF
--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -66,12 +66,12 @@ def _deploy(args):
             environment_name=args.env,
         )
         app_name = prepared.loaded.app_name
-        run_hint = run_command_hint(app_ref, app_name)
+        run_hint = run_command_hint(app_ref, app_name, args.env)
         is_first_deploy = bool(app_name) and is_first_deployment(
             client, app_name, args.env
         )
         if is_first_deploy and app_name:
-            print_first_deploy_nudge(args.console, app_name, run_hint)
+            print_first_deploy_nudge(args.console, app_name, run_hint, args.env)
         args.console.print(
             f"Deploying '{prepared.display_name}' as app '{prepared.loaded.app_name}'",
             style="bold",

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -5,7 +5,14 @@ import json
 
 from fal.api.client import SyncServerlessClient
 
-from .deploy_check import _resolve_deploy_check_source, deploy_with_check
+from .deploy_check import (
+    _resolve_deploy_check_source,
+    deploy_with_check,
+    is_first_deployment,
+    print_deploy_failure_nudge,
+    print_first_deploy_nudge,
+    run_command_hint,
+)
 from .parser import FalClientParser, RefAction, add_env_argument, get_output_parser
 
 
@@ -58,17 +65,25 @@ def _deploy(args):
             force_env_build=no_cache,
             environment_name=args.env,
         )
+        app_name = prepared.loaded.app_name
+        run_hint = run_command_hint(app_ref, app_name)
+        if app_name and is_first_deployment(client, app_name, args.env):
+            print_first_deploy_nudge(args.console, app_name, run_hint)
         args.console.print(
             f"Deploying '{prepared.display_name}' as app '{prepared.loaded.app_name}'",
             style="bold",
         )
         args.console.print("")
-        res = deploy_api.execute_prepared_deployment(
-            prepared,
-            result_handler=result_handler,
-            build_result_handler=build_result_handler,
-            prepare_options_handler=prepare_options_handler,
-        )
+        try:
+            res = deploy_api.execute_prepared_deployment(
+                prepared,
+                result_handler=result_handler,
+                build_result_handler=build_result_handler,
+                prepare_options_handler=prepare_options_handler,
+            )
+        except Exception:
+            print_deploy_failure_nudge(args.console, run_hint)
+            raise
 
     _render_deploy_result(args, res)
 

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -67,7 +67,10 @@ def _deploy(args):
         )
         app_name = prepared.loaded.app_name
         run_hint = run_command_hint(app_ref, app_name)
-        if app_name and is_first_deployment(client, app_name, args.env):
+        is_first_deploy = bool(app_name) and is_first_deployment(
+            client, app_name, args.env
+        )
+        if is_first_deploy and app_name:
             print_first_deploy_nudge(args.console, app_name, run_hint)
         args.console.print(
             f"Deploying '{prepared.display_name}' as app '{prepared.loaded.app_name}'",
@@ -82,7 +85,9 @@ def _deploy(args):
                 prepare_options_handler=prepare_options_handler,
             )
         except Exception:
-            print_deploy_failure_nudge(args.console, run_hint)
+            print_deploy_failure_nudge(
+                args.console, run_hint, already_nudged=is_first_deploy
+            )
             raise
 
     _render_deploy_result(args, res)

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -140,7 +140,8 @@ def deploy_with_check(
     )
     _render_deployment_check_summary(args.console, summary)
     run_hint = run_command_hint(app_ref, prepared.loaded.app_name)
-    if production_alias is None:
+    is_first_deploy = production_alias is None
+    if is_first_deploy:
         print_first_deploy_nudge(args.console, summary.app_name, run_hint)
     _confirm_deployment(
         summary.app_name,
@@ -155,7 +156,9 @@ def deploy_with_check(
             prepare_options_handler=prepare_options_handler,
         )
     except Exception:
-        print_deploy_failure_nudge(args.console, run_hint)
+        print_deploy_failure_nudge(
+            args.console, run_hint, already_nudged=is_first_deploy
+        )
         raise
 
 
@@ -224,8 +227,17 @@ def print_first_deploy_nudge(console, app_name: str, run_hint: str) -> None:
     console.print("")
 
 
-def print_deploy_failure_nudge(console, run_hint: str) -> None:
-    """Point users at ``fal run`` for faster local debugging after a failed deploy."""
+def print_deploy_failure_nudge(
+    console, run_hint: str, *, already_nudged: bool = False
+) -> None:
+    """Point users at ``fal run`` for faster local debugging after a failed deploy.
+
+    Skipped when ``already_nudged`` is set — a first-deploy run already showed the
+    ``fal run`` tip up front, so repeating it on failure would be redundant.
+    """
+    if already_nudged:
+        return
+
     console.print("")
     console.print(
         "[bold yellow]Deploy failed.[/bold yellow] To debug faster, reproduce this "

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -139,10 +139,10 @@ def deploy_with_check(
         force_env_build=force_env_build,
     )
     _render_deployment_check_summary(args.console, summary)
-    run_hint = run_command_hint(app_ref, prepared.loaded.app_name)
+    run_hint = run_command_hint(app_ref, prepared.loaded.app_name, args.env)
     is_first_deploy = production_alias is None
     if is_first_deploy:
-        print_first_deploy_nudge(args.console, summary.app_name, run_hint)
+        print_first_deploy_nudge(args.console, summary.app_name, run_hint, args.env)
     _confirm_deployment(
         summary.app_name,
         console=args.console,
@@ -165,25 +165,34 @@ def deploy_with_check(
 def run_command_hint(
     app_ref: tuple[str | None, str | None] | None,
     app_name: str | None = None,
+    environment_name: str | None = None,
 ) -> str:
     """Best-effort reconstruction of the equivalent ``fal run`` command.
 
     Used to point users at local validation with the same reference they just
     passed to ``fal deploy`` (a file path, ``file.py::App`` ref, or app name).
+    ``environment_name`` is appended as ``--env`` so the suggested command
+    targets the same environment the deploy did, not the default (``main``).
     """
     from ._utils import is_app_name
 
-    if app_ref:
-        file_path, func_name = app_ref
-        if file_path:
-            if is_app_name((file_path, func_name)):
+    def _base() -> str:
+        if app_ref:
+            file_path, func_name = app_ref
+            if file_path:
+                if is_app_name((file_path, func_name)):
+                    return f"fal run {file_path}"
+                if func_name:
+                    return f"fal run {file_path}::{func_name}"
                 return f"fal run {file_path}"
-            if func_name:
-                return f"fal run {file_path}::{func_name}"
-            return f"fal run {file_path}"
-    if app_name:
-        return f"fal run {app_name}"
-    return "fal run <app>"
+        if app_name:
+            return f"fal run {app_name}"
+        return "fal run <app>"
+
+    hint = _base()
+    if environment_name:
+        hint += f" --env {environment_name}"
+    return hint
 
 
 def is_first_deployment(
@@ -209,11 +218,22 @@ def is_first_deployment(
         return False
 
 
-def print_first_deploy_nudge(console, app_name: str, run_hint: str) -> None:
-    """Nudge users to validate locally with ``fal run`` before a first deploy."""
+def print_first_deploy_nudge(
+    console, app_name: str, run_hint: str, environment_name: str | None = None
+) -> None:
+    """Nudge users to validate locally with ``fal run`` before a first deploy.
+
+    First-deploy detection is per-environment, so when deploying to a non-default
+    environment the message names it — the app may already exist elsewhere.
+    """
+    where = (
+        f" to the [bold]{environment_name}[/bold] environment"
+        if environment_name
+        else ""
+    )
     console.print(
         f"[bold cyan]Tip:[/bold cyan] This looks like the first deployment of "
-        f"[bold]{app_name}[/bold]."
+        f"[bold]{app_name}[/bold]{where}."
     )
     console.print(
         "     Validate it locally first to catch import and setup() errors before "

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -139,16 +139,103 @@ def deploy_with_check(
         force_env_build=force_env_build,
     )
     _render_deployment_check_summary(args.console, summary)
+    run_hint = run_command_hint(app_ref, prepared.loaded.app_name)
+    if production_alias is None:
+        print_first_deploy_nudge(args.console, summary.app_name, run_hint)
     _confirm_deployment(
         summary.app_name,
         console=args.console,
         assume_yes=args.yes,
     )
-    return deploy_api.execute_prepared_deployment(
-        prepared,
-        result_handler=result_handler,
-        build_result_handler=build_result_handler,
-        prepare_options_handler=prepare_options_handler,
+    try:
+        return deploy_api.execute_prepared_deployment(
+            prepared,
+            result_handler=result_handler,
+            build_result_handler=build_result_handler,
+            prepare_options_handler=prepare_options_handler,
+        )
+    except Exception:
+        print_deploy_failure_nudge(args.console, run_hint)
+        raise
+
+
+def run_command_hint(
+    app_ref: tuple[str | None, str | None] | None,
+    app_name: str | None = None,
+) -> str:
+    """Best-effort reconstruction of the equivalent ``fal run`` command.
+
+    Used to point users at local validation with the same reference they just
+    passed to ``fal deploy`` (a file path, ``file.py::App`` ref, or app name).
+    """
+    from ._utils import is_app_name
+
+    if app_ref:
+        file_path, func_name = app_ref
+        if file_path:
+            if is_app_name((file_path, func_name)):
+                return f"fal run {file_path}"
+            if func_name:
+                return f"fal run {file_path}::{func_name}"
+            return f"fal run {file_path}"
+    if app_name:
+        return f"fal run {app_name}"
+    return "fal run <app>"
+
+
+def is_first_deployment(
+    client: SyncServerlessClient,
+    app_name: str | None,
+    environment_name: str | None,
+) -> bool:
+    """Best-effort check for whether ``app_name`` has no production alias yet.
+
+    Returns ``False`` (i.e. does not nudge) if the status can't be determined,
+    so a flaky lookup never blocks or misleads a deploy.
+    """
+    if not app_name:
+        return False
+
+    try:
+        return (
+            _get_production_alias(client, app_name, environment_name=environment_name)
+            is None
+        )
+    except Exception:
+        logger.warning("Failed to determine first-deploy status", exc_info=True)
+        return False
+
+
+def print_first_deploy_nudge(console, app_name: str, run_hint: str) -> None:
+    """Nudge users to validate locally with ``fal run`` before a first deploy."""
+    console.print(
+        f"[bold cyan]Tip:[/bold cyan] This looks like the first deployment of "
+        f"[bold]{app_name}[/bold]."
+    )
+    console.print(
+        "     Validate it locally first to catch import and setup() errors before "
+        "they become\n     a production crashloop:"
+    )
+    console.print(f"       [bold]{run_hint}[/bold]")
+    console.print(
+        "     [dim]`fal run` boots your app on a temporary worker (running setup() "
+        "and the\n     endpoints) so you can iterate without a full deploy.[/dim]"
+    )
+    console.print("")
+
+
+def print_deploy_failure_nudge(console, run_hint: str) -> None:
+    """Point users at ``fal run`` for faster local debugging after a failed deploy."""
+    console.print("")
+    console.print(
+        "[bold yellow]Deploy failed.[/bold yellow] To debug faster, reproduce this "
+        "locally first:"
+    )
+    console.print(f"       [bold]{run_hint}[/bold]")
+    console.print(
+        "     [dim]`fal run` boots your app on a temporary worker (running setup() "
+        "and the\n     endpoints) so you can fix errors without repeated deploys."
+        "[/dim]"
     )
 
 

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -21,6 +21,7 @@ from fal.cli.deploy_check import (
     _render_environment_build_cache_line,
     _resolve_deploy_check_source,
     is_first_deployment,
+    print_first_deploy_nudge,
     run_command_hint,
 )
 from fal.cli.main import parse_args
@@ -2756,3 +2757,61 @@ def test_deploy_first_deploy_failure_nudges_run_only_once(
     assert "first deployment" in rendered
     assert "Deploy failed" not in rendered
     assert rendered.count("fal run src/my_app/inference.py::MyApp") == 1
+
+
+def test_run_command_hint_appends_env():
+    assert (
+        run_command_hint(("app.py", "MyApp"), None, "staging")
+        == "fal run app.py::MyApp --env staging"
+    )
+    # no env -> no --env (targets default/main, same as fal run's default)
+    assert run_command_hint(("app.py", "MyApp")) == "fal run app.py::MyApp"
+    assert (
+        run_command_hint(("my-app", None), None, "staging")
+        == "fal run my-app --env staging"
+    )
+
+
+def test_print_first_deploy_nudge_names_environment():
+    console = Console(record=True, width=120)
+    print_first_deploy_nudge(
+        console, "my-app", "fal run app.py::A --env staging", "staging"
+    )
+    out = console.export_text()
+    assert "staging environment" in out
+    assert "--env staging" in out
+
+
+def test_print_first_deploy_nudge_omits_environment_for_default():
+    console = Console(record=True, width=120)
+    print_first_deploy_nudge(console, "my-app", "fal run app.py::A")
+    out = console.export_text()
+    assert "environment" not in out
+
+
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias", return_value=None)
+def test_deploy_first_deploy_nudge_threads_env(
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+    mock_execute_prepared_deployment.return_value = MagicMock(
+        revision="rev",
+        app_name="my-app",
+        auth_mode="public",
+        urls={"playground": {}, "sync": {}, "async": {}},
+        log_url="https://fal.ai/logs",
+    )
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.env = "staging"
+    args.console = Console(record=True, width=120)
+
+    _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "staging environment" in rendered
+    assert "fal run src/my_app/inference.py::MyApp --env staging" in rendered

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -20,6 +20,8 @@ from fal.cli.deploy_check import (
     _render_deployment_strategy_line,
     _render_environment_build_cache_line,
     _resolve_deploy_check_source,
+    is_first_deployment,
+    run_command_hint,
 )
 from fal.cli.main import parse_args
 from fal.project import find_project_root
@@ -2563,3 +2565,162 @@ def test_deploy_with_env_check_and_yes_renders_summary_without_prompt(
     mock_prepare_deployment.assert_called_once()
     mock_execute_prepared_deployment.assert_called_once()
     mock_input.assert_not_called()
+
+
+def test_run_command_hint_from_file_and_function_ref():
+    assert (
+        run_command_hint(("src/my_app/inference.py", "MyApp"))
+        == "fal run src/my_app/inference.py::MyApp"
+    )
+
+
+def test_run_command_hint_from_bare_file_ref():
+    assert run_command_hint(("my_app.py", None)) == "fal run my_app.py"
+
+
+def test_run_command_hint_from_app_name_ref():
+    # An app-name ref has no ".py" file and no function part.
+    assert run_command_hint(("my-app", None)) == "fal run my-app"
+
+
+def test_run_command_hint_falls_back_to_resolved_app_name():
+    # Bare `fal deploy` (no positional ref) still yields a usable hint.
+    assert run_command_hint((None, None), app_name="my-app") == "fal run my-app"
+
+
+def test_run_command_hint_final_fallback():
+    assert run_command_hint(None) == "fal run <app>"
+
+
+@patch("fal.cli.deploy_check._get_production_alias", return_value=None)
+def test_is_first_deployment_true_when_no_production_alias(mock_alias):
+    assert is_first_deployment(MagicMock(), "my-app", None) is True
+
+
+@patch("fal.cli.deploy_check._get_production_alias")
+def test_is_first_deployment_false_when_alias_exists(mock_alias):
+    mock_alias.return_value = _production_alias()
+    assert is_first_deployment(MagicMock(), "my-app", None) is False
+
+
+@patch("fal.cli.deploy_check._get_production_alias", side_effect=RuntimeError("boom"))
+def test_is_first_deployment_false_on_lookup_error(mock_alias):
+    # A flaky lookup must never block or mislabel a deploy.
+    assert is_first_deployment(MagicMock(), "my-app", None) is False
+
+
+def test_is_first_deployment_false_without_app_name():
+    assert is_first_deployment(MagicMock(), None, None) is False
+
+
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias", return_value=None)
+def test_deploy_first_deploy_nudges_run(
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+    mock_execute_prepared_deployment.return_value = MagicMock(
+        revision="rev",
+        app_name="my-app",
+        auth_mode="public",
+        urls={"playground": {}, "sync": {}, "async": {}},
+        log_url="https://fal.ai/logs",
+    )
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.console = Console(record=True, width=120)
+
+    _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "first deployment" in rendered
+    assert "fal run src/my_app/inference.py::MyApp" in rendered
+    mock_execute_prepared_deployment.assert_called_once()
+
+
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias")
+def test_deploy_existing_app_does_not_nudge_run(
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    mock_get_alias.return_value = _production_alias()
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+    mock_execute_prepared_deployment.return_value = MagicMock(
+        revision="rev",
+        app_name="my-app",
+        auth_mode="public",
+        urls={"playground": {}, "sync": {}, "async": {}},
+        log_url="https://fal.ai/logs",
+    )
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.console = Console(record=True, width=120)
+
+    _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "first deployment" not in rendered
+
+
+@patch(
+    "fal.api.deploy.execute_prepared_deployment",
+    side_effect=RuntimeError("crashloop"),
+)
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias")
+def test_deploy_failure_nudges_run(
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    # Existing app so the first-deploy nudge is not what we're asserting on.
+    mock_get_alias.return_value = _production_alias()
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.console = Console(record=True, width=120)
+
+    with pytest.raises(RuntimeError):
+        _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "Deploy failed" in rendered
+    assert "fal run src/my_app/inference.py::MyApp" in rendered
+
+
+@patch("fal.api.deploy.execute_prepared_deployment")
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias", return_value=None)
+@patch("sys.stdin.isatty", return_value=True)
+@patch("builtins.input", return_value="confirm")
+def test_deploy_with_check_first_deploy_nudges_run(
+    mock_input,
+    mock_isatty,
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+    mock_execute_prepared_deployment.return_value = MagicMock(
+        revision="rev-checked",
+        app_name="my-app",
+        auth_mode="public",
+        urls={"playground": {}, "sync": {}, "async": {}},
+        log_url="https://fal.ai/logs/checked",
+    )
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.check = True
+    args.console = Console(record=True, width=120)
+
+    _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "first deployment" in rendered
+    assert "fal run src/my_app/inference.py::MyApp" in rendered

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -2724,3 +2724,35 @@ def test_deploy_with_check_first_deploy_nudges_run(
     rendered = args.console.export_text()
     assert "first deployment" in rendered
     assert "fal run src/my_app/inference.py::MyApp" in rendered
+
+
+def test_print_deploy_failure_nudge_suppressed_when_already_nudged():
+    from fal.cli.deploy_check import print_deploy_failure_nudge
+
+    console = Console(record=True, width=120)
+    print_deploy_failure_nudge(console, "fal run app.py::A", already_nudged=True)
+    assert console.export_text().strip() == ""
+
+
+@patch("fal.api.deploy.execute_prepared_deployment", side_effect=RuntimeError("boom"))
+@patch("fal.api.deploy.prepare_deployment")
+@patch("fal.cli.deploy_check._get_production_alias", return_value=None)
+def test_deploy_first_deploy_failure_nudges_run_only_once(
+    mock_get_alias,
+    mock_prepare_deployment,
+    mock_execute_prepared_deployment,
+):
+    # First deploy (no production alias) that then fails: the up-front first-deploy
+    # tip fires, so the failure nudge must NOT repeat the `fal run` guidance.
+    mock_prepare_deployment.return_value = _prepared_deployment(reset_scale=False)
+
+    args = mock_args(app_ref=("src/my_app/inference.py", "MyApp"))
+    args.console = Console(record=True, width=120)
+
+    with pytest.raises(RuntimeError):
+        _deploy(args)
+
+    rendered = args.console.export_text()
+    assert "first deployment" in rendered
+    assert "Deploy failed" not in rendered
+    assert rendered.count("fal run src/my_app/inference.py::MyApp") == 1


### PR DESCRIPTION
 SERV-1403

Nudges users to validate with `fal run` before `fal deploy`, so first-time serverless users don't go straight to a hard-to-debug production crashloop.

Linear: https://linear.app/features-and-labels/issue/SERV-1403

### What changed
`fal deploy` now:
- **First deploy of an app** (no production alias yet) → prints a tip to validate locally with `fal run <same ref>` first. Fires on both the plain path and the `--check` path.
- **Build/register failure** → points the user at the equivalent `fal run` command to reproduce and debug locally, then re-raises the original error.
- **One nudge per run** — if the first-deploy tip already fired, the failure nudge is suppressed, so `fal run` is only suggested once per deploy (a failing app never registers, so it would otherwise stay a "first deploy" and double-nudge on every retry).

Implementation:
- `deploy_check.py`: `run_command_hint`, `is_first_deployment` (best-effort; never blocks/fails a deploy), `print_first_deploy_nudge`, `print_deploy_failure_nudge`.
- `deploy.py`: wires both into the plain deploy path; the `--check` path is handled inside `deploy_with_check`.
- The failure catch is `except Exception`, so an aborted confirmation (`SystemExit`) / `Ctrl-C` (`KeyboardInterrupt`) does **not** trigger the debug nudge.

### Rendered output
Actual render of the nudges across the three cases (first deploy, existing-app failure, and a first deploy that fails — deduped):

![fal run nudges](https://github.com/user-attachments/assets/98fa6384-d63b-42b2-ac5a-9decb3451835)

### Testing
- **15 passed** new nudge tests; **120 passed** overall in `tests/unit/cli/test_deploy.py`. Full log: [pytest-deploy.txt](https://gist.githubusercontent.com/jim-fal/629ad973191902230174c496a25fbf97/raw/fal-pytest-deploy.txt)
- New tests cover: `run_command_hint` (file+func / bare file / app-name / resolved-name / fallback), `is_first_deployment` (no alias → true, alias exists → false, lookup error → false, no app name → false), first-deploy nudge on both paths, no nudge for an existing app, and failure nudge + exception propagation.
- The 6 failing `test_deploy_with_cli_*` tests are **pre-existing** and unrelated — they assert on cwd-derived absolute paths and fail identically on `origin/main`.

- **Validated locally** against a real `fal deploy` (fal-ai account) using a valid app and a broken variant (unresolvable dependency), covering the three nudge scenarios:

  | Scenario | Command shape | Nudges shown |
  | --- | --- | --- |
  | First deploy of a new app name | `fal deploy app.py::App --app-name <new>` | first-deploy tip |
  | First deploy that fails at build | `fal deploy app_fail.py::App --app-name <new>` | first-deploy tip only (failure nudge suppressed) |
  | Existing app whose deploy fails | `fal deploy app_fail.py::App --app-name <existing>` | failure nudge only |

<sub>Testing artifacts (screenshot + logs) live in a gist rather than the branch: https://gist.github.com/jim-fal/629ad973191902230174c496a25fbf97</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only messaging around deploy; deploy behavior is unchanged aside from extra console output and a non-blocking alias lookup for first-deploy detection.
> 
> **Overview**
> **`fal deploy`** now prints CLI guidance to validate with **`fal run`** using the same app reference (and **`--env`** when set) before shipping to production.
> 
> On **first deploy** for an app/environment (no production alias yet), it shows a tip to run locally first—on both the normal deploy path and the **`--check`** flow. **`is_first_deployment`** is best-effort (lookup failures never block deploy). If **`execute_prepared_deployment`** raises, it suggests the same **`fal run`** command for faster debugging, then re-raises; the failure nudge is **skipped** when the first-deploy tip already ran so users only see one **`fal run`** suggestion per attempt.
> 
> New helpers in **`deploy_check.py`**: **`run_command_hint`**, **`print_first_deploy_nudge`**, **`print_deploy_failure_nudge`**, plus wiring in **`deploy.py`**. Unit tests cover hint building, first-deploy detection, nudge visibility, deduplication, and env threading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb0ab8f185f8526d24a7bf90291c125cfe9fe41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

