### PR TITLE
fix(project): stop process-lifetime lru_cache from serving stale project state

### DIFF
--- a/projects/fal/src/fal/project.py
+++ b/projects/fal/src/fal/project.py
@@ -5,8 +5,16 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Union
 import tomli
 
 
-@lru_cache
 def _load_toml(path: Union[Path, str]) -> Dict[str, Any]:
+    # Keyed on mtime as well as path, so an in-place edit within a live
+    # process is picked up instead of serving a stale parse from an earlier
+    # call. mtime_ns comes from a plain, uncached stat() call, so the check
+    # itself is always fresh.
+    return _load_toml_cached(str(path), Path(path).stat().st_mtime_ns)
+
+
+@lru_cache(maxsize=128)
+def _load_toml_cached(path: str, _mtime_ns: int) -> Dict[str, Any]:
     with open(path, "rb") as f:
         return tomli.load(f)
 
@@ -16,8 +24,7 @@ def _cached_resolve(path: Path) -> Path:
     return path.resolve()
 
 
-@lru_cache
-def find_project_root(srcs: Optional[Sequence[str]]) -> Tuple[Path, str]:
+def find_project_root(srcs: Optional[Sequence[str]] = None) -> Tuple[Path, str]:
     """Return a directory containing .git, or pyproject.toml.
 
     That directory will be a common parent of all files and directories
@@ -31,8 +38,17 @@ def find_project_root(srcs: Optional[Sequence[str]]) -> Tuple[Path, str]:
     project root was discovered.
     """
     if not srcs:
-        srcs = [str(_cached_resolve(Path.cwd()))]
+        # cwd-dependent, so this case cannot be cached on a constant key
+        # (see _find_project_root_cached, which only ever sees resolved srcs)
+        resolved_srcs: Tuple[str, ...] = (str(_cached_resolve(Path.cwd())),)
+    else:
+        resolved_srcs = tuple(srcs)
 
+    return _find_project_root_cached(resolved_srcs)
+
+
+@lru_cache
+def _find_project_root_cached(srcs: Tuple[str, ...]) -> Tuple[Path, str]:
     path_srcs = [_cached_resolve(Path(Path.cwd(), src)) for src in srcs]
 
     # A list of lists of parents for each 'src'. 'src' is included as a

--- a/projects/fal/tests/unit/cli/test_utils.py
+++ b/projects/fal/tests/unit/cli/test_utils.py
@@ -1,0 +1,50 @@
+from fal.cli._utils import get_app_data_from_toml
+
+
+def _write_project(tmp_path, name: str, body: str):
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(body)
+    return project_dir
+
+
+def test_get_app_data_from_toml_does_not_leak_secrets_across_chdir(
+    tmp_path, monkeypatch
+):
+    # Two distinct projects that happen to define an app under the same
+    # name, each with its own secrets and auth mode. A process that deploys
+    # both in sequence (an orchestrator, a notebook, a CI worker) must not
+    # have project B's lookup return project A's secrets just because
+    # project A was resolved first in this process.
+    project_a = _write_project(
+        tmp_path,
+        "project_a",
+        """
+        [tool.fal.apps.my-app]
+        ref = "src/app_a/inference.py::AppA"
+        secrets = ["SECRET_A"]
+        auth = "private"
+        """,
+    )
+    project_b = _write_project(
+        tmp_path,
+        "project_b",
+        """
+        [tool.fal.apps.my-app]
+        ref = "src/app_b/inference.py::AppB"
+        secrets = ["SECRET_B"]
+        auth = "public"
+        """,
+    )
+
+    monkeypatch.chdir(project_a)
+    app_a = get_app_data_from_toml("my-app")
+
+    monkeypatch.chdir(project_b)
+    app_b = get_app_data_from_toml("my-app")
+
+    assert app_a.auth == "private"
+    assert app_a.options.host["secrets"] == ["SECRET_A"]
+
+    assert app_b.auth == "public"
+    assert app_b.options.host["secrets"] == ["SECRET_B"]

--- a/projects/fal/tests/unit/test_project.py
+++ b/projects/fal/tests/unit/test_project.py
@@ -1,0 +1,42 @@
+import os
+
+from fal.project import find_pyproject_toml, parse_pyproject_toml
+
+
+def _write_project(tmp_path, name: str, body: str):
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(body)
+    return project_dir
+
+
+def test_find_pyproject_toml_follows_chdir_within_one_process(tmp_path, monkeypatch):
+    project_a = _write_project(tmp_path, "project_a", '[tool.fal]\nmarker = "a"\n')
+    project_b = _write_project(tmp_path, "project_b", '[tool.fal]\nmarker = "b"\n')
+
+    monkeypatch.chdir(project_a)
+    found_a = find_pyproject_toml()
+
+    monkeypatch.chdir(project_b)
+    found_b = find_pyproject_toml()
+
+    assert found_a == str(project_a / "pyproject.toml")
+    assert found_b == str(project_b / "pyproject.toml")
+
+
+def test_parse_pyproject_toml_observes_in_place_edit(tmp_path):
+    path = tmp_path / "pyproject.toml"
+    path.write_text('[tool.fal]\nmarker = "v1"\n')
+
+    first = parse_pyproject_toml(str(path))
+
+    # Force the mtime forward: some filesystems have coarse mtime
+    # resolution, and a same-second edit must still be observed.
+    new_mtime = path.stat().st_mtime + 1
+    path.write_text('[tool.fal]\nmarker = "v2"\n')
+    os.utime(path, (new_mtime, new_mtime))
+
+    second = parse_pyproject_toml(str(path))
+
+    assert first == {"marker": "v1"}
+    assert second == {"marker": "v2"}


### PR DESCRIPTION
## Summary

Fixes VUL-603. Two separate bugs, both from caching on the wrong key, kept
apart in the commit and here for the same reason.

**Bug 1, cwd-blind discovery (the security-relevant one):**
`find_project_root(None)` cached on the literal `None` key. cwd was only
read inside the function body, so a `chdir` mid-process returned the
previous project's root. Long-lived processes that deploy more than one
project (CI workers, notebooks, orchestrators wrapping the SDK) hit this;
`fal deploy` from a shell does not, each invocation is a fresh process.

Demonstrated directly, not just at the root-discovery level: two projects
each define an app of the same name with different `secrets`/`auth`. After
loading project A's app, `chdir` to project B and requesting the
same-named app returned project A's `secrets`/`auth` instead of project
B's own.

**Bug 2, mtime-blind loading:** `_load_toml(path)` was keyed on path alone,
so an in-place edit within a live process was invisible.

## Fix

- `find_project_root`: the `srcs=None` case is no longer cached on a
  constant key. cwd is resolved fresh on every call; the actual cached work
  moved to `_find_project_root_cached(srcs: Tuple[str, ...])`.
- `_load_toml`: now keyed on `(path, mtime_ns)` via `_load_toml_cached`,
  with an explicit `maxsize=128` since `lru_cache` never evicts on its own.
- `_cached_resolve` is untouched. It is genuinely path-pure, no cwd
  dependence.

No public `clear_cache()` added. That would put the burden on every caller
to know about a bug they cannot see.

## Test plan

- [x] `tests/unit/test_project.py`: `find_pyproject_toml` returns the right
      root after a `chdir` within one process; `parse_pyproject_toml`
      observes an in-place edit within one process (mtime forced forward to
      cover coarse filesystem mtime resolution)
- [x] `tests/unit/cli/test_utils.py`: `get_app_data_from_toml` does not
      leak project A's secrets/auth to project B after a `chdir`. This is
      the regression test that encodes the actual security property.
- [x] Full `tests/unit` suite: 885 passed, 3 skipped (hardware-dependent),
      6 pre-existing failures in `test_deploy.py`, same ones reproduced
      identically on unmodified `main`, unrelated to this diff (also seen
      in #1123)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Corrects a security-relevant cross-project config/secrets leak in long-lived SDK/CLI usage; behavior change is intentional but touches auth and secret resolution paths.
> 
> **Overview**
> Fixes **stale project state** in long-lived processes caused by `lru_cache` keys that ignored **cwd** and **file mtime**.
> 
> **Project discovery:** `find_project_root(None)` no longer caches on a constant `None` key. Each call resolves cwd first, then delegates to new `_find_project_root_cached` keyed on resolved source paths—so a mid-process `chdir` picks up the correct `pyproject.toml` / root instead of the first project touched.
> 
> **TOML loading:** `_load_toml` now includes `mtime_ns` in the cache key via `_load_toml_cached` (`maxsize=128`), so in-place edits to the same path are re-read instead of returning an old parse.
> 
> **Tests:** Unit coverage for `chdir` across two projects, mtime-aware re-parse, and a CLI regression ensuring same-named apps in different projects do not leak **secrets** / **auth** after switching directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b861d9da3e279da83d98db7da90c3f431fc5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->