### PR TITLE
fix FalFileSystem paths behind normalizing proxies

### DIFF
--- a/projects/fal/src/fal/files.py
+++ b/projects/fal/src/fal/files.py
@@ -88,8 +88,20 @@ class FalFileSystem(AbstractFileSystem):
 
         return posixpath.join(cwd, rpath)
 
+    def _endpoint_path(self, path):
+        """Return a path relative to the server's implicit ``/data`` root.
+
+        Embedding an absolute path in a route would produce a double slash, for
+        example ``/files/list//data/models``. HTTP proxies are allowed to
+        normalize that to ``/files/list/data/models``. The files API interprets
+        route paths as relative to ``/data``, so the normalized request would
+        otherwise address ``/data/data/models``.
+        """
+        return posixpath.relpath(self._abspath(path), "/data")
+
     def _ls(self, path):
-        response = self._request("GET", f"/files/list/{path}")
+        endpoint_path = self._endpoint_path(path)
+        response = self._request("GET", f"/files/list/{endpoint_path}")
         files = response.json()
         return sorted(
             (
@@ -149,7 +161,8 @@ class FalFileSystem(AbstractFileSystem):
             return
 
         with open(lpath, "wb") as fobj:
-            response = self._request("GET", f"/files/file/{abs_rpath}")
+            endpoint_path = self._endpoint_path(abs_rpath)
+            response = self._request("GET", f"/files/file/{endpoint_path}")
             fobj.write(response.content)
 
     def _put_file_multipart(self, lpath, rpath, size, progress):
@@ -163,7 +176,7 @@ class FalFileSystem(AbstractFileSystem):
 
         multipart = DataFileMultipartUpload(
             client=self._client,
-            target_path=rpath,
+            target_path=self._endpoint_path(rpath),
             chunk_size=MULTIPART_CHUNK_SIZE,
             max_concurrency=MULTIPART_MAX_CONCURRENCY,
         )
@@ -195,9 +208,10 @@ class FalFileSystem(AbstractFileSystem):
             else:
                 task = progress.add_task(f"{os.path.basename(lpath)}", total=1)
                 with open(lpath, "rb") as fobj:
+                    endpoint_path = self._endpoint_path(abs_rpath)
                     self._request(
                         "POST",
-                        f"/files/file/local/{abs_rpath}",
+                        f"/files/file/local/{endpoint_path}",
                         files={"file_upload": (posixpath.basename(lpath), fobj)},
                     )
                 progress.advance(task)
@@ -205,9 +219,10 @@ class FalFileSystem(AbstractFileSystem):
 
     def put_file_from_url(self, url, rpath, mode="overwrite", **kwargs):
         abs_rpath = self._abspath(rpath)
+        endpoint_path = self._endpoint_path(abs_rpath)
         self._request(
             "POST",
-            f"/files/file/url/{abs_rpath}",
+            f"/files/file/url/{endpoint_path}",
             json={"url": url},
             timeout=10 * 60,  # 10 minutes in seconds
         )
@@ -215,18 +230,20 @@ class FalFileSystem(AbstractFileSystem):
 
     def rm(self, path, **kwargs):
         abs_path = self._abspath(path)
+        endpoint_path = self._endpoint_path(abs_path)
         self._request(
             "DELETE",
-            f"/files/file/{abs_path}",
+            f"/files/file/{endpoint_path}",
         )
         self.dircache.clear()
 
     def rename(self, path, destination, **kwargs):
         abs_path = self._abspath(path)
         abs_dest = self._abspath(destination)
+        endpoint_path = self._endpoint_path(abs_path)
         self._request(
             "POST",
-            f"/files/rename/{abs_path}",
+            f"/files/rename/{endpoint_path}",
             json={"destination": abs_dest},
         )
         self.dircache.clear()

--- a/projects/fal/tests/unit/test_fal_filesystem.py
+++ b/projects/fal/tests/unit/test_fal_filesystem.py
@@ -1,0 +1,18 @@
+import pytest
+
+from fal.files import FalFileSystem
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/data", "."),
+        ("/data/tmp/file.txt", "tmp/file.txt"),
+        ("tmp/file.txt", "tmp/file.txt"),
+        (".", "."),
+    ],
+)
+def test_endpoint_path_is_relative_to_data(path, expected):
+    fs = FalFileSystem(skip_instance_cache=True)
+
+    assert fs._endpoint_path(path) == expected


### PR DESCRIPTION
## Summary

- serialize `FalFileSystem` route parameters relative to the files API's implicit `/data` root
- apply the conversion consistently to list, upload, multipart upload, download, delete, URL upload, and rename requests
- add a focused unit regression test for absolute and relative filesystem paths

## Root cause

`FalFileSystem` embedded absolute remote paths directly into route URLs, producing paths such as `/files/file/local//data/tmp/...`.

Envoy normalizes the double slash before forwarding the request. FastAPI therefore receives `/files/file/local/data/tmp/...` and interprets `data/tmp/...` relative to `/data`, writing the file under `/data/data/tmp/...`. A subsequent list returns that doubled path, which does not match the client's expected `/data/tmp/...`, so `exists()` returns false even though the upload returned 200.

The SDK now sends `tmp/...` in the route while preserving `/data/tmp/...` as the public filesystem path.

## Impact

This restores absolute `FalFileSystem` paths behind proxies that normalize repeated slashes and fixes `tests/integration/test_files.py::test_fal_fs` against shark. Relative filesystem paths retain their existing meaning.

## Validation

- `ruff format --check projects/fal/src/fal/files.py projects/fal/tests/unit/test_fal_filesystem.py`
- `ruff check --ignore PLC0415 projects/fal/src/fal/files.py projects/fal/tests/unit/test_fal_filesystem.py`
- `git diff --check`
- Tests were not run, per request.
