### PR TITLE
feat: add `--message` and `--annotation` options to `fal deploy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ venv
 
 .DS_Store
 .vscode
+
+# uv auto-generates lockfiles on `uv run`; only tools/uv.lock is committed.
+projects/*/uv.lock

--- a/projects/fal/src/fal/api/client.py
+++ b/projects/fal/src/fal/api/client.py
@@ -412,6 +412,8 @@ class SyncServerlessClient:
             auth: Authentication mode ("private" | "public").
             strategy: Deployment strategy ("recreate" | "rolling").
             reset_scale: If False, use previous scaling settings.
+            message: Freeform message to attach to this revision
+            annotations: Custom string key/value pairs to attach to this revision
             result_handler: Optional ``ResultHandler`` to observe streamed
                 build/deploy events. Defaults to the ``fal.api`` register
                 default (forwards logs to stdout).

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -24,6 +24,63 @@ from typing import cast
 
 User = namedtuple("User", ["user_id", "username"])
 
+# Guardrails for per-revision deploy metadata (message + annotations).
+MAX_DEPLOY_MESSAGE_LENGTH = 2048
+MAX_ANNOTATION_COUNT = 32
+MAX_ANNOTATION_KEY_LENGTH = 64
+MAX_ANNOTATIONS_TOTAL_BYTES = 16384
+
+# Keys that would collide with internal metadata stored in the same blob.
+RESERVED_ANNOTATION_KEYS = frozenset({"openapi", "message", "annotations"})
+
+
+def _validate_deploy_message(message: str | None) -> None:
+    if message is None:
+        return
+    if not isinstance(message, str):
+        raise ValueError("Deploy message must be a string.")
+    if len(message) > MAX_DEPLOY_MESSAGE_LENGTH:
+        raise ValueError(
+            f"Deploy message is too long ({len(message)} characters); "
+            f"the maximum is {MAX_DEPLOY_MESSAGE_LENGTH}."
+        )
+
+
+def _validate_deploy_annotations(annotations: dict[str, str] | None) -> None:
+    if annotations is None:
+        return
+    if not isinstance(annotations, dict):
+        raise ValueError(
+            "Deploy annotations must be a dict of string keys and string values."
+        )
+    if len(annotations) > MAX_ANNOTATION_COUNT:
+        raise ValueError(
+            f"Too many annotations ({len(annotations)}); "
+            f"the maximum is {MAX_ANNOTATION_COUNT}."
+        )
+    for key, value in annotations.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("Annotation keys must be non-empty strings.")
+        if len(key) > MAX_ANNOTATION_KEY_LENGTH:
+            raise ValueError(
+                f"Annotation key '{key[:MAX_ANNOTATION_KEY_LENGTH]}…' is too long "
+                f"({len(key)} characters); the maximum is "
+                f"{MAX_ANNOTATION_KEY_LENGTH}."
+            )
+        if key in RESERVED_ANNOTATION_KEYS:
+            raise ValueError(f"'{key}' is a reserved annotation key.")
+        if not isinstance(value, str):
+            raise ValueError(
+                f"Annotation '{key}' has a {type(value).__name__} value; "
+                "annotation values must be strings."
+            )
+    total_bytes = len(json.dumps(annotations).encode("utf-8"))
+    if total_bytes > MAX_ANNOTATIONS_TOTAL_BYTES:
+        raise ValueError(
+            f"Annotations are too large ({total_bytes} bytes serialized); "
+            f"the maximum is {MAX_ANNOTATIONS_TOTAL_BYTES} bytes."
+        )
+
 
 @dataclass
 class DeploymentResult:
@@ -115,9 +172,14 @@ def _resolve_deployment_reference(
     strategy: DeploymentStrategyLiteral = "rolling",
     reset_scale: bool = False,
     attach_to_deployment: bool | None = None,
+    message: str | None = None,
+    annotations: dict[str, str] | None = None,
 ) -> tuple[tuple[str | None, str | None], AppData]:
     from fal.cli._utils import AppData, get_app_data_from_toml, is_app_name
     from fal.cli.parser import RefAction
+
+    _validate_deploy_message(message)
+    _validate_deploy_annotations(annotations)
 
     if isinstance(app_ref, tuple):
         app_ref_tuple = app_ref
@@ -132,6 +194,8 @@ def _resolve_deployment_reference(
         reset_scale=cast(bool, reset_scale),
         attach_to_deployment=attach_to_deployment,
         name=app_name,
+        message=message,
+        annotations=annotations,
     )
 
     app_ref_candidate = cast("tuple[str, str | None]", app_ref_tuple)
@@ -142,7 +206,9 @@ def _resolve_deployment_reference(
         resolved_app_name, _unused_func_name = app_ref_candidate
         assert resolved_app_name is not None
 
+        # message/annotations are per-deploy, never from pyproject.toml
         app_data = get_app_data_from_toml(resolved_app_name)
+        app_data = replace(app_data, message=message, annotations=annotations)
         if attach_to_deployment is not None:
             app_data = replace(app_data, attach_to_deployment=attach_to_deployment)
         if app_data.python_entry_point is not None or app_data.ref is None:
@@ -287,13 +353,22 @@ def _execute_loaded_deployment(
 
     isolated_function.fetch_metadata(build_environment=False)
 
+    # Base metadata blob from the function (e.g. the openapi spec), plus the
+    # user-facing per-revision message/annotations. Copy so we never mutate
+    # the dict cached on the function's options.
+    metadata = dict(isolated_function.build_metadata())
+    if app_data.message is not None:
+        metadata["message"] = app_data.message
+    if app_data.annotations:
+        metadata["annotations"] = dict(app_data.annotations)
+
     result = host.register(
         func=isolated_function.func,
         options=isolated_function.options,
         application_name=loaded.app_name,
         application_auth_mode=loaded.app_auth,  # type: ignore
         source_code=loaded.source_code,
-        metadata=isolated_function.build_metadata(),
+        metadata=metadata,
         deployment_strategy=strategy,
         scale=app_data.reset_scale,
         attach_to_deployment=app_data.attach_to_deployment,
@@ -347,6 +422,8 @@ def prepare_deployment(
     attach_to_deployment: bool | None = None,
     force_env_build: bool = False,
     environment_name: str | None = None,
+    message: str | None = None,
+    annotations: dict[str, str] | None = None,
 ) -> PreparedDeployment:
     resolved_app_ref, app_data = _resolve_deployment_reference(
         app_ref,
@@ -355,6 +432,8 @@ def prepare_deployment(
         strategy=strategy,
         reset_scale=reset_scale,
         attach_to_deployment=attach_to_deployment,
+        message=message,
+        annotations=annotations,
     )
     return _prepare_deployment_from_reference(
         client,
@@ -397,6 +476,8 @@ def deploy(
     environment_name: str | None = None,
     result_handler: ResultHandler | None = None,
     build_result_handler: ResultHandler | None = None,
+    message: str | None = None,
+    annotations: dict[str, str] | None = None,
 ) -> DeploymentResult:
     resolved_app_ref, app_data = _resolve_deployment_reference(
         app_ref,
@@ -405,6 +486,8 @@ def deploy(
         strategy=strategy,
         reset_scale=reset_scale,
         attach_to_deployment=attach_to_deployment,
+        message=message,
+        annotations=annotations,
     )
     return _deploy_from_reference(
         client,

--- a/projects/fal/src/fal/api/deploy.py
+++ b/projects/fal/src/fal/api/deploy.py
@@ -63,7 +63,7 @@ def _validate_deploy_annotations(annotations: dict[str, str] | None) -> None:
             raise ValueError("Annotation keys must be non-empty strings.")
         if len(key) > MAX_ANNOTATION_KEY_LENGTH:
             raise ValueError(
-                f"Annotation key '{key[:MAX_ANNOTATION_KEY_LENGTH]}…' is too long "
+                f"Annotation key '{key[:MAX_ANNOTATION_KEY_LENGTH]}...' is too long "
                 f"({len(key)} characters); the maximum is "
                 f"{MAX_ANNOTATION_KEY_LENGTH}."
             )
@@ -74,7 +74,8 @@ def _validate_deploy_annotations(annotations: dict[str, str] | None) -> None:
                 f"Annotation '{key}' has a {type(value).__name__} value; "
                 "annotation values must be strings."
             )
-    total_bytes = len(json.dumps(annotations).encode("utf-8"))
+    # ensure_ascii=False so non-ASCII content is measured at its real UTF-8 size
+    total_bytes = len(json.dumps(annotations, ensure_ascii=False).encode("utf-8"))
     if total_bytes > MAX_ANNOTATIONS_TOTAL_BYTES:
         raise ValueError(
             f"Annotations are too large ({total_bytes} bytes serialized); "

--- a/projects/fal/src/fal/cli/_utils.py
+++ b/projects/fal/src/fal/cli/_utils.py
@@ -37,6 +37,8 @@ class AppData:
     team: Optional[str] = None
     name: Optional[str] = None
     options: Options = field(default_factory=Options)
+    message: Optional[str] = None
+    annotations: Optional[dict[str, str]] = None
 
 
 def get_client(host: str, team: str | None = None):

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -16,6 +16,26 @@ from .deploy_check import (
 from .parser import FalClientParser, RefAction, add_env_argument, get_output_parser
 
 
+def _parse_annotation(value: str) -> tuple[str, str]:
+    key, sep, val = value.partition("=")
+    if not sep or not key:
+        raise argparse.ArgumentTypeError(
+            f"invalid annotation {value!r}; expected KEY=VALUE"
+        )
+    return key, val
+
+
+def _annotations_from_args(args) -> dict[str, str] | None:
+    if not args.annotation:
+        return None
+    annotations: dict[str, str] = {}
+    for key, value in args.annotation:
+        if key in annotations:
+            raise ValueError(f"Duplicate annotation key '{key}'.")
+        annotations[key] = value
+    return annotations
+
+
 def _deploy(args):
     from ._result_handlers import (
         CliBuildEnvironmentResultHandler,
@@ -24,6 +44,7 @@ def _deploy(args):
     )
 
     team, app_ref = _resolve_team_and_app_ref(args)
+    annotations = _annotations_from_args(args)
 
     # Handle deprecated --force-env-build flag
     if args.force_env_build:
@@ -50,6 +71,8 @@ def _deploy(args):
             result_handler=result_handler,
             build_result_handler=build_result_handler,
             prepare_options_handler=prepare_options_handler,
+            message=args.message,
+            annotations=annotations,
         )
     else:
         from fal.api import deploy as deploy_api
@@ -64,6 +87,8 @@ def _deploy(args):
             attach_to_deployment=args.attach_to_deployment,
             force_env_build=no_cache,
             environment_name=args.env,
+            message=args.message,
+            annotations=annotations,
         )
         app_name = prepared.loaded.app_name
         run_hint = run_command_hint(app_ref, app_name, args.env)
@@ -213,6 +238,8 @@ def add_parser(main_subparsers, parents):
         "  fal deploy path/to/myfile.py::MyApp --app-name myapp --auth public\n"
         "  fal deploy my-app\n"
         "  fal deploy my-app --attach\n"
+        '  fal deploy my-app --message "a1b2c3d fix cold-start"\n'
+        "  fal deploy my-app --annotation DEPLOYER_ID=foo-123 --annotation GIT_SHA=1234567890\n"
     )
 
     parser = main_subparsers.add_parser(
@@ -306,6 +333,22 @@ def add_parser(main_subparsers, parents):
         help=(
             "Skip interactive deploy confirmation prompts. "
             "When combined with --check, the summary is still shown."
+        ),
+    )
+    parser.add_argument(
+        "--message",
+        help=(
+            "Freeform message to attach to this revision (e.g, 'add feature')"
+        ),
+    )
+    parser.add_argument(
+        "--annotation",
+        action="append",
+        type=_parse_annotation,
+        metavar="KEY=VALUE",
+        help=(
+            "Custom key=value pair to attach to this revision (e.g, "
+            "GIT_SHA=1234567890). Can be repeated. Value must be a string."
         ),
     )
     parser.add_argument(

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -239,7 +239,8 @@ def add_parser(main_subparsers, parents):
         "  fal deploy my-app\n"
         "  fal deploy my-app --attach\n"
         '  fal deploy my-app --message "a1b2c3d fix cold-start"\n'
-        "  fal deploy my-app --annotation DEPLOYER_ID=foo-123 --annotation GIT_SHA=1234567890\n"
+        "  fal deploy my-app --annotation DEPLOYER_ID=foo-123 "
+        "--annotation GIT_SHA=1234567890\n"
     )
 
     parser = main_subparsers.add_parser(
@@ -337,9 +338,7 @@ def add_parser(main_subparsers, parents):
     )
     parser.add_argument(
         "--message",
-        help=(
-            "Freeform message to attach to this revision (e.g, 'add feature')"
-        ),
+        help=("Freeform message to attach to this revision (e.g, 'add feature')"),
     )
     parser.add_argument(
         "--annotation",

--- a/projects/fal/src/fal/cli/deploy_check.py
+++ b/projects/fal/src/fal/cli/deploy_check.py
@@ -111,6 +111,8 @@ def deploy_with_check(
     result_handler: ResultHandler | None = None,
     build_result_handler: ResultHandler | None = None,
     prepare_options_handler: ProgressCallback | None = None,
+    message: str | None = None,
+    annotations: dict[str, str] | None = None,
 ) -> DeploymentResult:
     from fal.api import deploy as deploy_api
     from fal.api.deploy import _validate_attach_to_deployment
@@ -125,6 +127,8 @@ def deploy_with_check(
         attach_to_deployment=args.attach_to_deployment,
         force_env_build=force_env_build,
         environment_name=args.env,
+        message=message,
+        annotations=annotations,
     )
     _validate_attach_to_deployment(prepared.app_data)
     production_alias = _get_production_alias(

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -53,6 +53,127 @@ def test_deploy_attach_detach_flags():
     assert default_args.attach_to_deployment is None
 
 
+def test_deploy_message_and_annotation_flags():
+    from fal.cli.deploy import _annotations_from_args
+
+    args = parse_args(
+        [
+            "deploy",
+            "myfile.py::MyApp",
+            "--message",
+            "a1b2c3d fix cold-start",
+            "--annotation",
+            "deployer_id=nflx-123",
+            "--annotation",
+            "build=456",
+        ]
+    )
+    assert args.message == "a1b2c3d fix cold-start"
+    assert _annotations_from_args(args) == {
+        "deployer_id": "nflx-123",
+        "build": "456",
+    }
+
+    default_args = parse_args(["deploy", "myfile.py::MyApp"])
+    assert default_args.message is None
+    assert _annotations_from_args(default_args) is None
+
+
+def test_deploy_annotation_flag_value_with_equals_sign():
+    from fal.cli.deploy import _annotations_from_args
+
+    args = parse_args(["deploy", "myfile.py::MyApp", "--annotation", "query=a=b"])
+    assert _annotations_from_args(args) == {"query": "a=b"}
+
+
+def test_deploy_annotation_flag_rejects_malformed_values():
+    from fal.cli.parser import FalParserExit
+
+    for malformed in ["no-equals-sign", "=empty-key"]:
+        with pytest.raises(FalParserExit):
+            parse_args(["deploy", "myfile.py::MyApp", "--annotation", malformed])
+
+
+def test_deploy_annotation_flag_rejects_duplicate_keys():
+    from fal.cli.deploy import _annotations_from_args
+
+    args = parse_args(
+        [
+            "deploy",
+            "myfile.py::MyApp",
+            "--annotation",
+            "build=1",
+            "--annotation",
+            "build=2",
+        ]
+    )
+    with pytest.raises(ValueError, match="Duplicate annotation key 'build'"):
+        _annotations_from_args(args)
+
+
+def test_validate_deploy_message():
+    from fal.api.deploy import (
+        MAX_DEPLOY_MESSAGE_LENGTH,
+        _validate_deploy_message,
+    )
+
+    _validate_deploy_message(None)
+    _validate_deploy_message("a1b2c3d fix cold-start")
+
+    with pytest.raises(ValueError, match="must be a string"):
+        _validate_deploy_message(123)
+    with pytest.raises(ValueError, match="too long"):
+        _validate_deploy_message("x" * (MAX_DEPLOY_MESSAGE_LENGTH + 1))
+
+
+def test_validate_deploy_annotations():
+    from fal.api.deploy import (
+        MAX_ANNOTATION_COUNT,
+        MAX_ANNOTATION_KEY_LENGTH,
+        MAX_ANNOTATIONS_TOTAL_BYTES,
+        _validate_deploy_annotations,
+    )
+
+    _validate_deploy_annotations(None)
+    _validate_deploy_annotations({"deployer_id": "nflx-123"})
+
+    with pytest.raises(ValueError, match="must be a dict"):
+        _validate_deploy_annotations("not-a-dict")
+    with pytest.raises(ValueError, match="Too many annotations"):
+        _validate_deploy_annotations(
+            {f"key-{i}": "v" for i in range(MAX_ANNOTATION_COUNT + 1)}
+        )
+    with pytest.raises(ValueError, match="non-empty strings"):
+        _validate_deploy_annotations({"": "value"})
+    with pytest.raises(ValueError, match="too long"):
+        _validate_deploy_annotations({"k" * (MAX_ANNOTATION_KEY_LENGTH + 1): "v"})
+    with pytest.raises(ValueError, match="reserved annotation key"):
+        _validate_deploy_annotations({"openapi": "v"})
+    with pytest.raises(ValueError, match="values must be strings"):
+        _validate_deploy_annotations({"build": 456})
+    with pytest.raises(ValueError, match="too large"):
+        _validate_deploy_annotations({"blob": "x" * MAX_ANNOTATIONS_TOTAL_BYTES})
+
+
+def test_resolve_deployment_reference_carries_message_and_annotations():
+    from fal.api.deploy import _resolve_deployment_reference
+
+    _, app_data = _resolve_deployment_reference(
+        ("myfile.py", "MyApp"),
+        message="a1b2c3d fix cold-start",
+        annotations={"deployer_id": "nflx-123"},
+    )
+    assert app_data.message == "a1b2c3d fix cold-start"
+    assert app_data.annotations == {"deployer_id": "nflx-123"}
+
+    # Validation happens up front, before any loading or building.
+    with pytest.raises(ValueError, match="reserved annotation key"):
+        _resolve_deployment_reference(
+            ("myfile.py", "MyApp"),
+            annotations={"message": "nope"},
+        )
+
+
 def test_execute_prepared_deployment_reuses_result_handler_for_build_by_default():
     from fal.api.deploy import PreparedDeployment, execute_prepared_deployment
     from fal.sdk import (
@@ -213,6 +334,93 @@ def test_execute_prepared_deployment_forwards_attach_to_deployment():
 
     _, register_kwargs = host.register.call_args
     assert register_kwargs["attach_to_deployment"] is True
+
+
+def _make_prepared_deployment(app_data: AppData, base_metadata: dict):
+    """Prepared deployment with a mocked host, for asserting register() kwargs."""
+    from fal.api.deploy import PreparedDeployment
+    from fal.sdk import (
+        RegisterApplicationResult,
+        RegisterApplicationResultType,
+        ServiceURLs,
+    )
+
+    host = MagicMock()
+    options = Options(
+        environment={"requirements": ["."]},
+        host={"metadata": base_metadata},
+    )
+    isolated_function = IsolatedFunction(
+        host=host,
+        raw_func=lambda: None,
+        options=options,
+        app_name="my-app",
+        app_auth="public",
+    )
+    host.register.return_value = RegisterApplicationResult(
+        result=RegisterApplicationResultType(application_id="app-id"),
+        service_urls=ServiceURLs(
+            playground="https://playground.example",
+            run="https://run.example",
+            queue="https://queue.example",
+            ws="wss://ws.example",
+            log="https://log.example",
+        ),
+    )
+    host.prepare_options.return_value = options
+    prepared = PreparedDeployment(
+        host=host,
+        loaded=SimpleNamespace(
+            function=isolated_function,
+            app_name="my-app",
+            app_auth="public",
+            source_code=None,
+        ),
+        app_data=app_data,
+        display_name="MyApp",
+    )
+    return host, prepared
+
+
+def test_execute_prepared_deployment_merges_message_and_annotations():
+    from fal.api.deploy import execute_prepared_deployment
+
+    base_metadata = {"openapi": {"paths": {}}}
+    host, prepared = _make_prepared_deployment(
+        AppData(
+            deployment_strategy="rolling",
+            message="a1b2c3d fix cold-start",
+            annotations={"deployer_id": "nflx-123", "build": "456"},
+        ),
+        base_metadata,
+    )
+
+    execute_prepared_deployment(prepared)
+
+    _, register_kwargs = host.register.call_args
+    assert register_kwargs["metadata"] == {
+        "openapi": {"paths": {}},
+        "message": "a1b2c3d fix cold-start",
+        "annotations": {"deployer_id": "nflx-123", "build": "456"},
+    }
+    # The blob cached on the function's options must not be mutated.
+    assert base_metadata == {"openapi": {"paths": {}}}
+
+
+def test_execute_prepared_deployment_without_message_or_annotations():
+    from fal.api.deploy import execute_prepared_deployment
+
+    host, prepared = _make_prepared_deployment(
+        AppData(deployment_strategy="rolling"),
+        {"openapi": {"paths": {}}},
+    )
+
+    execute_prepared_deployment(prepared)
+
+    _, register_kwargs = host.register.call_args
+    assert register_kwargs["metadata"] == {"openapi": {"paths": {}}}
+    assert "message" not in register_kwargs["metadata"]
+    assert "annotations" not in register_kwargs["metadata"]
 
 
 def test_execute_prepared_deployment_rejects_attach_with_recreate_strategy():
@@ -408,6 +616,8 @@ def mock_args(
     team: Optional[str] = None,
     no_cache: bool = False,
     env: Optional[str] = None,
+    message: Optional[str] = None,
+    annotation: Optional[list] = None,
 ):
     args = MagicMock()
 
@@ -425,6 +635,8 @@ def mock_args(
     args.yes = False
     args.attach_to_deployment = None
     args.host = "my-host"
+    args.message = message
+    args.annotation = annotation
 
     return args
 

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -154,6 +154,13 @@ def test_validate_deploy_annotations():
     with pytest.raises(ValueError, match="too large"):
         _validate_deploy_annotations({"blob": "x" * MAX_ANNOTATIONS_TOTAL_BYTES})
 
+    # Non-ASCII content is measured at its real UTF-8 size
+    _validate_deploy_annotations(
+        {"blob": "é" * ((MAX_ANNOTATIONS_TOTAL_BYTES // 2) - 10)}
+    )
+    with pytest.raises(ValueError, match="too large"):
+        _validate_deploy_annotations({"blob": "é" * (MAX_ANNOTATIONS_TOTAL_BYTES // 2)})
+
 
 def test_resolve_deployment_reference_carries_message_and_annotations():
     from fal.api.deploy import _resolve_deployment_reference


### PR DESCRIPTION
## Overview

- Add two new flags to `fal deploy`
- `--message`: free form message to attach, similar to `git commit -m `
- `--annotation KEY=VALUE`: optional, repeatable user annotated metadata`--annotation GIT_SHA=a1b2c3d4`

## Testing

- [Backend PR](https://github.com/fal-ai/isolate-cloud/pull/8665) to support this shipped and live in shark
- Created a new deployment, and hit the revision info endpoint to verify that the message and annotations persist

via API
<img width="552" height="521" alt="Screenshot 2026-07-31 at 11 53 08 AM" src="https://github.com/user-attachments/assets/6c0a0a7d-24af-4155-9ad5-099f51e52ffd" />

in UI
<img width="2948" height="998" alt="image" src="https://github.com/user-attachments/assets/44c81afe-6fe8-4a95-bf0d-d33339fa8f54" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive deploy metadata and client-side validation only; deploy behavior is unchanged when flags are omitted.
> 
> **Overview**
> **Deploy** can now attach **per-revision metadata**: a freeform `--message` and repeatable `--annotation KEY=VALUE` flags on `fal deploy`, with the same `message` / `annotations` kwargs on the Python deploy API and `SyncServerlessClient.deploy()`.
> 
> Inputs are validated (length/count/size limits, string-only values, reserved keys like `openapi` / `message` / `annotations`) before load/build. On register, values are merged into the revision metadata blob alongside existing fields (e.g. OpenAPI) without mutating cached function options. For pyproject app-name deploys, message/annotations always come from the CLI/API, not TOML.
> 
> Also ignores `projects/*/uv.lock` in `.gitignore` and adds unit tests for parsing, validation, and `host.register` metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b492d89199a0f7ed5d1edd1dd2fbfd3784a1bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->