### PR TITLE
docs: document how to disable the CLI version-update notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ pip install -e 'projects/fal_client[dev]'
 pip install -e 'projects/isolate_proto[dev]'
 ```
 
+## Configuring the CLI
+
+The `fal` CLI stores its configuration in `~/.fal/config.toml` (override the
+location with the `FAL_CONFIG_PATH` environment variable).
+
+### Disabling the version-update notification
+
+On start-up the CLI prints a "new version is available" panel when a newer
+`fal` release exists. To turn it off — useful in CI — set the global
+`check_updates` key to `false`, at the top level of the file (not inside a
+profile section):
+
+```toml
+# ~/.fal/config.toml
+check_updates = false
+```
+
+The value must be a TOML boolean; the check is skipped automatically when the
+CLI's output is not a terminal.
+
 ## More resources
 
 - [Documentation index](https://fal.ai/docs/documentation)


### PR DESCRIPTION
Addresses Linear ticket F2D2-1 (Document how to disable the fal CLI version-update notification).

The `fal` CLI prints a "new version is available" panel on start-up when a newer release exists. The opt-out already exists in code — the global `check_updates` key in `~/.fal/config.toml`, gated in `projects/fal/src/fal/cli/main.py::_check_latest_version` — but it was not written down anywhere.

This PR adds a "Configuring the CLI" section to the README documenting:
- the setting name (`check_updates`) and where it lives (`~/.fal/config.toml`, overridable via `FAL_CONFIG_PATH`),
- how to set it (top-level TOML boolean `check_updates = false`),
- that the check is also skipped automatically when output is not a terminal.

Docs-only; no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds a **Configuring the CLI** section to the README that documents how to turn off the startup “new version is available” panel.
> 
> It explains that config lives in `~/.fal/config.toml` (or `FAL_CONFIG_PATH`), and that a top-level `check_updates = false` disables the check—useful in CI. It also notes the check is skipped when CLI output is not a terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb70c1285866106faf767410d7c73c5fbcb9b5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->