### PR TITLE
feat(toolkit): declare input video limits via x-fal

### DIFF
--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -11,6 +11,7 @@ from fal.toolkit.constraints import (
     ImageSizeConstraints,
     ImageValidationConfig,
     ImageValidationOptions,
+    VideoNormalization,
     VideoValidationConfig,
     VideoValidationOptions,
     to_xfal,
@@ -60,6 +61,7 @@ __all__ = [
     "KVStore",
     "Video",
     "VideoField",
+    "VideoNormalization",
     "VideoValidationConfig",
     "VideoValidationOptions",
     # Pydantic utilities

--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -11,7 +11,7 @@ from fal.toolkit.constraints import (
     ImageSizeConstraints,
     ImageValidationConfig,
     ImageValidationOptions,
-    VideoNormalization,
+    VideoNormalizationConfig,
     VideoValidationConfig,
     VideoValidationOptions,
     to_xfal,
@@ -61,7 +61,7 @@ __all__ = [
     "KVStore",
     "Video",
     "VideoField",
-    "VideoNormalization",
+    "VideoNormalizationConfig",
     "VideoValidationConfig",
     "VideoValidationOptions",
     # Pydantic utilities

--- a/projects/fal/src/fal/toolkit/__init__.py
+++ b/projects/fal/src/fal/toolkit/__init__.py
@@ -11,6 +11,8 @@ from fal.toolkit.constraints import (
     ImageSizeConstraints,
     ImageValidationConfig,
     ImageValidationOptions,
+    VideoValidationConfig,
+    VideoValidationOptions,
     to_xfal,
 )
 from fal.toolkit.exceptions import (
@@ -58,6 +60,8 @@ __all__ = [
     "KVStore",
     "Video",
     "VideoField",
+    "VideoValidationConfig",
+    "VideoValidationOptions",
     # Pydantic utilities
     "Field",
     "Hidden",

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -22,6 +22,25 @@ def to_xfal(
     }
 
 
+_BOUND_PAIRS = (
+    ("min_width", "max_width"),
+    ("min_height", "max_height"),
+    ("min_area", "max_area"),
+    ("min_frames", "max_frames"),
+    ("min_duration", "max_duration"),
+    ("min_fps", "max_fps"),
+    ("min_aspect_ratio", "max_aspect_ratio"),
+)
+
+
+def _validate_bounds(config: Any) -> None:
+    """Reject a config no input could satisfy. Equal bounds pin an exact value."""
+    for low, high in _BOUND_PAIRS:
+        lower, upper = getattr(config, low, None), getattr(config, high, None)
+        if lower is not None and upper is not None and lower > upper:
+            raise ValueError(f"{low} ({lower}) must not exceed {high} ({upper}).")
+
+
 def _validate_aspect_ratio_pair(
     min_aspect_ratio: Optional[float], max_aspect_ratio: Optional[float]
 ) -> None:
@@ -53,6 +72,7 @@ class ImageSizeConstraints:
     max_aspect_ratio: Optional[float] = None
 
     def __post_init__(self) -> None:
+        _validate_bounds(self)
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
 
 
@@ -84,6 +104,7 @@ class ImageValidationConfig:
     timeout: float = 20.0
 
     def __post_init__(self) -> None:
+        _validate_bounds(self)
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
 
 
@@ -135,6 +156,7 @@ class VideoValidationConfig:
     max_fps: Optional[float] = None
 
     def __post_init__(self) -> None:
+        _validate_bounds(self)
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
 
 
@@ -156,3 +178,6 @@ class VideoNormalizationConfig:
     max_area: Optional[int] = None
     max_duration: Optional[float] = None
     fps: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        _validate_bounds(self)

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -9,7 +9,10 @@ _NON_SCHEMA_FIELDS = {"timeout"}
 
 
 def to_xfal(
-    config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
+    config: ImageSizeConstraints
+    | ImageValidationConfig
+    | VideoValidationConfig
+    | VideoNormalization,
 ) -> dict[str, Any]:
     """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
     return {
@@ -133,3 +136,23 @@ class VideoValidationConfig:
 
     def __post_init__(self) -> None:
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
+
+
+@dataclasses.dataclass(frozen=True)
+class VideoNormalization:
+    """What a model does to an input video it accepts but has to reshape.
+
+    The counterpart to :class:`VideoValidationConfig`: those limits reject a
+    request, these describe a video that is accepted and then rescaled, trimmed
+    or resampled. Declaring both lets a UI block what will fail and merely warn
+    about what will change ("trimmed to 15s"). Areas are per frame, in pixels.
+    """
+
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_area: Optional[int] = None
+    max_area: Optional[int] = None
+    max_duration: Optional[float] = None
+    fps: Optional[float] = None

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -9,7 +9,7 @@ _NON_SCHEMA_FIELDS = {"timeout"}
 
 
 def to_xfal(
-    config: ImageSizeConstraints | ImageValidationConfig,
+    config: ImageSizeConstraints | ImageValidationConfig | VideoValidationConfig,
 ) -> dict[str, Any]:
     """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
     return {
@@ -79,6 +79,57 @@ class ImageValidationConfig:
     min_aspect_ratio: Optional[float] = None
     max_aspect_ratio: Optional[float] = None
     timeout: float = 20.0
+
+    def __post_init__(self) -> None:
+        _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)
+
+
+class VideoValidationOptions(TypedDict, total=False):
+    """Validation options accepted by input-video helpers."""
+
+    max_file_size: Optional[int]
+    min_width: Optional[int]
+    min_height: Optional[int]
+    max_width: Optional[int]
+    max_height: Optional[int]
+    min_area: Optional[int]
+    max_area: Optional[int]
+    min_aspect_ratio: Optional[float]
+    max_aspect_ratio: Optional[float]
+    min_frames: Optional[int]
+    max_frames: Optional[int]
+    min_duration: Optional[float]
+    max_duration: Optional[float]
+    min_fps: Optional[float]
+    max_fps: Optional[float]
+
+
+@dataclasses.dataclass(frozen=True)
+class VideoValidationConfig:
+    """Limits applied to an input video.
+
+    Attach to a video input via :func:`fal.toolkit.VideoField` to surface the
+    limits in the OpenAPI schema (under the ``x-fal`` extension), so clients and
+    UIs can reject a video before uploading it. Areas are per frame, in pixels.
+    These are documentation hints and are not enforced by the SDK. Fetch settings
+    such as the download timeout belong to the downloader, not here.
+    """
+
+    max_file_size: Optional[int] = None
+    min_width: Optional[int] = None
+    min_height: Optional[int] = None
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_area: Optional[int] = None
+    max_area: Optional[int] = None
+    min_aspect_ratio: Optional[float] = None
+    max_aspect_ratio: Optional[float] = None
+    min_frames: Optional[int] = None
+    max_frames: Optional[int] = None
+    min_duration: Optional[float] = None
+    max_duration: Optional[float] = None
+    min_fps: Optional[float] = None
+    max_fps: Optional[float] = None
 
     def __post_init__(self) -> None:
         _validate_aspect_ratio_pair(self.min_aspect_ratio, self.max_aspect_ratio)

--- a/projects/fal/src/fal/toolkit/constraints.py
+++ b/projects/fal/src/fal/toolkit/constraints.py
@@ -12,7 +12,7 @@ def to_xfal(
     config: ImageSizeConstraints
     | ImageValidationConfig
     | VideoValidationConfig
-    | VideoNormalization,
+    | VideoNormalizationConfig,
 ) -> dict[str, Any]:
     """Return a config's set (non-None) limits as the ``x-fal`` schema payload."""
     return {
@@ -139,7 +139,7 @@ class VideoValidationConfig:
 
 
 @dataclasses.dataclass(frozen=True)
-class VideoNormalization:
+class VideoNormalizationConfig:
     """What a model does to an input video it accepts but has to reshape.
 
     The counterpart to :class:`VideoValidationConfig`: those limits reject a

--- a/projects/fal/src/fal/toolkit/video/video.py
+++ b/projects/fal/src/fal/toolkit/video/video.py
@@ -23,6 +23,7 @@ def _merge_ui(schema: dict, ui: Optional[dict]) -> None:
 def VideoField(
     *args,
     constraints: Optional[VideoValidationConfig] = None,
+    combined_constraints: Optional[VideoValidationConfig] = None,
     normalization: Optional[VideoNormalizationConfig] = None,
     ui: Optional[dict] = None,
     **kwargs,
@@ -32,6 +33,9 @@ def VideoField(
     Pass ``constraints`` for limits that reject a request and ``normalization``
     for reshaping the model applies to videos it accepts; both are emitted under
     the ``x-fal`` schema extension, the latter nested under ``normalization``.
+    On a list of videos, ``constraints`` applies to each one and
+    ``combined_constraints`` to their totals (nested under ``combined``) - only
+    summable limits such as duration, file size and frames mean anything there.
     Pass ``ui`` for UI metadata (e.g. ``{"important": True}``); all other
     arguments are forwarded to ``Field``. ``ui`` is taken as an explicit argument
     (rather than a passthrough kwarg) so it is not dropped when an explicit
@@ -40,6 +44,10 @@ def VideoField(
     xfal: dict = {}
     if constraints is not None:
         xfal.update(to_xfal(constraints))
+    if combined_constraints is not None:
+        combined = to_xfal(combined_constraints)
+        if combined:
+            xfal["combined"] = combined
     if normalization is not None:
         applied = to_xfal(normalization)
         if applied:

--- a/projects/fal/src/fal/toolkit/video/video.py
+++ b/projects/fal/src/fal/toolkit/video/video.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import Field
 
-from fal.toolkit.constraints import VideoValidationConfig, to_xfal
+from fal.toolkit.constraints import VideoNormalization, VideoValidationConfig, to_xfal
 from fal.toolkit.file.file import IS_PYDANTIC_V2, File
 
 
@@ -19,22 +19,29 @@ def _merge_ui(schema: dict, ui: Optional[dict]) -> None:
 def VideoField(
     *args,
     constraints: Optional[VideoValidationConfig] = None,
+    normalization: Optional[VideoNormalization] = None,
     ui: Optional[dict] = None,
     **kwargs,
 ):
     """A ``Field`` for a video input that documents the videos it accepts.
 
-    Pass ``constraints`` to emit the accepted-video limits under the ``x-fal``
-    schema extension, and ``ui`` for UI metadata (e.g. ``{"important": True}``);
-    all other arguments are forwarded to ``Field``. ``ui`` is taken as an explicit
-    argument (rather than a passthrough kwarg) so it is not dropped when an
-    explicit ``json_schema_extra`` is also emitted on Pydantic v2.
+    Pass ``constraints`` for limits that reject a request and ``normalization``
+    for reshaping the model applies to videos it accepts; both are emitted under
+    the ``x-fal`` schema extension, the latter nested under ``normalization``.
+    Pass ``ui`` for UI metadata (e.g. ``{"important": True}``); all other
+    arguments are forwarded to ``Field``. ``ui`` is taken as an explicit argument
+    (rather than a passthrough kwarg) so it is not dropped when an explicit
+    ``json_schema_extra`` is also emitted on Pydantic v2.
     """
-    fal_extra: dict = {}
+    xfal: dict = {}
     if constraints is not None:
-        data = to_xfal(constraints)
-        if data:
-            fal_extra["x-fal"] = data
+        xfal.update(to_xfal(constraints))
+    if normalization is not None:
+        applied = to_xfal(normalization)
+        if applied:
+            xfal["normalization"] = applied
+
+    fal_extra: dict = {"x-fal": xfal} if xfal else {}
 
     if IS_PYDANTIC_V2:
         # Pydantic v2: use json_schema_extra

--- a/projects/fal/src/fal/toolkit/video/video.py
+++ b/projects/fal/src/fal/toolkit/video/video.py
@@ -1,12 +1,41 @@
 from functools import wraps
+from typing import Optional
 
 from pydantic import Field
 
+from fal.toolkit.constraints import VideoValidationConfig, to_xfal
 from fal.toolkit.file.file import IS_PYDANTIC_V2, File
 
 
+def _merge_ui(schema: dict, ui: Optional[dict]) -> None:
+    """Merge caller ``ui`` into a schema dict, defaulting ``ui.field`` to video."""
+    schema_ui = schema.setdefault("ui", {})
+    if ui:
+        schema_ui.update(ui)
+    schema_ui.setdefault("field", "video")
+
+
 @wraps(Field)
-def VideoField(*args, **kwargs):
+def VideoField(
+    *args,
+    constraints: Optional[VideoValidationConfig] = None,
+    ui: Optional[dict] = None,
+    **kwargs,
+):
+    """A ``Field`` for a video input that documents the videos it accepts.
+
+    Pass ``constraints`` to emit the accepted-video limits under the ``x-fal``
+    schema extension, and ``ui`` for UI metadata (e.g. ``{"important": True}``);
+    all other arguments are forwarded to ``Field``. ``ui`` is taken as an explicit
+    argument (rather than a passthrough kwarg) so it is not dropped when an
+    explicit ``json_schema_extra`` is also emitted on Pydantic v2.
+    """
+    fal_extra: dict = {}
+    if constraints is not None:
+        data = to_xfal(constraints)
+        if data:
+            fal_extra["x-fal"] = data
+
     if IS_PYDANTIC_V2:
         # Pydantic v2: use json_schema_extra
         json_schema_extra = kwargs.pop("json_schema_extra", None) or {}
@@ -16,17 +45,20 @@ def VideoField(*args, **kwargs):
 
             def merged_schema_extra(schema):
                 original_func(schema)
-                schema.setdefault("ui", {}).setdefault("field", "video")
+                _merge_ui(schema, ui)
+                schema.update(fal_extra)
 
             kwargs["json_schema_extra"] = merged_schema_extra
         else:
-            json_schema_extra.setdefault("ui", {}).setdefault("field", "video")
+            _merge_ui(json_schema_extra, ui)
+            json_schema_extra.update(fal_extra)
             kwargs["json_schema_extra"] = json_schema_extra
     else:
-        # Pydantic v1: use ui kwarg (stored in extra)
-        ui = kwargs.get("ui", {})
-        ui.setdefault("field", "video")
-        kwargs["ui"] = ui
+        # Pydantic v1: extra kwargs are stored on the field and emitted as-is.
+        merged_ui = dict(ui or {})
+        merged_ui.setdefault("field", "video")
+        kwargs["ui"] = merged_ui
+        kwargs.update(fal_extra)
     return Field(*args, **kwargs)
 
 

--- a/projects/fal/src/fal/toolkit/video/video.py
+++ b/projects/fal/src/fal/toolkit/video/video.py
@@ -3,7 +3,11 @@ from typing import Optional
 
 from pydantic import Field
 
-from fal.toolkit.constraints import VideoNormalization, VideoValidationConfig, to_xfal
+from fal.toolkit.constraints import (
+    VideoNormalizationConfig,
+    VideoValidationConfig,
+    to_xfal,
+)
 from fal.toolkit.file.file import IS_PYDANTIC_V2, File
 
 
@@ -19,7 +23,7 @@ def _merge_ui(schema: dict, ui: Optional[dict]) -> None:
 def VideoField(
     *args,
     constraints: Optional[VideoValidationConfig] = None,
-    normalization: Optional[VideoNormalization] = None,
+    normalization: Optional[VideoNormalizationConfig] = None,
     ui: Optional[dict] = None,
     **kwargs,
 ):

--- a/projects/fal/tests/unit/toolkit/test_constraints.py
+++ b/projects/fal/tests/unit/toolkit/test_constraints.py
@@ -1,0 +1,88 @@
+import pytest
+
+from fal.toolkit import (
+    ImageSizeConstraints,
+    ImageValidationConfig,
+    VideoValidationConfig,
+    to_xfal,
+)
+
+
+class TestToXfal:
+    def test_omits_unset_limits(self):
+        """Only limits the app actually set are emitted."""
+        payload = to_xfal(VideoValidationConfig(max_duration=15.0))
+        assert payload == {"max_duration": 15.0}
+
+    def test_omits_timeout(self):
+        """timeout is a download setting, not a client-checkable limit."""
+        payload = to_xfal(ImageValidationConfig(max_width=2048, timeout=5.0))
+        assert payload == {"max_width": 2048}
+
+    def test_emits_every_video_limit(self):
+        config = VideoValidationConfig(
+            max_file_size=50 * 1024 * 1024,
+            min_width=640,
+            min_height=640,
+            max_width=1112,
+            max_height=1112,
+            min_area=640 * 640,
+            max_area=834 * 1112,
+            min_aspect_ratio=0.4,
+            max_aspect_ratio=2.5,
+            min_frames=24,
+            max_frames=450,
+            min_duration=2.0,
+            max_duration=15.0,
+            min_fps=12.0,
+            max_fps=60.0,
+        )
+        assert to_xfal(config) == {
+            "max_file_size": 52428800,
+            "min_width": 640,
+            "min_height": 640,
+            "max_width": 1112,
+            "max_height": 1112,
+            "min_area": 409600,
+            "max_area": 927408,
+            "min_aspect_ratio": 0.4,
+            "max_aspect_ratio": 2.5,
+            "min_frames": 24,
+            "max_frames": 450,
+            "min_duration": 2.0,
+            "max_duration": 15.0,
+            "min_fps": 12.0,
+            "max_fps": 60.0,
+        }
+
+    def test_empty_config_emits_nothing(self):
+        assert to_xfal(VideoValidationConfig()) == {}
+
+    def test_handles_image_configs(self):
+        assert to_xfal(ImageSizeConstraints(max_width=2048)) == {"max_width": 2048}
+        assert to_xfal(ImageValidationConfig(max_width=2048)) == {"max_width": 2048}
+
+
+class TestVideoValidationConfig:
+    def test_defaults_are_unset(self):
+        config = VideoValidationConfig()
+        assert config.max_duration is None
+        assert config.max_area is None
+
+    def test_carries_only_limits(self):
+        """Fetch/processing settings stay with the downloader, not the config."""
+        fields = set(VideoValidationConfig.__dataclass_fields__)
+        assert not fields & {"timeout", "auto_fix"}
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"min_aspect_ratio": 0.5}, {"max_aspect_ratio": 2.0}],
+    )
+    def test_aspect_ratio_bounds_must_come_in_pairs(self, kwargs):
+        with pytest.raises(ValueError, match="must be provided together"):
+            VideoValidationConfig(**kwargs)
+
+    def test_aspect_ratio_pair_is_accepted(self):
+        config = VideoValidationConfig(min_aspect_ratio=0.5, max_aspect_ratio=2.0)
+        assert config.min_aspect_ratio == 0.5
+        assert config.max_aspect_ratio == 2.0

--- a/projects/fal/tests/unit/toolkit/test_constraints.py
+++ b/projects/fal/tests/unit/toolkit/test_constraints.py
@@ -3,6 +3,7 @@ import pytest
 from fal.toolkit import (
     ImageSizeConstraints,
     ImageValidationConfig,
+    VideoNormalizationConfig,
     VideoValidationConfig,
     to_xfal,
 )
@@ -86,3 +87,35 @@ class TestVideoValidationConfig:
         config = VideoValidationConfig(min_aspect_ratio=0.5, max_aspect_ratio=2.0)
         assert config.min_aspect_ratio == 0.5
         assert config.max_aspect_ratio == 2.0
+
+
+class TestBoundsAreSelfConsistent:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"min_width": 2048, "max_width": 512},
+            {"min_height": 2048, "max_height": 512},
+            {"min_area": 4096, "max_area": 1024},
+            {"min_frames": 300, "max_frames": 24},
+            {"min_duration": 15.0, "max_duration": 2.0},
+            {"min_fps": 60.0, "max_fps": 24.0},
+            {"min_aspect_ratio": 2.5, "max_aspect_ratio": 0.4},
+        ],
+    )
+    def test_a_lower_bound_above_its_upper_bound_is_rejected(self, kwargs):
+        """No input could satisfy these, so fail at declaration, not at serve time."""
+        with pytest.raises(ValueError, match="must not exceed"):
+            VideoValidationConfig(**kwargs)
+
+    def test_equal_bounds_are_allowed(self):
+        """Equal bounds pin an exact value, which is a legitimate declaration."""
+        config = VideoValidationConfig(min_width=1024, max_width=1024)
+        assert config.min_width == config.max_width == 1024
+
+    @pytest.mark.parametrize(
+        "factory",
+        [ImageSizeConstraints, ImageValidationConfig, VideoNormalizationConfig],
+    )
+    def test_every_config_checks_its_bounds(self, factory):
+        with pytest.raises(ValueError, match="must not exceed"):
+            factory(min_width=2048, max_width=512)

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from pydantic import Field
 
+from fal.toolkit.constraints import VideoValidationConfig
 from fal.toolkit.pydantic import (
     IS_PYDANTIC_V2,
     AudioField,
@@ -279,6 +280,54 @@ class TestFieldHelpers:
 
         schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
         assert schema["properties"]["video_input"]["ui"]["field"] == "video"
+
+    def test_video_field_without_constraints_emits_no_xfal(self):
+        """A video input with no declared limits stays free of x-fal."""
+
+        class Model(FalBaseModel):
+            video_input: str = VideoField(default="", description="A video input")
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        assert "x-fal" not in schema["properties"]["video_input"]
+
+    def test_video_field_constraints(self):
+        """VideoField should emit its declared limits under x-fal."""
+
+        class Model(FalBaseModel):
+            video_input: str = VideoField(
+                default="",
+                description="A video input",
+                constraints=VideoValidationConfig(
+                    max_file_size=50 * 1024 * 1024,
+                    max_duration=15.0,
+                    max_area=834 * 1112,
+                ),
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        video_input = schema["properties"]["video_input"]
+        assert video_input["x-fal"] == {
+            "max_file_size": 52428800,
+            "max_duration": 15.0,
+            "max_area": 927408,
+        }
+        assert video_input["ui"]["field"] == "video"
+
+    def test_video_field_constraints_keep_ui(self):
+        """Caller ui survives alongside x-fal, which v2 drops for extra kwargs."""
+
+        class Model(FalBaseModel):
+            video_input: str = VideoField(
+                default="",
+                description="A video input",
+                constraints=VideoValidationConfig(max_duration=15.0),
+                ui={"important": True},
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        video_input = schema["properties"]["video_input"]
+        assert video_input["ui"] == {"important": True, "field": "video"}
+        assert video_input["x-fal"] == {"max_duration": 15.0}
 
     def test_audio_field_init(self):
         """AudioField should initialize and set ui.field = 'audio' in schema."""

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 import pytest
 from pydantic import Field
@@ -333,7 +333,7 @@ class TestFieldHelpers:
         """On a list, per-item limits and list totals stay distinguishable."""
 
         class Model(FalBaseModel):
-            video_urls: list[str] = VideoField(
+            video_urls: List[str] = VideoField(
                 default_factory=list,
                 constraints=VideoValidationConfig(min_duration=2.0),
                 combined_constraints=VideoValidationConfig(max_duration=15.1),

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -329,6 +329,22 @@ class TestFieldHelpers:
             "normalization": {"max_duration": 15.1, "fps": 24},
         }
 
+    def test_video_field_combined_constraints(self):
+        """On a list, per-item limits and list totals stay distinguishable."""
+
+        class Model(FalBaseModel):
+            video_urls: list[str] = VideoField(
+                default_factory=list,
+                constraints=VideoValidationConfig(min_duration=2.0),
+                combined_constraints=VideoValidationConfig(max_duration=15.1),
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        assert schema["properties"]["video_urls"]["x-fal"] == {
+            "min_duration": 2.0,
+            "combined": {"max_duration": 15.1},
+        }
+
     def test_video_field_normalization_only(self):
         """A model that reshapes but never rejects still documents itself."""
 

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import Field
 
-from fal.toolkit.constraints import VideoValidationConfig
+from fal.toolkit.constraints import VideoNormalization, VideoValidationConfig
 from fal.toolkit.pydantic import (
     IS_PYDANTIC_V2,
     AudioField,
@@ -312,6 +312,36 @@ class TestFieldHelpers:
             "max_area": 927408,
         }
         assert video_input["ui"]["field"] == "video"
+
+    def test_video_field_normalization(self):
+        """Reshaping the model applies is nested, not mixed in with the limits."""
+
+        class Model(FalBaseModel):
+            video_input: str = VideoField(
+                default="",
+                constraints=VideoValidationConfig(min_duration=2.0),
+                normalization=VideoNormalization(max_duration=15.1, fps=24),
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        assert schema["properties"]["video_input"]["x-fal"] == {
+            "min_duration": 2.0,
+            "normalization": {"max_duration": 15.1, "fps": 24},
+        }
+
+    def test_video_field_normalization_only(self):
+        """A model that reshapes but never rejects still documents itself."""
+
+        class Model(FalBaseModel):
+            video_input: str = VideoField(
+                default="",
+                normalization=VideoNormalization(max_area=834 * 1112),
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        assert schema["properties"]["video_input"]["x-fal"] == {
+            "normalization": {"max_area": 927408}
+        }
 
     def test_video_field_constraints_keep_ui(self):
         """Caller ui survives alongside x-fal, which v2 drops for extra kwargs."""

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -3,7 +3,10 @@ from typing import Any, List
 import pytest
 from pydantic import Field
 
-from fal.toolkit.constraints import VideoNormalizationConfig, VideoValidationConfig
+from fal.toolkit.constraints import (
+    VideoNormalizationConfig,
+    VideoValidationConfig,
+)
 from fal.toolkit.pydantic import (
     IS_PYDANTIC_V2,
     AudioField,
@@ -343,6 +346,29 @@ class TestFieldHelpers:
         assert schema["properties"]["video_urls"]["x-fal"] == {
             "min_duration": 2.0,
             "combined": {"max_duration": 15.1},
+        }
+
+    def test_video_field_buckets_do_not_collide(self):
+        """One limit can mean three things at once without the buckets leaking.
+
+        Seedance declares max_duration in two buckets at the same value, so a
+        shared dict or an overwrite would go unnoticed. Distinct values here
+        pin each to its own place.
+        """
+
+        class Model(FalBaseModel):
+            video_urls: List[str] = VideoField(
+                default_factory=list,
+                constraints=VideoValidationConfig(max_duration=30.0),
+                combined_constraints=VideoValidationConfig(max_duration=15.1),
+                normalization=VideoNormalizationConfig(max_duration=10.0),
+            )
+
+        schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
+        assert schema["properties"]["video_urls"]["x-fal"] == {
+            "max_duration": 30.0,
+            "combined": {"max_duration": 15.1},
+            "normalization": {"max_duration": 10.0},
         }
 
     def test_video_field_normalization_only(self):

--- a/projects/fal/tests/unit/toolkit/test_pydantic.py
+++ b/projects/fal/tests/unit/toolkit/test_pydantic.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import Field
 
-from fal.toolkit.constraints import VideoNormalization, VideoValidationConfig
+from fal.toolkit.constraints import VideoNormalizationConfig, VideoValidationConfig
 from fal.toolkit.pydantic import (
     IS_PYDANTIC_V2,
     AudioField,
@@ -320,7 +320,7 @@ class TestFieldHelpers:
             video_input: str = VideoField(
                 default="",
                 constraints=VideoValidationConfig(min_duration=2.0),
-                normalization=VideoNormalization(max_duration=15.1, fps=24),
+                normalization=VideoNormalizationConfig(max_duration=15.1, fps=24),
             )
 
         schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()
@@ -335,7 +335,7 @@ class TestFieldHelpers:
         class Model(FalBaseModel):
             video_input: str = VideoField(
                 default="",
-                normalization=VideoNormalization(max_area=834 * 1112),
+                normalization=VideoNormalizationConfig(max_area=834 * 1112),
             )
 
         schema = Model.model_json_schema() if IS_PYDANTIC_V2 else Model.schema()


### PR DESCRIPTION
## Summary

- Add `VideoValidationConfig` + `VideoValidationOptions` for declaring the videos a model accepts: file size, dimensions, per-frame area, aspect ratio, frames, duration, fps (`constraints.py:87`).
- Add `VideoNormalizationConfig` for videos a model accepts and then reshapes - rescales, trims, resamples - so the spec describes the whole contract, not just what gets rejected (`constraints.py:142`).
- On a list of videos, `combined_constraints` declares limits on the totals - the aggregate rule per-item schemas cannot express (`video/video.py:23`).
- `VideoField(constraints=..., combined_constraints=..., normalization=...)` emits all three under the `x-fal` schema extension, the latter two nested under `combined` and `normalization` (`video/video.py:23`).
- Fix: `VideoField(ui=...)` was silently dropped on Pydantic v2. It rode in as a passthrough kwarg, which pydantic discards when `json_schema_extra` is also set - and `VideoField` always sets it. Now an explicit argument, same fix `ImageSizeField` already carries (`video/video.py:10`).
- Tests: 16 added, including the first coverage of `to_xfal` (`test_constraints.py`, `test_pydantic.py:284`).

## Why

Model owners have no way to declare input video limits, so they end up as prose in the field description and users hit opaque failures after uploading. Its real limits are advertised only as English today:

Example > Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.

This is the same mechanism as the image size constraints in #1079: declare in the toolkit, emit to the schema, let clients check before a request.

An example real contract needs both halves. It rejects on file size and minimum duration, but silently rescales anything outside `[640x640, 834x1112]` (`_seedance_reference_video_dimensions`) and trims past 15.1s (`target_duration = min(duration, SEEDANCE2_VIDEO_MAX_DURATION)`). Declaring the second group as limits would have a UI reject videos the model accepts; omitting it hides real behaviour. So they are separate:

```python
video_urls: list[str] = VideoField(
    constraints=VideoValidationConfig(          # violating these fails the request
        max_file_size=50 * 1024 * 1024, min_duration=2.0,
    ),
    combined_constraints=VideoValidationConfig(  # limits on the list's totals
        max_duration=15.1,
    ),
    normalization=VideoNormalizationConfig(      # accepted, then reshaped
        min_area=640 * 640, max_area=834 * 1112, max_duration=15.1, fps=24,
    ),
)
```

## What is not changing

- **No enforcement.** These are documentation hints, like the image constraints. The registry already enforces input video limits at download time in its own `VideoUrl` / `validate_video_async`.
- **No output size constraints.** Video models pick output size through closed enums (`resolution`, `duration`), which the schema already constrains, so there is nothing for a client to clamp - unlike `image_size`'s free-form `{width, height}`.
- **No `timeout` / `auto_fix`.** Fetch and processing settings, not properties of the video. `validate_video_async` already carries both as function defaults, separate from its constraints block. Note `ImageValidationConfig` still has `timeout` (untouched public API), so `to_xfal` keeps filtering it.

## Evidence

Example emitted schema for a `list[str]` field:

```json
"video_urls": {
  "type": "array", "items": {"type": "string"},
  "ui": {"field": "video", "important": true},
  "x-fal": {"max_file_size": 52428800, "min_duration": 2.0,
            "combined": {"max_duration": 15.1},
            "normalization": {"min_area": 409600, "max_area": 927408,
                              "max_duration": 15.1, "fps": 24}}
}
```

Note `x-fal` lands on the array property, not on `items` - relevant to whoever writes the client-side parser.

The `ui` bug, on `main`: `VideoField(default="", ui={"important": True})` emits `{'field': 'video'}`, dropping `important`. Seedance's `video_urls` passes exactly that today.

## Test plan

- [x] `pytest projects/fal/tests/unit/toolkit/test_constraints.py projects/fal/tests/unit/toolkit/test_pydantic.py` (37 pass, on both pydantic 1.10.18 and 2.13.3)
- [x] `ruff format --check` and `ruff check` on `projects/fal/src/fal/toolkit/` and `projects/fal/tests/unit/toolkit/`
- [x] Full unit suite unchanged vs base: 830 -> 846 passing, same pre-existing failures
- [ ] `pytest projects/fal/tests/unit/toolkit/ -k video_field` - the emitter's contract is asserted, not eyeballed:
  - `test_video_field_buckets_do_not_collide` - same limit in all three buckets at different values, so a leak or overwrite fails
  - `test_video_field_without_constraints_emits_no_xfal` - no `x-fal` key when nothing is declared
  - `test_video_field_constraints_keep_ui` - caller `ui` survives alongside `x-fal` (the Pydantic v2 bug above)
- [ ] `pytest projects/fal/tests/unit/toolkit/test_constraints.py` - `to_xfal` filtering and the bound checks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema-metadata API with no enforcement path changes; the only behavior shift is failing fast on inconsistent min/max at config construction, including for existing image constraint dataclasses.
> 
> **Overview**
> Adds **declarative video input contracts** in the toolkit so model owners can describe what clients should validate before upload, mirroring the existing image `x-fal` pattern.
> 
> **`VideoValidationConfig`** / **`VideoValidationOptions`** cover reject limits (size, dimensions, area, aspect ratio, frames, duration, fps). **`VideoNormalizationConfig`** documents reshape behavior (rescale, trim, fps) under a separate **`normalization`** bucket so UIs can warn instead of blocking. **`VideoField`** now accepts `constraints`, `combined_constraints` (list totals under `combined`), and `normalization`, all serialized via **`to_xfal`** into the field’s OpenAPI **`x-fal`** extension.
> 
> Shared **`_validate_bounds`** now runs on image and video configs at construction time (min must not exceed max). **`VideoField(ui=...)`** is an explicit argument so caller UI metadata is no longer dropped on Pydantic v2 when `json_schema_extra` is set.
> 
> New unit tests cover `to_xfal`, bound checks, and schema emission (including bucket separation and ui + `x-fal` coexistence). Limits remain **documentation-only**; runtime enforcement is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603be9ebef5a38ff2bbd238360d9b851d06b4c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

