### PR TITLE
fix(secrets): preserve default_exposed on fal secrets set

### DIFF
--- a/projects/fal/src/fal/cli/secrets.py
+++ b/projects/fal/src/fal/cli/secrets.py
@@ -10,7 +10,7 @@ def _set(args):
             name,
             value,
             environment_name=args.env,
-            default_exposed=not args.not_exposed_by_default,
+            default_exposed=args.default_exposed,
         )
 
 
@@ -32,12 +32,29 @@ def _add_set_parser(subparsers, parents):
         action=DictAction,
         help="Secret NAME=VALUE pairs.",
     )
-    parser.add_argument(
+    # Tri-state, matching the API: None leaves the exposure alone (the account
+    # default decides for a new secret, and an existing secret keeps whatever it
+    # was set to), so a plain value rotation never changes exposure.
+    exposure = parser.add_mutually_exclusive_group()
+    exposure.add_argument(
         "--not-exposed-by-default",
-        action="store_true",
+        dest="default_exposed",
+        action="store_const",
+        const=False,
+        default=None,
         help=(
             "Do not expose the secret to apps by default; it is only "
             "injected into apps that explicitly list it in their secrets."
+        ),
+    )
+    exposure.add_argument(
+        "--exposed-by-default",
+        dest="default_exposed",
+        action="store_const",
+        const=True,
+        help=(
+            "Expose the secret to apps that do not explicitly list their "
+            "secrets. Overrides the account-level default."
         ),
     )
     add_env_argument(parser)

--- a/projects/fal/tests/unit/cli/test_secrets.py
+++ b/projects/fal/tests/unit/cli/test_secrets.py
@@ -1,6 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from fal.cli.main import parse_args
+from fal.cli.parser import FalParserExit
 from fal.cli.secrets import _list, _set, _unset
 
 
@@ -8,14 +11,82 @@ def test_set():
     args = parse_args(["secrets", "set", "secret1=value1", "secret2=value2"])
     assert args.func == _set
     assert args.secrets == {"secret1": "value1", "secret2": "value2"}
-    assert args.not_exposed_by_default is False
+    assert args.default_exposed is None
 
 
 def test_set_not_exposed_by_default():
     args = parse_args(["secrets", "set", "secret1=value1", "--not-exposed-by-default"])
     assert args.func == _set
     assert args.secrets == {"secret1": "value1"}
-    assert args.not_exposed_by_default is True
+    assert args.default_exposed is False
+
+
+def test_set_exposed_by_default():
+    args = parse_args(["secrets", "set", "secret1=value1", "--exposed-by-default"])
+    assert args.func == _set
+    assert args.secrets == {"secret1": "value1"}
+    assert args.default_exposed is True
+
+
+def test_set_exposure_flags_are_mutually_exclusive():
+    with pytest.raises(FalParserExit):
+        parse_args(
+            [
+                "secrets",
+                "set",
+                "secret1=value1",
+                "--not-exposed-by-default",
+                "--exposed-by-default",
+            ]
+        )
+
+
+@patch("fal.cli.secrets.SyncServerlessClient")
+def test_set_forwards_no_exposure_opinion(mock_client_cls):
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    args = parse_args(["secrets", "set", "secret1=value1"])
+    args.func(args)
+
+    # A plain rotation must leave the exposure alone, so the API sees None rather
+    # than an explicit True that would reset a per-secret opt-out.
+    assert client.secrets.set.call_args.kwargs["default_exposed"] is None
+
+
+@patch("fal.cli.secrets.SyncServerlessClient")
+def test_set_forwards_not_exposed_by_default(mock_client_cls):
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    args = parse_args(["secrets", "set", "secret1=value1", "--not-exposed-by-default"])
+    args.func(args)
+
+    assert client.secrets.set.call_args.kwargs["default_exposed"] is False
+
+
+@patch("fal.cli.secrets.SyncServerlessClient")
+def test_set_forwards_exposed_by_default(mock_client_cls):
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    args = parse_args(["secrets", "set", "secret1=value1", "--exposed-by-default"])
+    args.func(args)
+
+    assert client.secrets.set.call_args.kwargs["default_exposed"] is True
+
+
+@patch("fal.cli.secrets.SyncServerlessClient")
+def test_set_forwards_exposure_for_every_pair(mock_client_cls):
+    client = MagicMock()
+    mock_client_cls.return_value = client
+    args = parse_args(["secrets", "set", "secret1=value1", "secret2=value2"])
+    args.func(args)
+
+    assert client.secrets.set.call_count == 2
+    assert [call.args[0] for call in client.secrets.set.call_args_list] == [
+        "secret1",
+        "secret2",
+    ]
+    for call in client.secrets.set.call_args_list:
+        assert call.kwargs["default_exposed"] is None
 
 
 def test_set_with_env():


### PR DESCRIPTION
## Problem

`fal secrets set NAME=VALUE` always sent an explicit `default_exposed`, so using it to rotate a value also reset the secret's exposure setting.

`--not-exposed-by-default` was a bare `store_true`, so `args.not_exposed_by_default` is `False` whenever the flag is absent, and `_set` computed:

```python
# projects/fal/src/fal/cli/secrets.py:13 (before)
default_exposed=not args.not_exposed_by_default,
```

Since `not <bool>` is always a bool, the CLI structurally could never send `None`. But `None` is what the API means by "no opinion", per the docstring on `SecretsClient.set` in `projects/fal/src/fal/api/client.py`:

> `default_exposed`: Whether the secret is exposed to apps that do not explicitly list their secrets. None keeps the account-level default (and preserves the current setting on updates).

So the sequence below did not do what it looks like it does. The second command silently undid the first, putting the secret back to being injected into apps that do not list their own `secrets=[...]`:

```console
$ fal secrets set HF_TOKEN=hf_old --not-exposed-by-default   # opt out
$ fal secrets set HF_TOKEN=hf_new                            # rotate the value... and re-expose it
```

## Fix

Make the exposure flags a tri-state that matches the API:

| invocation | value sent |
| --- | --- |
| `fal secrets set A=b` | `None` (leave exposure alone) |
| `fal secrets set A=b --not-exposed-by-default` | `False` |
| `fal secrets set A=b --exposed-by-default` | `True` (new flag) |

Both flags share `dest="default_exposed"` with `default=None` in a mutually exclusive group, so the existing `--not-exposed-by-default` flag name keeps working unchanged.

Two notes on the approach:

- `argparse.BooleanOptionalAction` would be tidier, but it needs Python 3.9 and this package declares `requires-python = ">=3.8"`. It would also rename the existing flag.
- `--exposed-by-default` is new and necessary rather than just convenient: a bare `set` no longer implies `True`, so without it there would be no way to opt a secret back in from the CLI.

`fal secrets list` already renders the third state as `account default` when the value is `None`, so this makes the write side able to express what the read side could already display.

## Behavior change

Creating a **new** secret via the CLI now sends `None` instead of `True`, which means the account-level default decides rather than the CLI pinning the secret to exposed.

For accounts using the default setting this is equivalent and nothing changes. For an account whose default has been set to not-exposed, newly created secrets are no longer exposed to apps that do not list them, which is the intended meaning of that setting but is a change in observable behavior. Those apps can either declare `secrets=[...]` or the secret can be created with `--exposed-by-default`.

## Test plan

The args-to-API translation at `cli/secrets.py:13` had no coverage: the existing tests asserted only the parsed argparse Namespace, never what reached `client.secrets.set`. That gap is how this got through in #1103. This PR adds tests that assert the forwarded value.

- `pre-commit run --files projects/fal/src/fal/cli/secrets.py projects/fal/tests/unit/cli/test_secrets.py`: all hooks pass (ruff-format, ruff, mypy).
- `uv run --extra dev python -m pytest tests/unit/cli/`: **6 failed, 224 passed** on this branch, versus **6 failed, 218 passed** on a pristine `origin/main` worktree. The 6 failures are pre-existing in `test_deploy.py` and unrelated to this change, so the delta is exactly the 6 new tests.
- `fal secrets set --help` renders the pair as `[--not-exposed-by-default | --exposed-by-default]`, and passing both errors with `argument --exposed-by-default: not allowed with argument --not-exposed-by-default`.

Not run: integration and e2e tests, per `AGENTS.md`, since credentials are not available here. This change was not exercised end to end against a live backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
