### PR TITLE
DRAFT: SERV-1404: adaptive multipart chunk size + resumable /data uploads (client)

### DIFF
--- a/projects/fal/src/fal/files.py
+++ b/projects/fal/src/fal/files.py
@@ -8,10 +8,10 @@ from fsspec import AbstractFileSystem
 
 from fal._user_agent import USER_AGENT
 from fal.upload import (
-    MULTIPART_CHUNK_SIZE,
     MULTIPART_MAX_CONCURRENCY,
     MULTIPART_THRESHOLD,
     DataFileMultipartUpload,
+    compute_multipart_chunk_size,
 )
 
 if TYPE_CHECKING:
@@ -155,7 +155,11 @@ class FalFileSystem(AbstractFileSystem):
     def _put_file_multipart(self, lpath, rpath, size, progress):
         md5 = _compute_md5(lpath)
 
-        num_parts = max(1, (size + MULTIPART_CHUNK_SIZE - 1) // MULTIPART_CHUNK_SIZE)
+        # Scale the chunk size with the file size so large checkpoints stay
+        # within the server's part-count limit (e.g. ~200GB checkpoints).
+        chunk_size = compute_multipart_chunk_size(size)
+
+        num_parts = max(1, (size + chunk_size - 1) // chunk_size)
         task = progress.add_task(f"{os.path.basename(lpath)}", total=num_parts)
 
         def on_part_complete(part_number: int):
@@ -164,9 +168,12 @@ class FalFileSystem(AbstractFileSystem):
         multipart = DataFileMultipartUpload(
             client=self._client,
             target_path=rpath,
-            chunk_size=MULTIPART_CHUNK_SIZE,
+            chunk_size=chunk_size,
             max_concurrency=MULTIPART_MAX_CONCURRENCY,
         )
+        # Enables server-side resume: the server derives a deterministic upload
+        # id from this identity and returns any parts already uploaded.
+        multipart._content_md5 = md5
 
         etag = multipart.upload_file(lpath, on_part_complete=on_part_complete)
 

--- a/projects/fal/src/fal/upload.py
+++ b/projects/fal/src/fal/upload.py
@@ -2,10 +2,9 @@ import concurrent.futures
 import logging
 import math
 import os
-import queue
 import time
-from threading import Lock, Thread
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from threading import Lock
+from typing import Any, Callable, Dict, List, Optional, Set, cast
 
 import httpx
 
@@ -16,6 +15,37 @@ logger = logging.getLogger(__name__)
 MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024  # 10MB per part
 MULTIPART_MAX_CONCURRENCY = 10
 MULTIPART_THRESHOLD = 10 * 1024 * 1024  # 10MB
+
+# These must stay in sync with the server (isolate_controller ... files/utils.py):
+# MAX_PART_SIZE and MAX_PART_NUMBER.
+MULTIPART_MAX_PART_SIZE = 100 * 1024 * 1024  # 100MB per part
+MULTIPART_MAX_PARTS = 10000  # maximum number of parts the server accepts
+_MB = 1024 * 1024
+
+
+def compute_multipart_chunk_size(size: int) -> int:
+    """Pick a chunk size so a file of ``size`` bytes fits within
+    ``MULTIPART_MAX_PARTS`` parts, each no larger than ``MULTIPART_MAX_PART_SIZE``.
+
+    Small files keep the default 10MB chunk; large files (e.g. multi-hundred-GB
+    checkpoints) scale the chunk up so the part count stays under the server cap.
+    """
+    if size <= 0:
+        return MULTIPART_CHUNK_SIZE
+
+    # Smallest chunk that keeps the part count within the server limit.
+    min_chunk = math.ceil(size / MULTIPART_MAX_PARTS)
+    chunk = max(MULTIPART_CHUNK_SIZE, min_chunk)
+    # Round up to a whole MB for stable, predictable part boundaries.
+    chunk = math.ceil(chunk / _MB) * _MB
+
+    if chunk > MULTIPART_MAX_PART_SIZE:
+        max_size = MULTIPART_MAX_PART_SIZE * MULTIPART_MAX_PARTS
+        raise FalServerlessException(
+            f"File is too large to upload ({size} bytes): exceeds the maximum "
+            f"supported size of {max_size} bytes."
+        )
+    return chunk
 
 
 class BaseMultipartUpload:
@@ -31,6 +61,12 @@ class BaseMultipartUpload:
         self._upload_id: Optional[str] = None
         self._parts: List[Dict[str, object]] = []
         self._parts_lock = Lock()
+        # Populated from the initiate response so already-uploaded parts can be
+        # skipped when resuming an interrupted upload.
+        self._completed_parts: Set[int] = set()
+        # File identity sent to initiate so the server can resume a prior upload.
+        self._content_md5: Optional[str] = None
+        self._file_size: Optional[int] = None
 
     @property
     def upload_id(self) -> str:
@@ -136,6 +172,16 @@ class BaseMultipartUpload:
         response = self._request("POST", self.initiate_url, **kwargs)
         data = response.json()
         self._upload_id = data["upload_id"]
+
+        # The server may return parts that were already uploaded in a previous
+        # (interrupted) run so we can resume instead of starting over.
+        existing = data.get("parts") or []
+        with self._parts_lock:
+            self._parts = [
+                {"part_number": p["part_number"], "etag": p["etag"]}
+                for p in existing
+            ]
+            self._completed_parts = {int(p["part_number"]) for p in self._parts}
         return self.upload_id
 
     def _upload_part(
@@ -173,12 +219,28 @@ class BaseMultipartUpload:
             except Exception as e:
                 logger.warning(f"Failed to cancel upload {self._upload_id}: {e}")
 
+    def _upload_part_from_file(
+        self, file_path: str, part_number: int
+    ) -> Dict[str, object]:
+        """Read a single part from ``file_path`` by offset and upload it.
+
+        Each worker opens its own file handle and seeks to the part offset so
+        only the parts that still need uploading are read from disk (important
+        when resuming a large upload that is already mostly complete).
+        """
+        offset = (part_number - 1) * self.chunk_size
+        with open(file_path, "rb") as f:
+            f.seek(offset)
+            chunk = f.read(self.chunk_size)
+        return self._upload_part(part_number, chunk)
+
     def upload_file(
         self,
         file_path: str,
         on_part_complete: Optional[Callable[[int], None]] = None,
     ) -> str:
-        size = os.path.getsize(file_path)
+        self._file_size = os.path.getsize(file_path)
+        size = self._file_size
 
         # Handle empty files specially - upload single empty part
         if size == 0:
@@ -188,15 +250,13 @@ class BaseMultipartUpload:
                 return ""
 
             try:
-                self._upload_part(1, b"")
+                if 1 not in self._completed_parts:
+                    self._upload_part(1, b"")
                 if on_part_complete:
                     on_part_complete(1)
                 return self.complete()
             except FileExistsError:
                 return ""
-            except Exception:
-                self.cancel()
-                raise
 
         num_parts = max(1, math.ceil(size / self.chunk_size))
 
@@ -205,64 +265,40 @@ class BaseMultipartUpload:
         except FileExistsError:
             return ""
 
-        chunk_queue: queue.Queue[Optional[Tuple[int, bytes]]] = queue.Queue(
-            maxsize=self.max_concurrency * 2
-        )
-        read_error: List[Exception] = []
+        # Reflect parts the server already has so progress reporting is accurate.
+        if on_part_complete:
+            for part_number in sorted(self._completed_parts):
+                on_part_complete(part_number)
 
-        def reader_thread():
-            """Reads file chunks and puts them in bounded queue"""
-            try:
-                with open(file_path, "rb") as f:
-                    for part_number in range(1, num_parts + 1):
-                        chunk = f.read(self.chunk_size)
-                        if chunk:
-                            chunk_queue.put((part_number, chunk))
-                # Sentinel to signal completion
-                chunk_queue.put(None)
-            except Exception as e:
-                read_error.append(e)
-                chunk_queue.put(None)
+        parts_to_upload = [
+            part_number
+            for part_number in range(1, num_parts + 1)
+            if part_number not in self._completed_parts
+        ]
 
-        reader = Thread(target=reader_thread, daemon=True)
-        reader.start()
-
+        # NOTE: we deliberately do NOT cancel the upload on failure. The parts
+        # uploaded so far are kept server-side, so re-running the upload resumes
+        # from where it left off instead of starting over.
         try:
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=self.max_concurrency
             ) as executor:
-                futures = []
+                future_to_part = {
+                    executor.submit(
+                        self._upload_part_from_file, file_path, part_number
+                    ): part_number
+                    for part_number in parts_to_upload
+                }
 
-                while True:
-                    item = chunk_queue.get()
-                    if item is None:
-                        break
-
-                    part_number, chunk = item
-                    future = executor.submit(
-                        self._upload_part,
-                        part_number,
-                        chunk,
-                    )
-                    futures.append((part_number, future))
-
-                # Wait for all uploads to complete
-                for part_number, future in futures:
+                for future in concurrent.futures.as_completed(future_to_part):
+                    part_number = future_to_part[future]
                     future.result()
                     if on_part_complete:
                         on_part_complete(part_number)
 
-            reader.join()
-
-            if read_error:
-                raise read_error[0]
-
             return self.complete()
         except FileExistsError:
             return ""
-        except Exception:
-            self.cancel()
-            raise
 
 
 class AppFileMultipartUpload(BaseMultipartUpload):
@@ -330,3 +366,13 @@ class DataFileMultipartUpload(BaseMultipartUpload):
     @property
     def cancel_url(self) -> Optional[str]:
         return f"/files/file/multipart/{self.target_path}/{self.upload_id}/cancel"
+
+    def get_initiate_payload(self) -> Optional[dict]:
+        # Sent so the server can derive a deterministic upload id and resume a
+        # previously interrupted upload of the same file to the same path.
+        payload: Dict[str, Any] = {"chunk_size": self.chunk_size}
+        if self._content_md5 is not None:
+            payload["content_md5"] = self._content_md5
+        if self._file_size is not None:
+            payload["size"] = self._file_size
+        return payload

--- a/projects/fal/tests/unit/test_multipart_upload.py
+++ b/projects/fal/tests/unit/test_multipart_upload.py
@@ -1,0 +1,127 @@
+import hashlib
+import json
+import math
+import os
+import tempfile
+
+import httpx
+import pytest
+
+from fal.exceptions import FalServerlessException
+from fal.upload import (
+    MULTIPART_CHUNK_SIZE,
+    MULTIPART_MAX_PART_SIZE,
+    MULTIPART_MAX_PARTS,
+    DataFileMultipartUpload,
+    compute_multipart_chunk_size,
+)
+
+MB = 1024 * 1024
+GB = 1024 * MB
+
+
+def _num_parts(size, chunk):
+    return math.ceil(size / chunk)
+
+
+@pytest.mark.parametrize("size", [1, MB, 50 * MB, 100 * GB, 200 * GB, 900 * GB])
+def test_adaptive_chunk_size_stays_within_limits(size):
+    chunk = compute_multipart_chunk_size(size)
+    assert chunk >= MULTIPART_CHUNK_SIZE
+    assert chunk <= MULTIPART_MAX_PART_SIZE
+    assert chunk % MB == 0
+    assert _num_parts(size, chunk) <= MULTIPART_MAX_PARTS
+
+
+def test_small_file_keeps_default_chunk():
+    assert compute_multipart_chunk_size(5 * MB) == MULTIPART_CHUNK_SIZE
+
+
+def test_200gb_would_exceed_cap_with_old_fixed_chunk():
+    # Regression guard for SERV-1404: the old fixed 10MB chunk overflowed the
+    # 10k-part cap for a 200GB file; the adaptive size must not.
+    assert _num_parts(200 * GB, MULTIPART_CHUNK_SIZE) > MULTIPART_MAX_PARTS
+    adaptive = compute_multipart_chunk_size(200 * GB)
+    assert _num_parts(200 * GB, adaptive) <= MULTIPART_MAX_PARTS
+
+
+def test_file_over_ceiling_raises():
+    over = MULTIPART_MAX_PART_SIZE * MULTIPART_MAX_PARTS + 1
+    with pytest.raises(FalServerlessException):
+        compute_multipart_chunk_size(over)
+
+
+class _FakeServer:
+    """Minimal stateful multipart server mirroring the controller behavior."""
+
+    def __init__(self):
+        self.store = {}  # upload_id -> {part_number: etag}
+        self.put_log = []  # part numbers PUT across all runs
+        self.fail_after = None  # fail once more than N successful PUTs happened
+
+    def transport(self):
+        return httpx.MockTransport(self._handle)
+
+    def _handle(self, req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if path.endswith("/initiate"):
+            body = json.loads(req.content)
+            uid = hashlib.sha256(
+                f"{body.get('content_md5')}:{body.get('chunk_size')}".encode()
+            ).hexdigest()
+            self.store.setdefault(uid, {})
+            parts = [
+                {"part_number": n, "etag": e}
+                for n, e in sorted(self.store[uid].items())
+            ]
+            return httpx.Response(200, json={"upload_id": uid, "parts": parts})
+        if path.endswith("/complete"):
+            return httpx.Response(200, json={"etag": "final"})
+        segs = path.rstrip("/").split("/")
+        part_number, uid = int(segs[-1]), segs[-2]
+        self.put_log.append(part_number)
+        if self.fail_after is not None and len(self.put_log) > self.fail_after:
+            return httpx.Response(500, json={"detail": "boom"})
+        etag = hashlib.md5(f"p{part_number}".encode()).hexdigest()
+        self.store[uid][part_number] = etag
+        return httpx.Response(200, json={"part_number": part_number, "etag": etag})
+
+
+def _make_upload(client, md5):
+    m = DataFileMultipartUpload(
+        client=client, target_path="ckpt.bin", chunk_size=MB
+    )
+    m._content_md5 = md5
+    return m
+
+
+def test_resume_skips_already_uploaded_parts():
+    server = _FakeServer()
+    client = httpx.Client(transport=server.transport(), base_url="http://x")
+
+    data = os.urandom(10 * MB + 123)  # 11 parts at 1MB
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(data)
+        path = f.name
+    md5 = hashlib.md5(data).hexdigest()
+
+    try:
+        # Run 1: fail after 4 successful parts.
+        server.fail_after = 4
+        with pytest.raises(Exception):
+            _make_upload(client, md5).upload_file(path)
+
+        stored = sorted(next(iter(server.store.values())).keys())
+        assert len(stored) == 4
+
+        # Run 2: succeeds, resuming and uploading only the missing parts.
+        server.put_log.clear()
+        server.fail_after = None
+        etag = _make_upload(client, md5).upload_file(path)
+
+        assert etag == "final"
+        run2 = set(server.put_log)
+        assert not (run2 & set(stored)), "resume re-uploaded already-stored parts"
+        assert run2 | set(stored) == set(range(1, 12))
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## SERV-1404 — client side: adaptive chunks + resumable `/data` uploads

Large model-checkpoint uploads to `/data` (~200GB) failed out of the box, so customers (e.g. BFL) built their own uploaders. Root cause: the client used a **fixed 10MB chunk**, which overflows the server's **10,000-part cap at ~100GB**.

### Changes
- **Adaptive chunk size** (`compute_multipart_chunk_size`) — scales the chunk so any file up to the server ceiling (~976 GiB) stays within 10k parts.
- **Resumable uploads** — the client sends the file identity (`content_md5`, `size`, `chunk_size`) to `initiate`; the server returns parts it already has, and the client skips them (seek-based, only-missing parts read). It also **no longer auto-cancels on failure**, so an interrupted upload resumes on re-run.

### Testing

Run: `cd projects/fal && uv run --extra test python -m pytest tests/unit/test_multipart_upload.py -v` → **10 passed**.

```
test_adaptive_chunk_size_stays_within_limits[1]                PASSED
test_adaptive_chunk_size_stays_within_limits[1048576]          PASSED
test_adaptive_chunk_size_stays_within_limits[52428800]         PASSED
test_adaptive_chunk_size_stays_within_limits[107374182400]     PASSED  # 100 GB
test_adaptive_chunk_size_stays_within_limits[214748364800]     PASSED  # 200 GB
test_adaptive_chunk_size_stays_within_limits[966367641600]     PASSED  # 900 GB
test_small_file_keeps_default_chunk                            PASSED
test_200gb_would_exceed_cap_with_old_fixed_chunk               PASSED
test_file_over_ceiling_raises                                  PASSED
test_resume_skips_already_uploaded_parts                       PASSED
============================ 10 passed in 3.08s ============================
```

**Adaptive chunk sizing** (old fixed 10MB overflows the 10k-part cap at ≥100GB):

| File size | Chunk | Parts (new) | Parts (old 10MB) | Within 10k cap |
|---|---|---|---|---|
| 1 GB | 10 MB | 103 | 103 | ✅ |
| 50 GB | 10 MB | 5,120 | 5,120 | ✅ |
| 100 GB | 11 MB | 9,310 | **10,240 ✗** | ✅ |
| 200 GB | 21 MB | 9,753 | **20,480 ✗** | ✅ |
| 500 GB | 52 MB | 9,847 | **51,200 ✗** | ✅ |
| 900 GB | 93 MB | 9,910 | **92,160 ✗** | ✅ |

**Resume** is exercised by `test_resume_skips_already_uploaded_parts`: a mock server stores parts, the upload is failed after 4 parts, and the re-run uploads only the 7 missing parts with zero overlap. Ruff: **0 new findings** on changed files.

### Artifacts
Full test report & runbook (all suites, commands, captured output): https://claude.ai/code/artifact/ef3068d9-0344-4fb9-aa6a-ad94861490fe — _private Claude artifact; ping me and I'll share it._

### Paired PRs
- Server: fal-ai/isolate-cloud#8646 · CronJob: fal-ai/infra#12590

> Draft: depends on the isolate-cloud server PR for end-to-end resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
