### PR TITLE
DRAFT: ci: daily canary against the published fal on PyPI

### DIFF
--- a/.github/workflows/fal-pypi-canary.yml
+++ b/.github/workflows/fal-pypi-canary.yml
@@ -1,0 +1,58 @@
+name: PyPI Canary (fal)
+
+# Installs the *published* fal from PyPI and checks the CLI starts.
+#
+# Everything else in CI tests a checkout. Nothing watches what users actually
+# receive, so an upstream release can break every fal version already on PyPI
+# with no commit to this repo and no signal here.
+#
+# That is not hypothetical: argcomplete 3.7.1 (2026-08-04 15:03 UTC) declared
+# `requires-python >=3.8` while using 3.10-only syntax, so `pip install fal`
+# produced a CLI that could not start on 3.8/3.9 -- for every release ever
+# published, including ones a month old. It went unnoticed until someone looked.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # every day at 7:00 UTC
+
+  workflow_dispatch:
+
+  # Run when this file changes, so it can be validated in review.
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/fal-pypi-canary.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  published:
+    name: published fal (py ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install the latest published fal from PyPI
+        run: |
+          pip install --upgrade pip wheel
+          pip install fal
+
+      - name: Report what resolved
+        run: pip freeze
+
+      - name: Start the CLI
+        run: |
+          python -c "import fal, fal.cli, fal.cli.parser"
+          fal --help > /dev/null


### PR DESCRIPTION
> **DRAFT** — opened as draft per repo convention. The change is complete; see the expected-red note below before reading CI.

Follow-up to [#1127](https://github.com/fal-ai/fal/pull/1127). That PR fixes the dependency and stops a release shipping on stale-green tests. This adds the missing detector.

## Problem

Every job in this repo tests a checkout. Nothing looks at what users actually receive from PyPI, so an upstream release can break **every published fal version** with no commit here and no signal.

That happened on 2026-08-04. [argcomplete 3.7.1](https://pypi.org/project/argcomplete/3.7.1/) declared `requires-python >=3.8` while using 3.10-only syntax, and because fal's `argcomplete<4` bound is open and present in every release, `pip install fal` produced a CLI that could not start:

| Install today | argcomplete | `fal --help` |
| --- | --- | --- |
| `fal==1.79.0` on py3.9 | 3.7.1 | **crashes** |
| `fal==1.78.3` on py3.9 (a month older) | 3.7.1 | **crashes** |
| `fal==1.79.0` on py3.10 | 3.7.1 | ok |

Users were broken for 9.5 hours before anyone noticed, and nothing in CI was capable of noticing. The daily `unit` cron would not have caught it either — it tests the source tree, not the released artifact.

## Change

One workflow. Installs the published package on each supported interpreter and starts the CLI:

```yaml
- run: pip install fal
- run: |
    python -c "import fal, fal.cli, fal.cli.parser"
    fal --help > /dev/null
```

Daily at 07:00 UTC, plus manual dispatch. It also runs on changes to its own file so it can be exercised in review rather than merged blind.

Deliberately minimal — install, import, `--help`. It answers one question ("can a user run fal right now?") and is not a place to grow a test suite; the unit matrix covers behaviour.

## Expect red on 3.8 and 3.9

`published fal (py 3.8)` and `(py 3.9)` **will fail on this PR**, and will keep failing until a release carrying [#1127](https://github.com/fal-ai/fal/pull/1127) reaches PyPI. That is the canary working: published fal genuinely is broken on those interpreters right now. The 3.10–3.14 jobs should pass.

If it were green today, it would not be measuring anything.

## How to test

Reproduce what the job does, on an interpreter it covers:

```bash
uv venv /tmp/canary39 --python 3.9
uv pip install --python /tmp/canary39/bin/python fal
/tmp/canary39/bin/python -c "import fal, fal.cli, fal.cli.parser"
/tmp/canary39/bin/fal --help          # currently: TypeError
```

Then confirm the job goes green once the dependency is sane, which is what a post-#1127 release will produce:

```bash
uv pip install --python /tmp/canary39/bin/python fal "argcomplete!=3.7.1"
/tmp/canary39/bin/fal --help          # ok
```

**Verified in this session:**

| Check | Result |
| --- | --- |
| Published `fal==1.79.0` on py3.9 | `fal --help` **crashes** — canary fires |
| Published `fal==1.78.3` on py3.9 | `fal --help` **crashes** — confirms it is not release-specific |
| Published `fal==1.79.0` on py3.10 | `fal --help` ok — no false positive above 3.10 |
| Published `fal==1.79.0` + `argcomplete!=3.7.1` on py3.9 | `fal --help` ok — canary clears once resolution is sane |
| Published `fal==1.79.0` + `argcomplete!=3.7.1` on py3.8 | `fal --help` ok — no undeclared runtime dep on 3.8 |
| `actionlint` | clean |

**Not verified:** the scheduled trigger, which cannot be exercised before merge. The matrix and steps are identical across triggers, and the PR run covers them.

## Note

`e2e` and `integration` failures on this repo are pre-existing and unrelated — they fail on `main` too, with `Insufficient permissions` from the CI service account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
