### PR TITLE
ci(release): smoke-test the built wheel before publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,16 +75,86 @@ jobs:
     needs: build
     uses: ./.github/workflows/fal-unit-tests.yml
 
+  # `unit-tests` installs the source tree (`pip install -e projects/fal`), so
+  # nothing above ever installs the artifact `pypi-publish` is about to upload.
+  # A wheel is a filtered copy of the source plus generated metadata, and the
+  # filter and the generation are both places to lose something: a subpackage
+  # missing from the packaging config, a data file not included, a broken
+  # console-script entry point, or a dependency marker that did not make it into
+  # METADATA. An editable install finds all of that on disk regardless, so the
+  # suite stays green and the breakage ships. This installs the built wheel with
+  # no checkout on the runner — site-packages is the only place the package can
+  # come from — and runs it.
+  wheel-smoke:
+    name: smoke (py ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    needs: [build, unit-tests]
+    if: >-
+      ${{ !cancelled()
+        && !inputs.skip_tests
+        && needs.build.result == 'success'
+        && (needs['unit-tests'].result == 'success' || needs['unit-tests'].result == 'skipped') }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.8 and 3.9 are where the dependency markers diverge from 3.10+, and
+        # where the argcomplete 3.7.1 break landed; 3.13 covers current
+        # resolution. All three projects declare requires-python >=3.8.
+        python: ["3.8", "3.9", "3.13"]
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install the built wheel
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+      - name: Import the installed package
+        env:
+          NAME: ${{ needs.build.outputs.name }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          python -c "
+          import importlib, importlib.metadata as md, os
+          name = os.environ['NAME']
+          importlib.import_module(name)
+          installed = md.version(name)
+          print(f'{name} {installed} installed from wheel and imports')
+          expected = os.environ['VERSION']
+          if installed != expected:
+              print(f'::warning::wheel is version {installed}, tag says {expected}')
+          "
+
+      - name: Run the CLI entry point
+        if: ${{ needs.build.outputs.name == 'fal' }}
+        run: |
+          set -euo pipefail
+          fal --version
+          fal --help > /dev/null
+
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: [build, unit-tests]
+    needs: [build, unit-tests, wheel-smoke]
     # `unit-tests` is skipped for non-fal projects (isolate_proto, fal_client),
-    # and a skipped dependency would otherwise skip this job too.
+    # both are skipped by `skip_tests`, and a skipped dependency would otherwise
+    # skip this job too.
     if: >-
       ${{ !cancelled()
         && needs.build.result == 'success'
-        && (needs['unit-tests'].result == 'success' || needs['unit-tests'].result == 'skipped') }}
+        && (needs['unit-tests'].result == 'success' || needs['unit-tests'].result == 'skipped')
+        && (needs['wheel-smoke'].result == 'success' || needs['wheel-smoke'].result == 'skipped') }}
     environment:
       name: pypi
       url: https://pypi.org/p/${{ needs.build.outputs.name }}
@@ -104,12 +174,13 @@ jobs:
   # run in parallel with the suite and could push ghcr.io/fal-ai/fal:latest from
   # a build the gate had just blocked from PyPI.
   release-container:
-    needs: [build, unit-tests]
+    needs: [build, unit-tests, wheel-smoke]
     if: >-
       ${{ !cancelled()
         && needs.build.outputs.name == 'fal'
         && needs.build.result == 'success'
-        && (needs['unit-tests'].result == 'success' || needs['unit-tests'].result == 'skipped') }}
+        && (needs['unit-tests'].result == 'success' || needs['unit-tests'].result == 'skipped')
+        && (needs['wheel-smoke'].result == 'success' || needs['wheel-smoke'].result == 'skipped') }}
     uses: ./.github/workflows/container.yml
     with:
       version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
> [!NOTE]
> **DRAFT** — the gate logic and the job body are verified (details below), but this has not run against a real `release` event, which requires publishing.

Follow-up to [#1127](https://github.com/fal-ai/fal/pull/1127), which gated the PyPI publish on a fresh unit-test run.

## Problem

The gate [#1127](https://github.com/fal-ai/fal/pull/1127) added installs the **source tree**:

```yaml
# .github/workflows/fal-unit-tests.yml
pip install -e 'projects/fal[test]' graphlib ${{ matrix.deps }}
pytest -n auto -v projects/fal/tests/unit
```

`build` produces the wheel, `pypi-publish` uploads that same wheel, and nothing in between installs it. An editable install points Python at `projects/fal/src` on disk, so the suite exercises the repository, not the artifact users download.

A wheel is a filtered copy of the source plus generated metadata, and both the filter and the generation can lose something:

| Failure | Caught by the unit gate today | Ships silently |
| --- | --- | --- |
| Bug in fal's own logic | ✅ | |
| Open dependency bound resolves to a broken release (the argcomplete 3.7.1 case) | ✅ | |
| Subpackage missing from the packaging config | ❌ | ✅ |
| Non-`.py` data file not included in the wheel | ❌ | ✅ |
| `fal` console-script entry point broken in built metadata | ❌ | ✅ |
| Dependency marker in `pyproject.toml` absent from built `METADATA` | ❌ | ✅ |

The last row is the closest to home: [#1127](https://github.com/fal-ai/fal/pull/1127)'s fix *is* a metadata change, and the gate reads that constraint from `pyproject.toml`, never from the wheel. Every one of these presents to a user exactly like the 1.79.0 incident — `pip install fal` succeeds, the first command crashes.

## Changes

One new job in [`release.yaml`](https://github.com/fal-ai/fal/blob/ba269185/.github/workflows/release.yaml), between `unit-tests` and publish:

```yaml
wheel-smoke:
  needs: [build, unit-tests]
  strategy:
    matrix:
      python: ["3.8", "3.9", "3.13"]
  steps:
    - download-artifact: dist          # the exact bytes build produced
    - setup-python
    - python -m pip install dist/*.whl # no checkout on the runner
    - python -c "import <project>"     # site-packages is the only source
    - fal --version && fal --help      # fal only
```

There is deliberately **no `actions/checkout`** in this job: with no source tree on disk, `site-packages` is the only place the package can come from, so an incomplete wheel cannot be papered over.

`pypi-publish` and `release-container` now list `wheel-smoke` in `needs` and tolerate `success || skipped`, matching how they already treat `unit-tests` — a skipped dependency would otherwise skip the publish.

Three details worth a reviewer's eye:

- **`!inputs.skip_tests`, not `github.event.inputs.skip_tests`.** Same trap [#1127](https://github.com/fal-ai/fal/pull/1127) documented: the latter is always a string and every non-empty string is truthy, so it would disable the gate on every dispatch while looking correct. The emergency bypass skips this job along with the unit suite.
- **Not scoped to `fal`.** The install-and-import check runs for `fal_client` and `isolate_proto` too, which have no release gating at all today. Verified below that both install and import cleanly on 3.8 and 3.13, so this does not put their releases at new risk. The CLI step is `fal`-only, since only `fal` ships a console script.
- **The version mismatch is a warning, not a failure.** `build` derives `version` from the tag while the wheel's version comes from `setuptools_scm` on the checked-out tree. On a `release` event these agree; on a `workflow_dispatch` with a `tag` input they can diverge, and failing there would be a new way to block an emergency release rather than a defect this job is meant to catch.

Costs ~30s per leg, three legs, in parallel with nothing else on the critical path.

## How to test

Reproduce what the job does, against the real published wheel:

```bash
curl -sLO https://files.pythonhosted.org/packages/3a/39/dbeec30b1a3a34754089beb2bf2912771dd8d307ba9c7c081b9d4cec0023/fal-1.79.1-py3-none-any.whl
uv venv /tmp/smoke --python 3.9 --seed
/tmp/smoke/bin/python -m pip install fal-1.79.1-py3-none-any.whl
/tmp/smoke/bin/python -c "import fal, importlib.metadata as m; print(m.version('fal'))"
/tmp/smoke/bin/fal --version && /tmp/smoke/bin/fal --help > /dev/null
```

Confirm it fails when it should — the actual incident, using the yanked artifact:

```bash
# fal 1.79.0, the release this class of gate exists to stop
uv venv /tmp/neg --python 3.9 --seed
/tmp/neg/bin/python -m pip install fal-1.79.0-py3-none-any.whl
/tmp/neg/bin/fal --version    # TypeError from argcomplete 3.7.1, exit 1
```

`actionlint .github/workflows/release.yaml` for the workflow itself. The job cannot run on a pull request — it needs a `release` event — so it was exercised on throwaway branches, described below.

**Verified in this session:**

| Check | Result |
| --- | --- |
| `actionlint` on `release.yaml` | clean (repo-wide findings are pre-existing: `set-output` in `container.yml`, shellcheck info in `create-release.yaml`) |
| Job body on GitHub runners, py 3.8 / 3.9 / 3.13 | **all 3 green**, 25–32s each |
| — py3.8 leg resolved | `argcomplete 3.7.0` (marker honoured from wheel METADATA) |
| — py3.9 leg resolved | `argcomplete 3.7.0` |
| — py3.13 leg resolved | `argcomplete 3.7.1` (latest, unaffected) |
| Real `fal-1.79.1` wheel, local py 3.8 / 3.9 / 3.13 | installs, imports, `fal --version` → `1.79.1`, `fal --help` exit 0 |
| **Negative:** yanked `fal-1.79.0` wheel on py3.9 | `fal --version` **exit 1**, `TypeError: unsupported operand type(s) for \|` — the incident is caught |
| **Negative:** `fal-1.79.1` wheel with `fal/cli/parser.py` removed from the zip and RECORD | `import fal` **passes**, `fal --version` **exit 1** (`ModuleNotFoundError: fal.cli.parser`) while the file is still present in `projects/fal/src` — i.e. an editable install would stay green |
| `fal_client` and `isolate_proto` install + import, py 3.8 and 3.13 | ok — extending the job to them is safe |

### Gate conditions, executed

The `needs`/`if` graph is where a wrong expression silently blocks every release or silently disables the gate, so it was reproduced job-for-job with the publish and container steps replaced by `echo`, and run on a throwaway branch (since deleted):

| Scenario | `unit-tests` | `wheel-smoke` | `pypi-publish` | `release-container` | Expected |
| --- | --- | --- | --- | --- | --- |
| `fal`, everything passes | success | success | **ran** | **ran** | ✅ publishes |
| `fal`, smoke fails | success | failure | **skipped** | **skipped** | ✅ gate holds |
| `isolate_proto` | skipped | success | **ran** | **skipped** | ✅ other projects unaffected, container stays fal-only |

The second row is the point of the change; the third is the one that would break `isolate_proto` and `fal_client` releases if the success-or-skipped tolerance were wrong.

**Not verified:** no run against a real `release` event, which would require publishing a version — the simulations above cover the job body and the gate logic separately. The `skip_tests` bypass path was not re-executed here; `inputs.skip_tests` is unreachable from a push event, and the clause is identical to the one measured in [#1127](https://github.com/fal-ai/fal/pull/1127).

## Follow-ups, not in this PR

- **The sdist is still untested.** `build` produces `.tar.gz` as well, and nothing installs it. `pip install dist/*.tar.gz` on one leg would cover it, at the cost of a real build per run.
- **`twine check dist/*`** in `build` would catch malformed long-description metadata before PyPI rejects it.
- **A scheduled canary against the published package**, still open from [#1127](https://github.com/fal-ai/fal/pull/1127)'s follow-ups — this job checks the artifact at release time, but an upstream break *after* release is still invisible until a user reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release gating; no application runtime or auth/data paths modified, though a stricter gate could block releases if smoke fails.
> 
> **Overview**
> Adds a **`wheel-smoke`** job to the release workflow so PyPI and container publish only run after the **built wheel** (not an editable source install) is exercised.
> 
> The job downloads the `dist` artifact **without checkout**, installs `dist/*.whl` on Python **3.8, 3.9, and 3.13**, imports the release package, and for **`fal` only** runs `fal --version` and `fal --help`. It respects **`!inputs.skip_tests`** like unit tests and allows **`unit-tests`** to be skipped for non-`fal` projects.
> 
> **`pypi-publish`** and **`release-container`** now **`need` `wheel-smoke`** and accept **`success || skipped`** so a failed smoke blocks release without breaking `isolate_proto` / `fal_client` paths where unit tests are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad9e06ab33c2af482b6f1c6350af706b8c71c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->