### PR TITLE
fix(cli): suggest the upgrade command that matches how fal was installed

### DIFF
--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -66,11 +66,26 @@ def _is_uv_project(prefix: str) -> bool:
     return os.path.exists(os.path.join(os.path.dirname(prefix), "uv.lock"))
 
 
+def _same_path(left: Optional[str], right: Optional[str]) -> bool:
+    if not left or not right:
+        return False
+
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        # One of them does not exist; compare them textually instead.
+        return os.path.normcase(os.path.normpath(left)) == os.path.normcase(
+            os.path.normpath(right)
+        )
+
+
 def _pip_command() -> str:
-    # Inside an activated virtualenv, `pip` is the one we want. Otherwise the
-    # `pip` on PATH may well belong to a different interpreter than the one
-    # running fal, so spell out the interpreter instead.
-    if sys.prefix != sys.base_prefix and os.environ.get("VIRTUAL_ENV"):
+    # `pip` on PATH is the right one only when the venv fal runs from is also
+    # the activated one. If a *different* venv is activated, that `pip` would
+    # upgrade the wrong environment, so spell out the interpreter instead.
+    if sys.prefix != sys.base_prefix and _same_path(
+        os.environ.get("VIRTUAL_ENV"), sys.prefix
+    ):
         return "pip"
 
     executable = sys.executable or "python"

--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -78,6 +78,20 @@ def _same_path(left: Optional[str], right: Optional[str]) -> bool:
         )
 
 
+def _uv_project_root(prefix: str) -> Optional[str]:
+    """The nearest ancestor of this venv holding a `uv.lock`, if any."""
+    current = os.path.dirname(os.path.abspath(prefix))
+    while True:
+        if os.path.exists(os.path.join(current, "uv.lock")):
+            return current
+
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+
+        current = parent
+
+
 def _is_uv_project(prefix: str) -> bool:
     """Is this venv the environment uv manages for a project with a lockfile?
 
@@ -85,10 +99,26 @@ def _is_uv_project(prefix: str) -> bool:
     root creates one too, and `uv sync` there would upgrade `.venv` instead,
     leaving the running install untouched. uv's project environment is `.venv`
     unless `UV_PROJECT_ENVIRONMENT` moves it, in which case the lockfile need
-    not be adjacent at all.
+    not be adjacent at all — and, just as importantly, an adjacent `.venv` is
+    then merely an ordinary venv that `uv sync` will not touch.
     """
-    if _same_path(os.environ.get("UV_PROJECT_ENVIRONMENT"), prefix):
-        return True
+    override = os.environ.get("UV_PROJECT_ENVIRONMENT")
+    if override:
+        # The override *is* the project environment, so this is the whole
+        # question — a `.venv` beside the lockfile no longer qualifies.
+        if not os.path.isabs(override):
+            # uv resolves a relative override against the project root, not the
+            # cwd (verified against uv 0.11.29). Without a lockfile to locate
+            # that root we cannot say, so decline rather than guess: the caller
+            # then falls back to a `uv pip` command, which upgrades the right
+            # environment even though a later `uv sync` would revert it.
+            root = _uv_project_root(prefix)
+            if root is None:
+                return False
+
+            override = os.path.join(root, override)
+
+        return _same_path(override, prefix)
 
     if os.path.basename(prefix) != ".venv":
         return False

--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -104,13 +104,16 @@ def detect_install_manager(package: str = _PACKAGE) -> str:
     if os.path.exists(os.path.join(prefix, _UV_TOOL_MARKER)):
         return "uv-tool"
 
-    installer = _read_installer(package)
+    # Only the leading token names the installer: Poetry writes its version
+    # too ("Poetry 2.4.1"), while pip, uv and pdm write a bare name.
+    installer = (_read_installer(package) or "").split()
+    name = installer[0] if installer else None
 
-    if installer == "uv":
+    if name == "uv":
         return "uv-project" if _is_uv_project(prefix) else "uv"
 
-    if installer in ("poetry", "pdm"):
-        return installer
+    if name in ("poetry", "pdm"):
+        return name
 
     return "pip"
 

--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -29,12 +29,16 @@ def _installer_from_disk(package: str) -> Optional[str]:
     import glob
 
     site_packages = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    pattern = os.path.join(site_packages, f"{package}-*.dist-info", "INSTALLER")
+    # `glob.escape` the directory: a bracketed path component (legal on every
+    # platform) would otherwise be read as a character class and match nothing.
+    pattern = os.path.join(
+        glob.escape(site_packages), f"{package}-*.dist-info", "INSTALLER"
+    )
     for path in sorted(glob.glob(pattern)):
         try:
             with open(path) as fobj:
                 installer = fobj.read().strip().lower()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
 
         if installer:
@@ -61,11 +65,6 @@ def _read_installer(package: str) -> Optional[str]:
     return _installer_from_disk(package) or _installer_from_metadata(package)
 
 
-def _is_uv_project(prefix: str) -> bool:
-    """Is this venv the `.venv` of a uv project with a lockfile?"""
-    return os.path.exists(os.path.join(os.path.dirname(prefix), "uv.lock"))
-
-
 def _same_path(left: Optional[str], right: Optional[str]) -> bool:
     if not left or not right:
         return False
@@ -79,20 +78,79 @@ def _same_path(left: Optional[str], right: Optional[str]) -> bool:
         )
 
 
-def _pip_command() -> str:
-    # `pip` on PATH is the right one only when the venv fal runs from is also
-    # the activated one. If a *different* venv is activated, that `pip` would
-    # upgrade the wrong environment, so spell out the interpreter instead.
-    if sys.prefix != sys.base_prefix and _same_path(
+def _is_uv_project(prefix: str) -> bool:
+    """Is this venv the environment uv manages for a project with a lockfile?
+
+    Sitting next to a `uv.lock` is not enough: `uv venv side-env` in a project
+    root creates one too, and `uv sync` there would upgrade `.venv` instead,
+    leaving the running install untouched. uv's project environment is `.venv`
+    unless `UV_PROJECT_ENVIRONMENT` moves it, in which case the lockfile need
+    not be adjacent at all.
+    """
+    if _same_path(os.environ.get("UV_PROJECT_ENVIRONMENT"), prefix):
+        return True
+
+    if os.path.basename(prefix) != ".venv":
+        return False
+
+    return os.path.exists(os.path.join(os.path.dirname(prefix), "uv.lock"))
+
+
+def _in_activated_venv() -> bool:
+    """Is fal running from the virtualenv that is currently activated?
+
+    Only then does the activated venv's `bin/` — which leads PATH — belong to
+    the install we want upgraded. If a *different* venv is activated, a bare
+    `pip` or `uv pip` would resolve to that one and upgrade the wrong
+    environment, so callers have to spell the interpreter out instead.
+    """
+    return sys.prefix != sys.base_prefix and _same_path(
         os.environ.get("VIRTUAL_ENV"), sys.prefix
-    ):
-        return "pip"
+    )
+
+
+def _quote(path: str) -> str:
+    if " " not in path:
+        return path
+
+    # Valid in POSIX shells and in cmd.exe. PowerShell parses a leading quoted
+    # string as an expression and needs its `&` call operator to run it, which
+    # cmd.exe in turn rejects, so no single spelling satisfies all three.
+    return f'"{path}"'
+
+
+def _python_invocation() -> str:
+    """The shortest spelling of the running interpreter, as pip's own hint does.
+
+    Preferring the bare name when PATH resolves it to this very interpreter
+    keeps the hint short and sidesteps quoting a path with spaces entirely.
+    """
+    import shutil
 
     executable = sys.executable or "python"
-    if " " in executable:
-        executable = f'"{executable}"'
+    name = os.path.basename(executable)
+    found = shutil.which(name)
+    if found and _same_path(found, executable):
+        return name
 
-    return f"{executable} -m pip"
+    return _quote(executable)
+
+
+def _pip_command() -> str:
+    if _in_activated_venv():
+        return "pip"
+
+    return f"{_python_invocation()} -m pip"
+
+
+def _uv_pip_install_command(package: str) -> str:
+    if _in_activated_venv():
+        return f"uv pip install --upgrade {package}"
+
+    # `uv pip` picks its target environment by discovery (VIRTUAL_ENV, then a
+    # nearby `.venv`), not from the interpreter running fal — name it.
+    python = _quote(sys.executable or "python")
+    return f"uv pip install --python {python} --upgrade {package}"
 
 
 def detect_install_manager(package: str = _PACKAGE) -> str:
@@ -122,6 +180,14 @@ def get_upgrade_command(package: str = _PACKAGE) -> str:
     try:
         manager = detect_install_manager(package)
     except Exception:
+        from fal.logging import get_logger
+
+        # Never fatal — a version nudge must not break the CLI — but log it, or
+        # a wrong hint for the very installs this exists to serve leaves no
+        # trace at all.
+        get_logger(__name__).warning(
+            "Failed to detect how %s was installed", package, exc_info=True
+        )
         manager = "pip"
 
     if manager == "pipx":
@@ -129,9 +195,11 @@ def get_upgrade_command(package: str = _PACKAGE) -> str:
     if manager == "uv-tool":
         return f"uv tool upgrade {package}"
     if manager == "uv-project":
-        return f"uv lock --upgrade-package {package} && uv sync"
+        # Relocks and syncs in one command; `uv lock && uv sync` would need a
+        # `&&`, which Windows PowerShell 5.1 rejects.
+        return f"uv sync --upgrade-package {package}"
     if manager == "uv":
-        return f"uv pip install --upgrade {package}"
+        return _uv_pip_install_command(package)
     if manager == "poetry":
         return f"poetry update {package}"
     if manager == "pdm":

--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -119,6 +119,20 @@ def _quote(path: str) -> str:
     return f'"{path}"'
 
 
+def _same_binary(left: str, right: str) -> bool:
+    """Are these the same file, *without* following symlinks?
+
+    A venv's `bin/python` is normally a symlink to the interpreter it was built
+    from, so following symlinks would call a different venv's `python` — or the
+    base interpreter itself — equivalent, and the bare name would then upgrade
+    the wrong environment. pip's own hint compares `lstat`s for this reason.
+    """
+    try:
+        return os.path.samestat(os.lstat(left), os.lstat(right))
+    except OSError:
+        return False
+
+
 def _python_invocation() -> str:
     """The shortest spelling of the running interpreter, as pip's own hint does.
 
@@ -130,7 +144,7 @@ def _python_invocation() -> str:
     executable = sys.executable or "python"
     name = os.path.basename(executable)
     found = shutil.which(name)
-    if found and _same_path(found, executable):
+    if found and _same_binary(found, executable):
         return name
 
     return _quote(executable)

--- a/projects/fal/src/fal/_installer.py
+++ b/projects/fal/src/fal/_installer.py
@@ -1,0 +1,122 @@
+"""Detect how fal was installed, so upgrade hints suggest a command that works.
+
+`pip install --upgrade fal` is wrong (or a no-op) for the common non-pip
+installs: pipx and `uv tool` put fal in a managed virtualenv of their own, and
+uv projects revert anything installed behind the lockfile's back.
+"""
+
+import os
+import sys
+from typing import Optional
+
+_PACKAGE = "fal"
+
+# `pipx` and `uv tool` both drop a receipt in the root of the virtualenv they
+# manage, which is the only reliable way to tell them apart from a plain venv:
+# pipx installs with uv under the hood these days, so the dist-info INSTALLER
+# says "uv" for both.
+_PIPX_MARKER = "pipx_metadata.json"
+_UV_TOOL_MARKER = "uv-receipt.toml"
+
+
+def _installer_from_disk(package: str) -> Optional[str]:
+    """Read INSTALLER from the dist-info sitting next to this package.
+
+    `importlib.metadata` resolves by name against `sys.path`, so a stale
+    `fal.egg-info` in the working directory can shadow the real install. The
+    dist-info next to the module we are actually running cannot.
+    """
+    import glob
+
+    site_packages = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    pattern = os.path.join(site_packages, f"{package}-*.dist-info", "INSTALLER")
+    for path in sorted(glob.glob(pattern)):
+        try:
+            with open(path) as fobj:
+                installer = fobj.read().strip().lower()
+        except OSError:
+            continue
+
+        if installer:
+            return installer
+
+    return None
+
+
+def _installer_from_metadata(package: str) -> Optional[str]:
+    from importlib.metadata import PackageNotFoundError, distribution
+
+    try:
+        installer = distribution(package).read_text("INSTALLER")
+    except (PackageNotFoundError, OSError, ValueError):
+        return None
+
+    if not installer:
+        return None
+
+    return installer.strip().lower()
+
+
+def _read_installer(package: str) -> Optional[str]:
+    return _installer_from_disk(package) or _installer_from_metadata(package)
+
+
+def _is_uv_project(prefix: str) -> bool:
+    """Is this venv the `.venv` of a uv project with a lockfile?"""
+    return os.path.exists(os.path.join(os.path.dirname(prefix), "uv.lock"))
+
+
+def _pip_command() -> str:
+    # Inside an activated virtualenv, `pip` is the one we want. Otherwise the
+    # `pip` on PATH may well belong to a different interpreter than the one
+    # running fal, so spell out the interpreter instead.
+    if sys.prefix != sys.base_prefix and os.environ.get("VIRTUAL_ENV"):
+        return "pip"
+
+    executable = sys.executable or "python"
+    if " " in executable:
+        executable = f'"{executable}"'
+
+    return f"{executable} -m pip"
+
+
+def detect_install_manager(package: str = _PACKAGE) -> str:
+    prefix = sys.prefix
+
+    if os.path.exists(os.path.join(prefix, _PIPX_MARKER)):
+        return "pipx"
+
+    if os.path.exists(os.path.join(prefix, _UV_TOOL_MARKER)):
+        return "uv-tool"
+
+    installer = _read_installer(package)
+
+    if installer == "uv":
+        return "uv-project" if _is_uv_project(prefix) else "uv"
+
+    if installer in ("poetry", "pdm"):
+        return installer
+
+    return "pip"
+
+
+def get_upgrade_command(package: str = _PACKAGE) -> str:
+    try:
+        manager = detect_install_manager(package)
+    except Exception:
+        manager = "pip"
+
+    if manager == "pipx":
+        return f"pipx upgrade {package}"
+    if manager == "uv-tool":
+        return f"uv tool upgrade {package}"
+    if manager == "uv-project":
+        return f"uv lock --upgrade-package {package} && uv sync"
+    if manager == "uv":
+        return f"uv pip install --upgrade {package}"
+    if manager == "poetry":
+        return f"poetry update {package}"
+    if manager == "pdm":
+        return f"pdm update {package}"
+
+    return f"{_pip_command()} install --upgrade {package}"

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -126,8 +126,11 @@ def _check_latest_version():
         (latest_version, "bold green"),
     )
     line2 = Text.assemble((get_upgrade_command(), "bold cyan"))
-    # `align` truncates to `width`, so never go below the longest line.
-    line2.align("center", width=max(len(line1), len(line2)))
+    # Center both against the longest line: the command can now be longer than
+    # the headline, and `align` truncates to `width` rather than padding.
+    width = max(len(line1), len(line2))
+    line1.align("center", width=width)
+    line2.align("center", width=width)
 
     panel = Panel(
         line1 + "\n\n" + line2,

--- a/projects/fal/src/fal/cli/main.py
+++ b/projects/fal/src/fal/cli/main.py
@@ -100,6 +100,7 @@ def _check_latest_version():
     from rich.panel import Panel
     from rich.text import Text
 
+    from fal._installer import get_upgrade_command
     from fal._version import get_latest_version, version_tuple
 
     # If we have a dev version, we don't want to check for updates
@@ -124,8 +125,9 @@ def _check_latest_version():
         ("A new version of fal is available: ", "bold white"),
         (latest_version, "bold green"),
     )
-    line2 = Text.assemble(("pip install --upgrade fal", "bold cyan"))
-    line2.align("center", width=len(line1))
+    line2 = Text.assemble((get_upgrade_command(), "bold cyan"))
+    # `align` truncates to `width`, so never go below the longest line.
+    line2.align("center", width=max(len(line1), len(line2)))
 
     panel = Panel(
         line1 + "\n\n" + line2,

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -102,6 +102,48 @@ def test_remote_exception_deserialization_is_user_function_exception() -> None:
         raise AssertionError("expected UserFunctionException")
 
 
+def test_update_panel_centers_both_lines(monkeypatch, tmp_path) -> None:
+    # A long upgrade command (the spelled-out interpreter fallback) is wider
+    # than the headline, so the headline has to be centered against it too.
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("")
+    monkeypatch.setenv("FAL_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("FAL_PROFILE", raising=False)
+
+    monkeypatch.setattr(fal_version, "get_latest_version", lambda: "99.0.0")
+    monkeypatch.setattr(fal_version, "version_tuple", (1, 0, 0))
+
+    command = (
+        "/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --upgrade fal"
+    )
+    monkeypatch.setattr(
+        importlib.import_module("fal._installer"),
+        "get_upgrade_command",
+        lambda *_args, **_kwargs: command,
+    )
+
+    console = Console(
+        record=True, width=120, force_terminal=True, color_system=None, no_color=True
+    )
+    monkeypatch.setattr(cli_main, "console", console)
+
+    cli_main._check_latest_version()
+
+    lines = [line for line in console.export_text().splitlines() if "│" in line]
+    headline = next(line for line in lines if "A new version" in line)
+    command_line = next(line for line in lines if command in line)
+
+    def padding(line: str) -> tuple:
+        body = line.strip("│")
+        return len(body) - len(body.lstrip()), len(body) - len(body.rstrip())
+
+    # Nothing truncated, and the headline is centered rather than left-flush.
+    assert command in command_line
+    left, right = padding(headline)
+    assert abs(left - right) <= 1
+    assert left > padding(command_line)[0]
+
+
 def test_update_check_can_be_disabled(monkeypatch, tmp_path) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text("check_updates = false\n")

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -1,21 +1,32 @@
+import builtins
 import importlib
 import os
+import shutil
 
+fal_logging = importlib.import_module("fal.logging")
 installer = importlib.import_module("fal._installer")
 
 
-def _fake_prefix(monkeypatch, tmp_path, marker=None):
-    prefix = tmp_path / "env"
+def _fake_prefix(monkeypatch, tmp_path, marker=None, name="env"):
+    prefix = tmp_path / name
     prefix.mkdir()
     if marker:
         (prefix / marker).write_text("{}")
     monkeypatch.setattr(installer.sys, "prefix", str(prefix))
     monkeypatch.setattr(installer.sys, "base_prefix", str(tmp_path / "base"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
     return prefix
 
 
 def _fake_installer_metadata(monkeypatch, value):
     monkeypatch.setattr(installer, "_read_installer", lambda _package: value)
+
+
+def _fake_interpreter(monkeypatch, executable, on_path=None):
+    """Run as `executable`, with `on_path` as what its bare name resolves to."""
+    monkeypatch.setattr(installer.sys, "executable", executable)
+    monkeypatch.setattr(shutil, "which", lambda _name: on_path)
 
 
 def test_pipx_install_suggests_pipx_upgrade(monkeypatch, tmp_path) -> None:
@@ -34,18 +45,58 @@ def test_uv_tool_install_suggests_uv_tool_upgrade(monkeypatch, tmp_path) -> None
 
 
 def test_uv_venv_suggests_uv_pip(monkeypatch, tmp_path) -> None:
-    _fake_prefix(monkeypatch, tmp_path)
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
     _fake_installer_metadata(monkeypatch, "uv")
 
     assert installer.get_upgrade_command() == "uv pip install --upgrade fal"
 
 
-def test_uv_project_suggests_lock_and_sync(monkeypatch, tmp_path) -> None:
-    prefix = _fake_prefix(monkeypatch, tmp_path)
+def test_uv_pip_names_the_interpreter_when_it_is_not_the_activated_venv(
+    monkeypatch, tmp_path
+) -> None:
+    # `uv pip` finds its target by discovery (VIRTUAL_ENV, then a nearby
+    # `.venv`), so without --python it would upgrade the activated venv A while
+    # fal keeps running from B.
+    _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "some-other-venv"))
+    _fake_interpreter(monkeypatch, "/usr/bin/python3")
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == (
+        "uv pip install --python /usr/bin/python3 --upgrade fal"
+    )
+
+
+def test_uv_project_suggests_sync_with_upgrade_package(monkeypatch, tmp_path) -> None:
+    prefix = _fake_prefix(monkeypatch, tmp_path, name=".venv")
     (prefix.parent / "uv.lock").write_text("")
     _fake_installer_metadata(monkeypatch, "uv")
 
-    assert installer.get_upgrade_command() == "uv lock --upgrade-package fal && uv sync"
+    assert installer.get_upgrade_command() == "uv sync --upgrade-package fal"
+
+
+def test_side_venv_in_a_uv_project_is_not_the_project_environment(
+    monkeypatch, tmp_path
+) -> None:
+    # `uv venv side-env` in a project root sits next to the lockfile but is not
+    # what `uv sync` would touch, so syncing would leave this install stale.
+    prefix = _fake_prefix(monkeypatch, tmp_path, name="side-env")
+    (prefix.parent / "uv.lock").write_text("")
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv pip install --upgrade fal"
+
+
+def test_uv_project_environment_override_is_recognised(monkeypatch, tmp_path) -> None:
+    # UV_PROJECT_ENVIRONMENT moves the managed environment, so it need not be
+    # named `.venv` nor sit beside the lockfile.
+    prefix = _fake_prefix(monkeypatch, tmp_path, name="managed-env")
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(prefix))
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv sync --upgrade-package fal"
 
 
 def test_poetry_install_suggests_poetry_update(monkeypatch, tmp_path) -> None:
@@ -95,7 +146,7 @@ def test_a_different_activated_venv_spells_out_the_interpreter(
     # would resolve through PATH to A's pip and upgrade the wrong environment.
     _fake_prefix(monkeypatch, tmp_path)
     monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "some-other-venv"))
-    monkeypatch.setattr(installer.sys, "executable", "/usr/bin/python3")
+    _fake_interpreter(monkeypatch, "/usr/bin/python3")
     _fake_installer_metadata(monkeypatch, "pip")
 
     assert (
@@ -106,8 +157,7 @@ def test_a_different_activated_venv_spells_out_the_interpreter(
 
 def test_global_install_spells_out_the_interpreter(monkeypatch, tmp_path) -> None:
     _fake_prefix(monkeypatch, tmp_path)
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.setattr(installer.sys, "executable", "/usr/bin/python3")
+    _fake_interpreter(monkeypatch, "/usr/bin/python3")
     _fake_installer_metadata(monkeypatch, "pip")
 
     assert (
@@ -116,15 +166,71 @@ def test_global_install_spells_out_the_interpreter(monkeypatch, tmp_path) -> Non
     )
 
 
+def test_interpreter_on_path_is_named_without_its_directory(
+    monkeypatch, tmp_path
+) -> None:
+    # When PATH resolves the bare name to this very interpreter, the short
+    # spelling is equivalent — and avoids quoting entirely.
+    executable = tmp_path / "python3.14"
+    executable.write_text("")
+    _fake_prefix(monkeypatch, tmp_path)
+    _fake_interpreter(monkeypatch, str(executable), on_path=str(executable))
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert installer.get_upgrade_command() == "python3.14 -m pip install --upgrade fal"
+
+
 def test_interpreter_path_with_spaces_is_quoted(monkeypatch, tmp_path) -> None:
     _fake_prefix(monkeypatch, tmp_path)
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.setattr(installer.sys, "executable", "/opt/my python/bin/python")
+    # A different `python` leads PATH, so the full path is needed.
+    _fake_interpreter(
+        monkeypatch, "/opt/my python/bin/python", on_path="/usr/bin/python"
+    )
     _fake_installer_metadata(monkeypatch, "pip")
 
     assert installer.get_upgrade_command() == (
         '"/opt/my python/bin/python" -m pip install --upgrade fal'
     )
+
+
+def _write_dist_info(tmp_path, contents, *, directory="projects [client]"):
+    """Lay out a real `fal-*.dist-info/INSTALLER` and point the module at it."""
+    site_packages = tmp_path / directory / "site-packages"
+    dist_info = site_packages / "fal-1.2.3.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "INSTALLER").write_text(contents)
+    return site_packages / "fal" / "_installer.py"
+
+
+def test_installer_is_read_from_the_dist_info_beside_the_package(
+    monkeypatch, tmp_path
+) -> None:
+    # Bracketed path components are legal everywhere but are a glob character
+    # class, so an unescaped pattern silently matches nothing here. The real
+    # capitalisation is exercised too: only this layer lowercases.
+    module = _write_dist_info(tmp_path, "Poetry 2.4.1\n")
+    monkeypatch.setattr(installer, "__file__", str(module))
+
+    assert installer._installer_from_disk("fal") == "poetry 2.4.1"
+
+    _fake_prefix(monkeypatch, tmp_path)
+    assert installer.get_upgrade_command() == "poetry update fal"
+
+
+def test_an_undecodable_installer_file_is_ignored(monkeypatch, tmp_path) -> None:
+    # A corrupted INSTALLER used to escape as UnicodeDecodeError, which only
+    # the catch-all in `get_upgrade_command` stopped — silently, and after
+    # losing the detection. Raised from `open` rather than written as bytes so
+    # the test does not depend on the locale's encoding.
+    module = _write_dist_info(tmp_path, "uv\n", directory="plain")
+    monkeypatch.setattr(installer, "__file__", str(module))
+
+    def explode(*_args, **_kwargs):
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(builtins, "open", explode)
+
+    assert installer._installer_from_disk("fal") is None
 
 
 def test_missing_metadata_falls_back_to_pip(monkeypatch, tmp_path) -> None:
@@ -135,7 +241,9 @@ def test_missing_metadata_falls_back_to_pip(monkeypatch, tmp_path) -> None:
     assert installer.get_upgrade_command() == "pip install --upgrade fal"
 
 
-def test_detection_errors_fall_back_to_pip(monkeypatch, tmp_path) -> None:
+def test_detection_errors_fall_back_to_pip_and_are_logged(
+    monkeypatch, tmp_path
+) -> None:
     prefix = _fake_prefix(monkeypatch, tmp_path)
     monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
 
@@ -144,4 +252,14 @@ def test_detection_errors_fall_back_to_pip(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(installer, "_read_installer", boom)
 
+    warnings = []
+
+    class _Logger:
+        def warning(self, message, *args, **kwargs):
+            warnings.append((message % args, kwargs))
+
+    monkeypatch.setattr(fal_logging, "get_logger", lambda *_args: _Logger())
+
     assert installer.get_upgrade_command() == "pip install --upgrade fal"
+
+    assert warnings == [("Failed to detect how fal was installed", {"exc_info": True})]

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -49,10 +49,26 @@ def test_uv_project_suggests_lock_and_sync(monkeypatch, tmp_path) -> None:
 
 
 def test_poetry_install_suggests_poetry_update(monkeypatch, tmp_path) -> None:
+    # A real `poetry add` writes its version too, e.g. "Poetry 2.4.1"; only
+    # `poetry install` of the root project writes a bare "poetry".
+    _fake_prefix(monkeypatch, tmp_path)
+    _fake_installer_metadata(monkeypatch, "poetry 2.4.1")
+
+    assert installer.get_upgrade_command() == "poetry update fal"
+
+
+def test_bare_poetry_installer_value_still_matches(monkeypatch, tmp_path) -> None:
     _fake_prefix(monkeypatch, tmp_path)
     _fake_installer_metadata(monkeypatch, "poetry")
 
     assert installer.get_upgrade_command() == "poetry update fal"
+
+
+def test_pdm_install_suggests_pdm_update(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path)
+    _fake_installer_metadata(monkeypatch, "pdm")
+
+    assert installer.get_upgrade_command() == "pdm update fal"
 
 
 def test_activated_venv_suggests_bare_pip(monkeypatch, tmp_path) -> None:

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -1,0 +1,105 @@
+import importlib
+
+installer = importlib.import_module("fal._installer")
+
+
+def _fake_prefix(monkeypatch, tmp_path, marker=None):
+    prefix = tmp_path / "env"
+    prefix.mkdir()
+    if marker:
+        (prefix / marker).write_text("{}")
+    monkeypatch.setattr(installer.sys, "prefix", str(prefix))
+    monkeypatch.setattr(installer.sys, "base_prefix", str(tmp_path / "base"))
+    return prefix
+
+
+def _fake_installer_metadata(monkeypatch, value):
+    monkeypatch.setattr(installer, "_read_installer", lambda _package: value)
+
+
+def test_pipx_install_suggests_pipx_upgrade(monkeypatch, tmp_path) -> None:
+    # pipx shells out to uv these days, so INSTALLER says "uv" even here.
+    _fake_prefix(monkeypatch, tmp_path, marker="pipx_metadata.json")
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "pipx upgrade fal"
+
+
+def test_uv_tool_install_suggests_uv_tool_upgrade(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path, marker="uv-receipt.toml")
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv tool upgrade fal"
+
+
+def test_uv_venv_suggests_uv_pip(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path)
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv pip install --upgrade fal"
+
+
+def test_uv_project_suggests_lock_and_sync(monkeypatch, tmp_path) -> None:
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    (prefix.parent / "uv.lock").write_text("")
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv lock --upgrade-package fal && uv sync"
+
+
+def test_poetry_install_suggests_poetry_update(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path)
+    _fake_installer_metadata(monkeypatch, "poetry")
+
+    assert installer.get_upgrade_command() == "poetry update fal"
+
+
+def test_activated_venv_suggests_bare_pip(monkeypatch, tmp_path) -> None:
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert installer.get_upgrade_command() == "pip install --upgrade fal"
+
+
+def test_global_install_spells_out_the_interpreter(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(installer.sys, "executable", "/usr/bin/python3")
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert (
+        installer.get_upgrade_command()
+        == "/usr/bin/python3 -m pip install --upgrade fal"
+    )
+
+
+def test_interpreter_path_with_spaces_is_quoted(monkeypatch, tmp_path) -> None:
+    _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(installer.sys, "executable", "/opt/my python/bin/python")
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert installer.get_upgrade_command() == (
+        '"/opt/my python/bin/python" -m pip install --upgrade fal'
+    )
+
+
+def test_missing_metadata_falls_back_to_pip(monkeypatch, tmp_path) -> None:
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
+    _fake_installer_metadata(monkeypatch, None)
+
+    assert installer.get_upgrade_command() == "pip install --upgrade fal"
+
+
+def test_detection_errors_fall_back_to_pip(monkeypatch, tmp_path) -> None:
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
+
+    def boom(_package):
+        raise RuntimeError("no metadata for you")
+
+    monkeypatch.setattr(installer, "_read_installer", boom)
+
+    assert installer.get_upgrade_command() == "pip install --upgrade fal"

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -99,6 +99,38 @@ def test_uv_project_environment_override_is_recognised(monkeypatch, tmp_path) ->
     assert installer.get_upgrade_command() == "uv sync --upgrade-package fal"
 
 
+def test_dot_venv_is_not_the_project_environment_when_the_override_moved_it(
+    monkeypatch, tmp_path
+) -> None:
+    # The override points elsewhere, so `uv sync` populates *that* environment
+    # and leaves this `.venv` stale — verified against uv 0.11.29. Suggesting a
+    # sync here would print a command that silently changes nothing, and the
+    # update panel would keep coming back.
+    prefix = _fake_prefix(monkeypatch, tmp_path, name=".venv")
+    (prefix.parent / "uv.lock").write_text("")
+    (tmp_path / "managed-env").mkdir()
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(tmp_path / "managed-env"))
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix))
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv pip install --upgrade fal"
+
+
+def test_relative_override_resolves_against_the_project_root(
+    monkeypatch, tmp_path
+) -> None:
+    # uv resolves a relative UV_PROJECT_ENVIRONMENT against the project root —
+    # the directory holding the lockfile — not the cwd, so a relative override
+    # naming this very venv still means "sync me".
+    prefix = _fake_prefix(monkeypatch, tmp_path, name="managed-env")
+    (tmp_path / "uv.lock").write_text("")
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "managed-env")
+    monkeypatch.chdir(prefix)  # deliberately not the project root
+    _fake_installer_metadata(monkeypatch, "uv")
+
+    assert installer.get_upgrade_command() == "uv sync --upgrade-package fal"
+
+
 def test_poetry_install_suggests_poetry_update(monkeypatch, tmp_path) -> None:
     # A real `poetry add` writes its version too, e.g. "Poetry 2.4.1"; only
     # `poetry install` of the root project writes a bare "poetry".

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -180,6 +180,29 @@ def test_interpreter_on_path_is_named_without_its_directory(
     assert installer.get_upgrade_command() == "python3.14 -m pip install --upgrade fal"
 
 
+def test_another_venv_symlinked_to_the_same_interpreter_is_not_equivalent(
+    monkeypatch, tmp_path
+) -> None:
+    # A venv's `bin/python` is a symlink to the interpreter it was built from,
+    # so following symlinks makes venv A's python look like venv B's. Running
+    # the bare name would then upgrade A while fal keeps running from B.
+    base = tmp_path / "base-python"
+    base.write_text("")
+
+    def venv_python(prefix):
+        binary = prefix / "bin" / "python3.12"
+        binary.parent.mkdir(parents=True)
+        binary.symlink_to(base)
+        return binary
+
+    ours = venv_python(_fake_prefix(monkeypatch, tmp_path, name="venv-b"))
+    theirs = venv_python(tmp_path / "venv-a")
+    _fake_interpreter(monkeypatch, str(ours), on_path=str(theirs))
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert installer.get_upgrade_command() == f"{ours} -m pip install --upgrade fal"
+
+
 def test_interpreter_path_with_spaces_is_quoted(monkeypatch, tmp_path) -> None:
     _fake_prefix(monkeypatch, tmp_path)
     # A different `python` leads PATH, so the full path is needed.

--- a/projects/fal/tests/unit/test_installer.py
+++ b/projects/fal/tests/unit/test_installer.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 installer = importlib.import_module("fal._installer")
 
@@ -60,6 +61,31 @@ def test_activated_venv_suggests_bare_pip(monkeypatch, tmp_path) -> None:
     _fake_installer_metadata(monkeypatch, "pip")
 
     assert installer.get_upgrade_command() == "pip install --upgrade fal"
+
+
+def test_activated_venv_accepts_an_equivalent_path(monkeypatch, tmp_path) -> None:
+    # A trailing slash (or a symlinked path) still names the same venv.
+    prefix = _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(prefix) + os.sep)
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert installer.get_upgrade_command() == "pip install --upgrade fal"
+
+
+def test_a_different_activated_venv_spells_out_the_interpreter(
+    monkeypatch, tmp_path
+) -> None:
+    # fal runs from venv B while venv A is the activated one, so bare `pip`
+    # would resolve through PATH to A's pip and upgrade the wrong environment.
+    _fake_prefix(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "some-other-venv"))
+    monkeypatch.setattr(installer.sys, "executable", "/usr/bin/python3")
+    _fake_installer_metadata(monkeypatch, "pip")
+
+    assert (
+        installer.get_upgrade_command()
+        == "/usr/bin/python3 -m pip install --upgrade fal"
+    )
 
 
 def test_global_install_spells_out_the_interpreter(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Problem

The "new version of fal is available" panel always printed `pip install --upgrade fal`:

```
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 99.0.0  │
│                                             │
│          pip install --upgrade fal          │
│                                             │
╰─────────────────────────────────────────────╯
```

That command doesn't work for the common non-pip installs:

- **pipx** and **`uv tool`** put `fal` in a virtualenv they manage; `pip` may not even be on `PATH` there.
- In a **uv project**, `pip install` succeeds but the next `uv sync` reverts it.
- For a **global (non-venv) install**, the `pip` on `PATH` can easily belong to a different interpreter than the one running `fal`.

## Change

New [`fal/_installer.py`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py) exposes `get_upgrade_command()`, and [`fal/cli/main.py#L124-L133`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/cli/main.py#L124-L133) uses it instead of the hardcoded string.

| Detected via | Suggested command |
| --- | --- |
| `pipx_metadata.json` in `sys.prefix` | `pipx upgrade fal` |
| `uv-receipt.toml` in `sys.prefix` | `uv tool upgrade fal` |
| `INSTALLER == uv` + this venv is the project environment | `uv sync --upgrade-package fal` |
| `INSTALLER == uv`, this venv activated | `uv pip install --upgrade fal` |
| `INSTALLER == uv`, a *different* venv activated | `uv pip install --python <sys.executable> --upgrade fal` |
| `INSTALLER` starts with `poetry` / `pdm` | `poetry update fal` / `pdm update fal` |
| Activated virtualenv, and it's the one fal runs from | `pip install --upgrade fal` |
| Anything else | `<interpreter> -m pip install --upgrade fal` |

### Details worth a reviewer's attention

1. **Marker files are checked before `INSTALLER` metadata** — see [`detect_install_manager`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py#L170-L190). pipx installs through uv nowadays, so a pipx venv's dist-info reads `INSTALLER: uv`. Only the `pipx_metadata.json` / `uv-receipt.toml` receipt in the venv root distinguishes pipx and `uv tool` from a plain uv-created venv. Without this ordering, pipx users would be told to run `uv pip install --upgrade fal`, which edits the pipx venv behind pipx's back.

2. **`INSTALLER` is read from the dist-info next to the running package** ([`_installer_from_disk`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py#L22-L47)), not resolved by name through `importlib.metadata`. `importlib.metadata` searches `sys.path`, so a stale `fal.egg-info` in the working directory shadows the real install and yields no `INSTALLER` at all — this reproduced while testing from `projects/fal`. The by-name lookup is kept as a fallback for layouts where the dist-info isn't adjacent. The glob is `glob.escape`d, because a bracketed path component (`.../projects [client]/...`, legal on every platform) is otherwise read as a character class and matches nothing — which silently lands back on the shadowing path this exists to avoid.

3. **A venv next to a `uv.lock` is not necessarily uv's project environment** ([`_is_uv_project`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py#L81-L96)). `uv venv side-env` in a project root creates one too, and `uv sync` there would upgrade `.venv` instead, leaving the running install stale and the panel reappearing forever. So the venv must be `.venv` beside the lockfile, or `samefile`-match `UV_PROJECT_ENVIRONMENT` — which also means an environment relocated by that variable is still recognised as a project.

4. **The interpreter is named the way pip's own upgrade notice names it** ([`_python_invocation`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py#L122-L150), cf. [pip's `entrypoints.py`](https://github.com/pypa/pip/blob/26.2.1/src/pip/_internal/utils/entrypoints.py#L54-L72)): the bare name when `shutil.which` resolves it to this very interpreter, the full path otherwise. Shorter, and it avoids quoting a path containing spaces — which matters because a quoted leading path is a parse error in PowerShell (it needs the `&` call operator, which cmd.exe in turn rejects, so no spelling satisfies all three shells).

    That comparison deliberately does **not** follow symlinks (`os.path.samestat` on two `lstat`s, [as pip does](https://github.com/pypa/pip/blob/26.2.1/src/pip/_internal/utils/entrypoints.py#L60-L64)). A venv's `bin/python` is a symlink to the interpreter it was built from, so `samefile` would call venv A's `python` equivalent to venv B's, and the bare name would upgrade A while fal keeps running from B — the exact case this fallback exists to prevent. The trade is that a Homebrew interpreter reached through the `/opt/homebrew/bin` symlink is now spelled out in full: longer, never the wrong environment. Note the contrast with the venv *directory* comparison below, where following symlinks is what you want, since two spellings of one directory are the same environment.

Bare `pip` / `uv pip` is only suggested when the activated venv (whose `bin/` leads `PATH`) is the same one fal runs from — compared with `os.path.samefile`, so a trailing slash or symlink still matches. If a *different* venv is activated, those would upgrade that one instead, so the interpreter is spelled out: `-m pip` for pip, `--python` for `uv pip` (verified to override uv's discovery, not merely hint at it).

Only the **leading token** of `INSTALLER` is matched, because Poetry appends its own version: `poetry add` writes `Poetry 2.4.1` ([`wheel_installer.py#L134`](https://github.com/python-poetry/poetry/blob/2.4.1/src/poetry/installation/wheel_installer.py#L134)) while a root `poetry install` writes a bare `poetry` ([`editable.py#L231`](https://github.com/python-poetry/poetry/blob/2.4.1/src/poetry/masonry/builders/editable.py#L231)). pip, uv, and pdm all write a bare name, so they are unaffected.

Detection failures are non-fatal: [`get_upgrade_command`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_installer.py#L193-L222) falls back to the pip command, so a version nudge can never break the CLI — but it now logs a warning first (`exc_info=True`, matching [`get_latest_version`](https://github.com/fal-ai/fal/blob/4b9a2ae8d3e042cb3bdec86c6a4ce53ed502ed01/projects/fal/src/fal/_version.py#L63-L86), which feeds the same panel), so a silently wrong hint leaves a trace.

### Panel layout

Both lines of the panel now center against `max(len(line1), len(line2))`. `Text.align(align, width)` truncates to `width` before padding, so the old `width=len(line1)` would have cut the tail off any command longer than the headline; and since the command can now be the wider line, the headline needs aligning too or it stays left-flush while the command spans the full width.

## How to test

```bash
cd projects/fal
python -m pytest tests/unit/test_installer.py tests/unit/cli/test_main.py -q
```

To see the panel without waiting for a release, force a newer "latest" version:

```bash
python -c "
import sys
from rich.console import Console
import fal._version as v, fal.cli.main, fal._installer as inst
m = sys.modules['fal.cli.main']
v.get_latest_version = lambda: '99.0.0'
v.version_tuple = (1, 0, 0)
m.console = Console(force_terminal=True, width=100)
print(inst.detect_install_manager(), '->', inst.get_upgrade_command())
m._check_latest_version()
"
```

(Note `_check_latest_version` returns early when the console isn't a terminal and when `check_updates = false` is set in the fal config, so pass `force_terminal=True` and an empty `FAL_CONFIG_PATH`.)

To check detection inside a *real* environment rather than a synthesised prefix, copy the module into that environment's `site-packages` so its `__file__` sits next to the real dist-info, then ask it about any installed package:

```bash
SP=$(<env>/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
mkdir -p "$SP/probe" && : > "$SP/probe/__init__.py"
cp projects/fal/src/fal/_installer.py "$SP/probe/_installer.py"
<env>/bin/python -c "from probe import _installer as i; print(i._read_installer('six'), i.detect_install_manager('six'), i.get_upgrade_command('six'), sep=' | ')"
rm -rf "$SP/probe"
```

## Testing performed

**Unit tests** — 21 tests covering every row of the table above, including the pipx-installs-through-uv case, both Poetry `INSTALLER` spellings, a side venv inside a uv project, `UV_PROJECT_ENVIRONMENT`, an activated venv that isn't the one fal runs from (for both `pip` and `uv pip`), two venvs symlinked to one interpreter, the bare-name and quoted-path interpreter spellings, a real bracketed-path dist-info read, an undecodable `INSTALLER`, and both fallback paths (missing metadata, detection raising and logging), plus a panel-layout test:

```
$ python -m pytest tests/unit/test_installer.py tests/unit/cli/test_main.py -q
25 passed in 0.04s
```

Every regression test was run against its unfixed code and fails there — including the nine added or changed in `ef1c8b6a` and `4b9a2ae8` — so none is vacuous.

**Real environments (macOS)** — ran the detection module inside eight actual installs, not against synthesised prefixes:

```
# pipx install (Python 3.14.6, fal 1.78.3)
prefix:    /Users/…/Library/Application Support/pipx/venvs/fal
INSTALLER: 'uv'        <- metadata alone would give the wrong command
manager:   pipx        command: pipx upgrade fal

# uv tool install
prefix:    /Users/…/.local/share/uv/tools/<tool>
manager:   uv-tool     command: uv tool upgrade <tool>

# uv init + uv add six        (.venv beside uv.lock)
manager:   uv-project  command: uv sync --upgrade-package six

# uv venv side-env in that same project root
manager:   uv          command: uv pip install --python …/side-env/bin/python --upgrade six

# …and with that side venv activated
manager:   uv          command: uv pip install --upgrade six

# UV_PROJECT_ENVIRONMENT=…/managed-env + uv add six
manager:   uv-project  command: uv sync --upgrade-package six

# poetry add six  (Poetry 2.4.1, in-project .venv)
INSTALLER: 'poetry 2.4.1'
manager:   poetry      command: poetry update six

# pdm add six  (in-project .venv)
INSTALLER: 'pdm'
manager:   pdm         command: pdm update six

# global homebrew interpreter, sys.executable
#   /opt/homebrew/opt/python@3.14/bin/python3.14
# `which python3.14` -> /opt/homebrew/bin/python3.14, a *symlink* to it,
# so the full path is used rather than the bare name
manager:   pip         command: /opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --upgrade six

# same interpreter, with its real bin/ dir leading PATH, so `which` lands on
# the identical path and the short spelling is provably equivalent
manager:   pip         command: python3.14 -m pip install --upgrade six
```

**The two suggested commands were run, not just printed:**

```
$ uv add 'six==1.15.0' && sed -i '' 's/six==1.15.0/six/' pyproject.toml
$ uv sync --upgrade-package six
Uninstalled 1 package in 0.46ms
Installed 1 package in 2ms
 - six==1.15.0
 + six==1.17.0

# venv A activated, B named explicitly:
$ uv pip install --python $B/bin/python --upgrade six
 - six==1.15.0
 + six==1.17.0
$ $B/bin/python -c "import six; print(six.__version__)"   -> 1.17.0
$ $A/bin/python -c "…find_spec('six')…"                   -> A has six: False
```

so `--python` overrides uv's environment discovery rather than merely hinting at it, and `uv sync --upgrade-package` relocks *and* syncs in one command (no `&&`, which Windows PowerShell 5.1 rejects).

**Panel rendering** — verbatim output for the command shapes, re-captured at `4b9a2ae8`. Nothing truncated; a long command widens the box and both lines stay centered:

```
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 99.0.0  │
│                                             │
│              pipx upgrade fal               │
│                                             │
╰─────────────────────────────────────────────╯
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 99.0.0  │
│                                             │
│             uv tool upgrade fal             │
│                                             │
╰─────────────────────────────────────────────╯
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 99.0.0  │
│                                             │
│        uv sync --upgrade-package fal        │
│                                             │
╰─────────────────────────────────────────────╯
╭─────────────────────────────────────────────╮
│                                             │
│  A new version of fal is available: 99.0.0  │
│                                             │
│   python3.14 -m pip install --upgrade fal   │
│                                             │
╰─────────────────────────────────────────────╯
╭─────────────────────────────────────────────────────────────────────────────╮
│                                                                             │
│                  A new version of fal is available: 99.0.0                  │
│                                                                             │
│  /opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --upgrade fal  │
│                                                                             │
╰─────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────╮
│                                                                      │
│              A new version of fal is available: 99.0.0               │
│                                                                      │
│  "/Program Files/Python314/python.exe" -m pip install --upgrade fal  │
│                                                                      │
╰──────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────╮
│                                                                                  │
│                    A new version of fal is available: 99.0.0                     │
│                                                                                  │
│  uv pip install --python /Users/jim/work/proj/side-env/bin/python --upgrade fal  │
│                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────╯
```

**Lint / types** — `ruff format` and `ruff check` clean at the repo-pinned v0.3.4; `mypy 1.3.0` (with the pre-commit hook's stub packages) reports nothing in the new module. The `PLC0415` lazy-import ban doesn't apply here — neither `_installer.py` nor `cli/main.py` is in that hook's file list, and the imports are deliberately lazy to stay off the CLI startup path.

**CI** — at `ef1c8b6a`: `unit` green on py3.10–3.14 and on `windows-2022`, plus `pre-commit`, `container`, `pages` and CodeQL green.

Two known-red jobs, neither caused by this change:

- **`unit` on py3.8 and py3.9** fail at *collection*, in every CLI test module, from [`argcomplete 3.7.1`](https://pypi.org/project/argcomplete/3.7.1/) (published 2026-08-04 15:03 UTC). It still declares `requires-python >=3.8` but uses syntax that does not work there — `completers.py:30` subscripts `collections.abc.Iterable` in a class body (3.9+) and uses `X | Y` unions (3.10+) — so py3.8 raises `TypeError: 'ABCMeta' object is not subscriptable` and py3.9 raises `TypeError: unsupported operand type(s) for |: 'type' and 'type'`. Both tracebacks bottom out inside `site-packages/argcomplete/`, reached through `fal/cli/parser.py`. Reproduced locally on 3.8: the error appears with `argcomplete==3.7.1` and disappears with `3.7.0` (248 passed in `tests/unit/cli` + `tests/unit/test_installer.py`, leaving only the pre-existing `test_deploy` failures). This blocks any PR in the repo touching these matrix entries — `main`'s last `unit` run predates the release — and is deliberately not pinned here, to keep this diff to the upgrade hint.
- **`integration` and `e2e`** fail with `UNAUTHENTICATED: Insufficient permissions` from the shared `FAL_KEY` against `api.alpha.fal.ai`, across every test in the job; the last two `integration` runs on `main` fail the same way, so this is a credential/environment issue rather than a regression from this change.

### Not verified

- **A real install of any of these managers on Linux or Windows.** The unit tests do run and pass on `windows-2022` in CI, and detection is pure path/marker logic with no platform branches, but all nine live-environment probes above were macOS only. In particular the PowerShell claims (`&&` rejected by 5.1; a quoted leading path needing `&`) come from documented behaviour and the reviewer's report, not from a Windows shell in this session — the code sidesteps both where it can (`uv sync --upgrade-package`, bare interpreter name when PATH resolves it) but the quoted-full-path fallback remains unrunnable as-is in PowerShell.
- **Poetry's editable spelling.** The bare `poetry` value a root `poetry install` writes is covered by a unit test and by reading Poetry's source, not by a live editable install; the versioned `Poetry 2.4.1` spelling from `poetry add` was verified live.
- The full `tests/unit` suite has 6 pre-existing failures in `tests/unit/cli/test_deploy.py` on this checkout, plus 12 errors in `tests/unit/test_file_sync.py` that need credentials the local environment lacks; both reproduce with this change stashed and are unrelated to it. Everything else passes (900 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX change with broad test coverage; detection failures fall back to pip and log a warning without breaking the CLI.
> 
> **Overview**
> Replaces the hardcoded `pip install --upgrade fal` in the **new version available** panel with **`get_upgrade_command()`** from new **`fal/_installer.py`**, which infers install context (pipx, `uv tool`, uv project vs plain uv venv, Poetry, PDM, activated venv) and returns the matching upgrade command.
> 
> Detection uses venv marker files before dist-info `INSTALLER` (pipx uses uv under the hood), reads `INSTALLER` from the dist-info beside the running package, and applies uv-project heuristics (`uv.lock`, `.venv`, `UV_PROJECT_ENVIRONMENT`). Pip/uv hints spell out the interpreter when the activated venv is not the one running fal.
> 
> The update panel centers both lines against the wider of headline and command so long commands are not truncated. Unit tests cover detection edge cases and panel layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8ef1e7f0b42f58becb9f1e90af1d381e20b926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->