### PR TITLE
fix(cli): report app import exits

### DIFF
--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -163,14 +163,10 @@ def load_function_from(
     try:
         module = runpy.run_path(file_path)
     except SystemExit as exc:
-        status = exc.code
-        if status is None:
-            status = 0
-        elif not isinstance(status, int):
-            status = 1
+        exit_arg = exc.code
         raise FalServerlessError(
             f"Failed to load app from {file_path!r}: "
-            f"the app module called sys.exit({status}) during import."
+            f"the app module called sys.exit({exit_arg!r}) during import."
         ) from None
     target, found_app_name, found_app_auth, class_name = _find_target(
         module, function_name

--- a/projects/fal/src/fal/utils.py
+++ b/projects/fal/src/fal/utils.py
@@ -160,7 +160,18 @@ def load_function_from(
         raise FalServerlessError("App ref must resolve to a file path.")
 
     sys.path.append(os.getcwd())
-    module = runpy.run_path(file_path)
+    try:
+        module = runpy.run_path(file_path)
+    except SystemExit as exc:
+        status = exc.code
+        if status is None:
+            status = 0
+        elif not isinstance(status, int):
+            status = 1
+        raise FalServerlessError(
+            f"Failed to load app from {file_path!r}: "
+            f"the app module called sys.exit({status}) during import."
+        ) from None
     target, found_app_name, found_app_auth, class_name = _find_target(
         module, function_name
     )

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import fal
-from fal.api import IsolatedFunction, Options
+from fal.api import FalServerlessError, IsolatedFunction, Options
 from fal.api.api import merge_basic_config
 from fal.api.client import SyncServerlessClient
 from fal.sdk import ApplicationHealthCheckConfig
@@ -487,6 +487,17 @@ def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
     assert wrapped_cls.app_files == ["class-files"]
     assert wrapped_cls.app_files_ignore == ["class-ignore"]
     assert wrapped_cls.app_files_context_dir == "class-context"
+
+
+def test_load_function_from_reports_system_exit_during_import(tmp_path):
+    app_file = tmp_path / "app.py"
+    app_file.write_text("raise SystemExit(1)\n")
+
+    with pytest.raises(
+        FalServerlessError,
+        match=r"app\.py.*called sys\.exit\(1\) during import",
+    ):
+        load_function_from(DummyHost(), str(app_file))
 
 
 def test_load_function_from_rejects_class_app_files_with_toml_image(tmp_path):

--- a/projects/fal/tests/unit/test_utils.py
+++ b/projects/fal/tests/unit/test_utils.py
@@ -489,15 +489,24 @@ def test_load_function_from_preserves_app_defined_app_files_over_toml(tmp_path):
     assert wrapped_cls.app_files_context_dir == "class-context"
 
 
-def test_load_function_from_reports_system_exit_during_import(tmp_path):
+@pytest.mark.parametrize(
+    ("exit_arg", "rendered_arg"),
+    [
+        (1, "1"),
+        ("missing API key", "'missing API key'"),
+    ],
+)
+def test_load_function_from_reports_system_exit_during_import(
+    tmp_path, exit_arg, rendered_arg
+):
     app_file = tmp_path / "app.py"
-    app_file.write_text("raise SystemExit(1)\n")
+    app_file.write_text(f"raise SystemExit({exit_arg!r})\n")
 
-    with pytest.raises(
-        FalServerlessError,
-        match=r"app\.py.*called sys\.exit\(1\) during import",
-    ):
+    with pytest.raises(FalServerlessError) as exc_info:
         load_function_from(DummyHost(), str(app_file))
+
+    assert str(app_file) in exc_info.value.message
+    assert f"called sys.exit({rendered_arg}) during import" in exc_info.value.message
 
 
 def test_load_function_from_rejects_class_app_files_with_toml_image(tmp_path):


### PR DESCRIPTION
Fixes INFRA-4449.

`runpy.run_path()` can propagate `SystemExit` from application import code. Because `SystemExit` bypasses the CLI’s `except Exception` handler, `fal deploy` previously terminated with the requested status and no fal error output.

Convert that import-time exit into a user-facing `FalServerlessError` that names the app file and exit status. Added a regression test for `SystemExit(1)` and verified the CLI now prints the diagnostic before returning code 1.

Verification:
- `python -m uv run --project projects/fal --extra test pytest projects/fal/tests/unit/test_utils.py -q` (36 passed)
- smoke: `fal deploy` against an app containing `raise SystemExit(1)` prints the new diagnostic and exits 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling around app import in utils.py; no changes to deploy/runtime behavior beyond clearer failures when import code exits.
> 
> **Overview**
> When an app file calls `sys.exit()` (or raises `SystemExit`) during import, `runpy.run_path` used to let that bubble out of `load_function_from`, so commands like **`fal deploy`** could exit silently with no fal error message because `SystemExit` is not caught by generic `except Exception` handlers.
> 
> **`load_function_from`** now catches import-time **`SystemExit`**, re-raises **`FalServerlessError`** with the app path and exit code/message, so the CLI can print a clear diagnostic before exiting. A parametrized unit test covers numeric and string exit arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41709e22b1c648b34debbbe1f750c5b5219b5d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->