### PR TITLE
render multi-line deploy failures legibly in the CLI 

### DIFF
--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -83,23 +83,45 @@ def parse_args(argv=None):
 
 
 def _print_error(msg):
-    # Wrap at (width - 2) and print with a hanging indent: the cross leads the
-    # first line, continuation lines (explicit newlines and soft-wraps) are
-    # indented 2 columns. Multi-line deploy failures (a reason + a "Check the
-    # logs: <url>" pointer) then read as one block instead of collapsing to
-    # column 0 and blending into surrounding terminal output.
+    # Print with a hanging indent: the cross leads the first line, continuation
+    # lines are indented 2 columns. Multi-line deploy failures (a reason + a
+    # "Check the logs: <url>" pointer) then read as one block instead of
+    # collapsing to column 0 and blending into surrounding terminal output.
     from rich.text import Text
 
-    text = Text(str(msg))
+    # overflow="ignore" keeps a token longer than the wrap width — a logs URL
+    # with a UUID revision id is ~116 chars — on one line instead of folding it
+    # mid-token, so it stays clickable and copy-pasteable. (Text.wrap only
+    # short-circuits wrapping entirely when "ignore" arrives as its *argument*,
+    # not as the Text's own attribute, so word wrapping still happens here.)
+    text = Text(str(msg), overflow="ignore")
     # Building a Text bypasses the ReprHighlighter that console.print(str) applies,
     # so re-apply it to keep URLs / numbers / paths styled (e.g. the logs link).
-    if console.highlighter is not None:
+    # `_highlight` is rich's record of the `highlight=` constructor flag; checking
+    # `console.highlighter` instead would be a no-op guard, since rich coerces a
+    # `highlighter=None` into a NullHighlighter instance.
+    if console._highlight:
         text = console.highlighter(text)
 
-    lines = text.wrap(console, max(console.width - 2, 1)) or [Text()]
+    if console.is_terminal:
+        # The terminal soft-wraps continuation lines back to column 0, so wrap
+        # here instead to keep them under the hanging indent.
+        lines = text.wrap(console, max(console.width - 2, 1))
+    else:
+        # Redirected output (pipes, CI logs, files) has no visual width to wrap
+        # to, and rich would fall back to 80 columns. Indent at the explicit
+        # newlines only, so a single-line grep over a CI log still matches.
+        lines = text.split(allow_blank=True)
+
     for i, line in enumerate(lines):
         gutter = f"{get_cross_icon(console)} " if i == 0 else "  "
-        console.print(Text.from_markup(gutter) + line)
+        rendered = Text.from_markup(gutter) + line
+        # Blank lines in the message would otherwise render as two spaces of
+        # gutter, and `Text.wrap` only strips whitespace *beyond* the wrap width,
+        # so a word-break space can survive at the end of a wrapped line.
+        rendered.rstrip()
+        # Already wrapped above; stop the console from wrapping or cropping again.
+        console.print(rendered, soft_wrap=True)
 
 
 def _get_check_updates_config() -> bool:

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -90,7 +90,13 @@ def _print_error(msg):
     # column 0 and blending into surrounding terminal output.
     from rich.text import Text
 
-    lines = Text(str(msg)).wrap(console, max(console.width - 2, 1)) or [Text()]
+    text = Text(str(msg))
+    # Building a Text bypasses the ReprHighlighter that console.print(str) applies,
+    # so re-apply it to keep URLs / numbers / paths styled (e.g. the logs link).
+    if console.highlighter is not None:
+        text = console.highlighter(text)
+
+    lines = text.wrap(console, max(console.width - 2, 1)) or [Text()]
     for i, line in enumerate(lines):
         gutter = f"{get_cross_icon(console)} " if i == 0 else "  "
         console.print(Text.from_markup(gutter) + line)

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -83,7 +83,14 @@ def parse_args(argv=None):
 
 
 def _print_error(msg):
-    console.print(f"{get_cross_icon(console)} {msg}")
+    # Render multi-line errors (e.g. a deploy failure with a reason on the first
+    # line and a "Check the logs: <url>" pointer on the next) with the cross on
+    # the first line and continuation lines indented beneath it, so the reason
+    # and the logs link stay legible instead of collapsing into one blob.
+    first, *rest = str(msg).split("\n")
+    console.print(f"{get_cross_icon(console)} {first}")
+    for line in rest:
+        console.print(f"  {line}")
 
 
 def _get_check_updates_config() -> bool:

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -83,14 +83,17 @@ def parse_args(argv=None):
 
 
 def _print_error(msg):
-    # Render multi-line errors (e.g. a deploy failure with a reason on the first
-    # line and a "Check the logs: <url>" pointer on the next) with the cross on
-    # the first line and continuation lines indented beneath it, so the reason
-    # and the logs link stay legible instead of collapsing into one blob.
-    first, *rest = str(msg).split("\n")
-    console.print(f"{get_cross_icon(console)} {first}")
-    for line in rest:
-        console.print(f"  {line}")
+    # Wrap at (width - 2) and print with a hanging indent: the cross leads the
+    # first line, continuation lines (explicit newlines and soft-wraps) are
+    # indented 2 columns. Multi-line deploy failures (a reason + a "Check the
+    # logs: <url>" pointer) then read as one block instead of collapsing to
+    # column 0 and blending into surrounding terminal output.
+    from rich.text import Text
+
+    lines = Text(str(msg)).wrap(console, max(console.width - 2, 1)) or [Text()]
+    for i, line in enumerate(lines):
+        gutter = f"{get_cross_icon(console)} " if i == 0 else "  "
+        console.print(Text.from_markup(gutter) + line)
 
 
 def _get_check_updates_config() -> bool:

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import os
 import subprocess
 import sys
@@ -124,13 +125,34 @@ def test_update_check_can_be_disabled(monkeypatch, tmp_path) -> None:
     test_console.print.assert_not_called()
 
 
-def _render_print_error(monkeypatch, msg, *, width=120, styles=False, **console_kwargs):
+# A logs URL with a UUID revision id: 116 chars once the "  Check the logs: "
+# gutter is on it, so it overruns rich's 80-column non-terminal default.
+LONG_LOGS_URL = (
+    "https://fal.ai/dashboard/logs?app=my-app"
+    "&revisionId=01937c8e-6f4b-7c3d-9e2a-1234567890ab"
+)
+
+
+def _render_print_error(
+    monkeypatch,
+    msg,
+    *,
+    width=120,
+    styles=False,
+    force_terminal=True,
+    color_system=None,
+    soft_wrap=True,
+    **console_kwargs,
+):
+    # file=StringIO keeps rich from deriving ascii_only from pytest's captured
+    # stdout, so the exact-"✘" assertions below hold under `pytest -s` too.
     console = Console(
         record=True,
+        file=io.StringIO(),
         width=width,
-        force_terminal=console_kwargs.pop("force_terminal", False),
-        color_system=console_kwargs.pop("color_system", None),
-        soft_wrap=True,
+        force_terminal=force_terminal,
+        color_system=color_system,
+        soft_wrap=soft_wrap,
         **console_kwargs,
     )
     monkeypatch.setattr(cli_main, "console", console)
@@ -165,9 +187,60 @@ def test_print_error_wraps_long_line_with_hanging_indent(monkeypatch) -> None:
     assert all(line.startswith("  ") for line in lines[1:])
 
 
-def test_print_error_empty_message_prints_bare_cross(monkeypatch) -> None:
-    output = _render_print_error(monkeypatch, "")
-    assert output.strip() == "✘"
+def test_print_error_keeps_a_long_url_whole_when_piped(monkeypatch) -> None:
+    """`fal deploy | tee`, CI logs, redirects: not a terminal, so rich falls back
+    to 80 columns. Folding there would insert a real newline mid-URL, which no
+    terminal rejoins on copy and no single-line `grep revisionId=` matches."""
+    output = _render_print_error(
+        monkeypatch,
+        f"New revision did not become ready.\nCheck the logs: {LONG_LOGS_URL}",
+        width=80,
+        force_terminal=False,
+        soft_wrap=False,
+    )
+    assert f"  Check the logs: {LONG_LOGS_URL}" in output.split("\n")
+
+
+def test_print_error_keeps_a_long_url_whole_in_a_narrow_terminal(monkeypatch) -> None:
+    """Same guarantee on a terminal too small for the URL: prose still wraps at
+    word boundaries, but the URL overflows onto its own line rather than folding
+    — the terminal soft-wraps it, and terminals rejoin soft-wraps on copy."""
+    output = _render_print_error(
+        monkeypatch,
+        f"New revision did not become ready.\nCheck the logs: {LONG_LOGS_URL}",
+        width=40,
+    )
+    lines = output.split("\n")
+    assert f"  {LONG_LOGS_URL}" in lines
+    assert "✘ New revision did not become ready." in lines
+
+
+def test_print_error_blank_lines_stay_empty(monkeypatch) -> None:
+    """A gutter prepended unconditionally would turn blank lines into two spaces,
+    which shows up in captured CI logs and exact-match greps."""
+    output = _render_print_error(monkeypatch, "reason\n\ndetail\n")
+    assert output.split("\n")[:4] == ["✘ reason", "", "  detail", ""]
+
+
+def test_print_error_leaves_no_trailing_whitespace(monkeypatch) -> None:
+    # Text.wrap only strips whitespace beyond the wrap width, so the space that
+    # broke "logs: " from the URL survives inside the budget without an rstrip.
+    output = _render_print_error(
+        monkeypatch, f"Check the logs: {LONG_LOGS_URL}", width=40
+    )
+    assert not any(line != line.rstrip() for line in output.split("\n"))
+
+
+def test_print_error_does_not_interpret_markup(monkeypatch) -> None:
+    """The main win of rendering via Text() rather than console.print(str):
+    brackets in a server-controlled message are literal text. Before, a token
+    like `[expected int]` was silently eaten as a style tag, and a stray
+    close-tag `[/red]` raised MarkupError from inside main()'s except handler."""
+    output = _render_print_error(monkeypatch, "invalid argument [expected int] got str")
+    assert output.strip() == "✘ invalid argument [expected int] got str"
+
+    output = _render_print_error(monkeypatch, "KeyError: [/red] unmatched")
+    assert output.strip() == "✘ KeyError: [/red] unmatched"
 
 
 def test_print_error_preserves_repr_highlighting(monkeypatch) -> None:
@@ -176,7 +249,6 @@ def test_print_error_preserves_repr_highlighting(monkeypatch) -> None:
             monkeypatch,
             msg,
             width=200,
-            force_terminal=True,
             color_system="standard",
             styles=True,
         )
@@ -198,6 +270,9 @@ def test_print_error_renders_with_cp1252_output() -> None:
     )
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "cp1252"
+    # rich sizes non-terminal consoles from COLUMNS too; a leaked narrow value
+    # (tmux, some Docker images, CI wrappers) would split the asserted phrase.
+    env.pop("COLUMNS", None)
 
     result = subprocess.run(
         [sys.executable, "-c", script],
@@ -212,7 +287,7 @@ def test_print_error_renders_with_cp1252_output() -> None:
 
 
 def test_main_prints_deploy_failure_reason_and_logs_link(monkeypatch) -> None:
-    """PR #8647 + #1119 (CLI boundary): a failed deploy comes back as a
+    """isolate-cloud#8647 (CLI boundary): a failed deploy comes back as a
     grpc.RpcError whose details() carry the categorized reason + logs link; main()
     must surface that to the terminal via _print_error, not swallow it. Guards the
     seam between the gRPC error status and the rendered ``✘`` line."""

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -209,3 +209,47 @@ def test_print_error_renders_with_cp1252_output() -> None:
     assert result.returncode == 0, result.stderr.decode(errors="replace")
     assert b"startup timeout" in result.stdout
     assert b"Check the logs" in result.stdout
+
+
+def test_main_prints_deploy_failure_reason_and_logs_link(monkeypatch) -> None:
+    """PR #8647 + #1119 (CLI boundary): a failed deploy comes back as a
+    grpc.RpcError whose details() carry the categorized reason + logs link; main()
+    must surface that to the terminal via _print_error, not swallow it. Guards the
+    seam between the gRPC error status and the rendered ``✘`` line."""
+    import grpc
+
+    reason = (
+        "New revision did not become ready within the startup timeout — the runner "
+        "never passed its health check (often a setup() failure or a crash-looping "
+        "runner).\n"
+        "Check the logs: https://fal.ai/dashboard/logs"
+        "?app=fail-app&revisionId=rev-new-123"
+    )
+
+    class _DeployRpcError(grpc.RpcError):
+        def code(self):
+            return grpc.StatusCode.FAILED_PRECONDITION
+
+        def details(self):
+            return reason
+
+    def deploy(_args):
+        raise _DeployRpcError()
+
+    console = Console(record=True, width=200, force_terminal=False, color_system=None)
+    monkeypatch.setattr(cli_main, "console", console)
+    monkeypatch.setattr(cli_main, "_check_latest_version", lambda: None)
+    monkeypatch.setattr(cli_main, "debugtools", lambda _args: nullcontext())
+    monkeypatch.setattr(
+        cli_main, "parse_args", lambda _argv: SimpleNamespace(func=deploy)
+    )
+
+    assert cli_main.main([]) == 1
+
+    output = console.export_text()
+    # The categorized reason and the revision-scoped logs link both reach stdout.
+    assert "New revision did not become ready within the startup timeout" in output
+    assert "Check the logs:" in output
+    assert "revisionId=rev-new-123" in output
+    # ...rendered as an error (cross glyph, ascii-fallback tolerant).
+    assert output.lstrip().startswith(("✘", "x "))

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -1,4 +1,7 @@
 import importlib
+import os
+import subprocess
+import sys
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -119,3 +122,90 @@ def test_update_check_can_be_disabled(monkeypatch, tmp_path) -> None:
 
     get_latest_version.assert_not_called()
     test_console.print.assert_not_called()
+
+
+def _render_print_error(monkeypatch, msg, *, width=120, styles=False, **console_kwargs):
+    console = Console(
+        record=True,
+        width=width,
+        force_terminal=console_kwargs.pop("force_terminal", False),
+        color_system=console_kwargs.pop("color_system", None),
+        soft_wrap=True,
+        **console_kwargs,
+    )
+    monkeypatch.setattr(cli_main, "console", console)
+    cli_main._print_error(msg)
+    return console.export_text(styles=styles)
+
+
+def test_print_error_single_line_is_unchanged(monkeypatch) -> None:
+    output = _render_print_error(monkeypatch, "You must run `fal run` first.")
+    assert output.strip() == "✘ You must run `fal run` first."
+
+
+def test_print_error_multiline_hangs_under_the_cross(monkeypatch) -> None:
+    output = _render_print_error(
+        monkeypatch,
+        "New revision did not become ready.\n"
+        "Check the logs: https://fal.ai/logs?revisionId=abc-123",
+        width=120,
+    )
+    lines = [line for line in output.split("\n") if line]
+    assert lines[0].startswith("✘ New revision did not become ready.")
+    assert lines[1] == "  Check the logs: https://fal.ai/logs?revisionId=abc-123"
+    # every continuation line hangs under the message instead of at column 0
+    assert all(line.startswith("  ") for line in lines[1:])
+
+
+def test_print_error_wraps_long_line_with_hanging_indent(monkeypatch) -> None:
+    output = _render_print_error(monkeypatch, "alpha " * 20, width=24)
+    lines = [line for line in output.split("\n") if line]
+    assert len(lines) > 1  # soft-wrapped into multiple visual lines
+    assert lines[0].startswith("✘ ")
+    assert all(line.startswith("  ") for line in lines[1:])
+
+
+def test_print_error_empty_message_prints_bare_cross(monkeypatch) -> None:
+    output = _render_print_error(monkeypatch, "")
+    assert output.strip() == "✘"
+
+
+def test_print_error_preserves_repr_highlighting(monkeypatch) -> None:
+    def render(msg):
+        return _render_print_error(
+            monkeypatch,
+            msg,
+            width=200,
+            force_terminal=True,
+            color_system="standard",
+            styles=True,
+        )
+
+    with_url = render("Check the logs: https://fal.ai/logs?revisionId=abc-123")
+    without = render("no highlightable tokens present here")
+    # URL / number highlighting adds ANSI styling beyond the red cross glyph;
+    # building a Text without re-applying the highlighter would drop it.
+    assert with_url.count("\x1b[") > without.count("\x1b[")
+
+
+def test_print_error_renders_with_cp1252_output() -> None:
+    script = "\n".join(
+        [
+            "from fal.cli.main import _print_error",
+            '_print_error("Setup failed within the startup timeout.\\n"',
+            '             "Check the logs: https://fal.ai/logs?app=fail-app&revisionId=abc-123")',
+        ]
+    )
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
+    assert b"startup timeout" in result.stdout
+    assert b"Check the logs" in result.stdout


### PR DESCRIPTION
## Problem

The richer deploy failures from [isolate-cloud#8647](https://github.com/fal-ai/isolate-cloud/pull/8647) are multi-line and long, and `rich` soft-wraps them to the terminal width. `_print_error` printed the whole thing with a single `console.print(f"{cross} {msg}")`, so every wrapped/continuation line fell back to **column 0** — the same column as `Building environment...` and the shell prompt. The reason and the logs link stop looking like part of the error and read as unrelated stray output.

## Change

Render the message through a `rich.Text` and print it with a **hanging indent**: the cross leads the first visual line, and every continuation line — explicit newlines and, on a terminal, wraps — carries a 2-space gutter. The failure reads as one coherent block anchored to the `✘`. Single-line errors are unchanged.

Three things fall out of moving off plain-string printing, and each is deliberate:

| Concern | Handling |
| --- | --- |
| Long log URLs must stay copy-pasteable and `grep`-able | Wrap **only** when `console.is_terminal`; build the `Text` with `overflow="ignore"` so an over-long token never folds mid-URL |
| `console.print(str)` applies `ReprHighlighter`; `console.print(Text)` does not | Re-apply it, guarded on `console._highlight` |
| Server-controlled text must not be parsed as rich markup | Compose `Text` objects instead of `Text.from_markup` over the message |

## Before / after

All output below is real — produced by executing the old and new `_print_error` against a fixed 80-column `rich.Console`, not hand-drawn. `·` marks a space where trailing whitespace is the point.

### 1. Hanging indent (vs `main`), 80-column terminal

**Before** — reason, `Check the logs:`, and the wrapped URL all collapse to column 0 and blend into surrounding output:

```text
Building environment...
✓ Build complete
Setting up runtime...
✘ New revision did not become ready within the startup timeout — the runner
never passed its health check (often a setup() failure or a crash-looping
runner).
Check the logs:
https://fal.ai/dashboard/logs?app=fail-app&revisionId=2bbb8365-80ea-4544-a76b-dc
13c4e17fa6
$
```

**After** — the whole failure hangs under the `✘`, and the logs link survives as one token:

```text
Building environment...
✓ Build complete
Setting up runtime...
✘ New revision did not become ready within the startup timeout — the runner
  never passed its health check (often a setup() failure or a crash-looping
  runner).
  Check the logs:
  https://fal.ai/dashboard/logs?app=fail-app&revisionId=2bbb8365-80ea-4544-a76b-dc13c4e17fa6
$
```

### 2. Piped output — `fal deploy | tee`, CI logs, redirects

Not a terminal, so `rich` falls back to 80 columns. An earlier revision of this PR wrapped unconditionally and folded a real `\n` into the middle of the URL — not clickable, and a single-line `grep revisionId=` over the CI log missed it. Now the indent is applied at explicit newlines only:

```text
✘ New revision did not become ready within the startup timeout — the runner never passed its health check (often a setup() failure or a crash-looping runner).
  Check the logs: https://fal.ai/dashboard/logs?app=fail-app&revisionId=2bbb8365-80ea-4544-a76b-dc13c4e17fa6
```

### 3. Whitespace fidelity

`Text.wrap` only strips whitespace *beyond* the wrap width, and a gutter prepended unconditionally turns blank lines into two spaces. Both show up in captured CI logs and exact-match greps.

| | Blank line + trailing newline | Word-break space before a wrap |
| --- | --- | --- |
| **Before** | <pre>✘·reason<br>··<br>··detail<br>··</pre> | <pre>✘·Check·the·logs:·<br>··https://…</pre> |
| **After** | <pre>✘·reason<br><br>··detail<br></pre> | <pre>✘·Check·the·logs:<br>··https://…</pre> |

### 4. Brackets in a server message are literal (vs `main`)

`exc.details()` and `str(exc)` are server-controlled, so bracket tokens reach `_print_error` in practice:

| Input | `main` | This PR |
| --- | --- | --- |
| `invalid argument [expected int] got str` | `✘ invalid argument  got str` — token silently eaten | `✘ invalid argument [expected int] got str` |
| `KeyError: [/red] unmatched` | raises `MarkupError` **from inside `main()`'s except handler** | `✘ KeyError: [/red] unmatched` |

## The code

```python
def _print_error(msg):
    # Print with a hanging indent: the cross leads the first line, continuation
    # lines are indented 2 columns. Multi-line deploy failures (a reason + a
    # "Check the logs: <url>" pointer) then read as one block instead of
    # collapsing to column 0 and blending into surrounding terminal output.
    from rich.text import Text

    # overflow="ignore" keeps a token longer than the wrap width — a logs URL
    # with a UUID revision id is ~116 chars — on one line instead of folding it
    # mid-token, so it stays clickable and copy-pasteable. (Text.wrap only
    # short-circuits wrapping entirely when "ignore" arrives as its *argument*,
    # not as the Text's own attribute, so word wrapping still happens here.)
    text = Text(str(msg), overflow="ignore")
    # Building a Text bypasses the ReprHighlighter that console.print(str) applies,
    # so re-apply it to keep URLs / numbers / paths styled (e.g. the logs link).
    # `_highlight` is rich's record of the `highlight=` constructor flag; checking
    # `console.highlighter` instead would be a no-op guard, since rich coerces a
    # `highlighter=None` into a NullHighlighter instance.
    if console._highlight:
        text = console.highlighter(text)

    if console.is_terminal:
        # The terminal soft-wraps continuation lines back to column 0, so wrap
        # here instead to keep them under the hanging indent.
        lines = text.wrap(console, max(console.width - 2, 1))
    else:
        # Redirected output (pipes, CI logs, files) has no visual width to wrap
        # to, and rich would fall back to 80 columns. Indent at the explicit
        # newlines only, so a single-line grep over a CI log still matches.
        lines = text.split(allow_blank=True)

    for i, line in enumerate(lines):
        gutter = f"{get_cross_icon(console)} " if i == 0 else "  "
        rendered = Text.from_markup(gutter) + line
        # Blank lines in the message would otherwise render as two spaces of
        # gutter, and `Text.wrap` only strips whitespace *beyond* the wrap width,
        # so a word-break space can survive at the end of a wrapped line.
        rendered.rstrip()
        # Already wrapped above; stop the console from wrapping or cropping again.
        console.print(rendered, soft_wrap=True)
```

## How to test

**End to end.** This renders whatever the server sends, so the fastest check is to call it directly with the message [isolate-cloud#8647](https://github.com/fal-ai/isolate-cloud/pull/8647) emits — once on a terminal, once piped:

```bash
MSG='New revision did not become ready within the startup timeout — the runner never passed its health check (often a setup() failure or a crash-looping runner).
Check the logs: https://fal.ai/dashboard/logs?app=fail-app&revisionId=2bbb8365-80ea-4544-a76b-dc13c4e17fa6'

python -c "import os,sys; from fal.cli.main import _print_error; _print_error(os.environ['MSG'])"
python -c "import os,sys; from fal.cli.main import _print_error; _print_error(os.environ['MSG'])" | cat -A
```

Expect the hanging indent in both, and the URL intact on a single physical line in the piped run. Against a real deploy: `fal deploy ... 2>&1 | tee /tmp/deploy.log` on an app that fails its health check, then `grep -c 'revisionId=' /tmp/deploy.log` — must be `1`, and the matched line must end in the full revision id.

**Automated.**

```bash
pytest projects/fal/tests/unit/cli/test_main.py           # 14 passed
pytest projects/fal/tests/unit/cli                        # 244 passed
ruff check projects/fal/src/fal/cli/main.py projects/fal/tests/unit/cli/test_main.py
ruff format --check projects/fal/src/fal/cli/main.py projects/fal/tests/unit/cli/test_main.py
```

**Verified in this session** (Python 3.12, rich 14.3.4):

- All four before/after sections above, by executing both implementations.
- `pytest projects/fal/tests/unit/cli` — 244 passed; `test_main.py` — 14 passed.
- Environment hardening the tests now survive, both reproducibly red before the change: `PYTHONIOENCODING=cp1252 pytest -s …` (4 failures, from rich deriving `ascii_only` off pytest's capture stream) and `COLUMNS=20 pytest …` (1 failure, from a leaked narrow width splitting an asserted phrase).
- Mutation-checked that each new assertion has teeth — removing the `is_terminal` branch, the `overflow="ignore"`, the `rstrip()`, or the `Text` composition each turns a specific new test red, and nothing else covers them.
- `ruff check` reports the same 10 pre-existing `PLC0415` findings before and after; `ruff format --check` clean.

**Not verified.** No end-to-end run against a real failing deploy — the message this targets requires [isolate-cloud#8647](https://github.com/fal-ai/isolate-cloud/pull/8647) deployed, and the e2e/integration CI jobs on this repo fail on `main` for unrelated credential reasons. The rendering is exercised through the real `_print_error` with the exact server message instead, plus a subprocess test that crosses the real stdout-encoding boundary under `PYTHONIOENCODING=cp1252`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation change to error printing with extensive unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Reworks **`_print_error`** so multi-line deploy failures (reason + logs URL) read as one block under the `✘`, instead of continuation lines snapping to column 0.
> 
> Rendering goes through **`rich.Text`**: terminals get word-wrap with a 2-space hanging indent; piped/CI output only indents at explicit newlines so long **`revisionId`** URLs stay on one line for copy/grep. **`overflow="ignore"`** avoids mid-URL breaks; **`ReprHighlighter`** is re-applied for URLs; messages are composed as plain **`Text`** so server strings with `[brackets]` are not parsed as markup.
> 
> Adds broad unit coverage in **`test_main.py`** (wrap/indent, piped URLs, blank lines, trailing whitespace, markup, highlighting, cp1252 subprocess) plus a **`main()`** test that surfaces gRPC deploy failure **`details()`** through **`_print_error`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7376cd675d2d5ef68e72033dc082bb9c7c5352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->