### PR TITLE
feat: Add forward compat flag

### DIFF
--- a/projects/fal/src/fal/cli/run.py
+++ b/projects/fal/src/fal/cli/run.py
@@ -80,6 +80,11 @@ def _run(args):
     isolated_function = loaded.function
     if args.machine_type is not None:
         isolated_function.options.host["machine_type"] = args.machine_type
+    if args.forward_compat:
+        isolated_function.options.host["_scheduler_options"] = {
+            **(isolated_function.options.host.get("_scheduler_options") or {}),
+            "forward_compat": True,
+        }
 
     if not args.local:
         from ._result_handlers import PrepareRequirementsCallback
@@ -205,6 +210,11 @@ def add_parser(main_subparsers, parents):
         "--machine-type",
         type=str,
         help="Machine type to use for this run.",
+    )
+    parser.add_argument(
+        "--forward-compat",
+        action="store_true",
+        help="Run on test nodes carrying upcoming node changes.",
     )
     parser.add_argument(
         "--limit-max-requests",

--- a/projects/fal/tests/unit/cli/test_run.py
+++ b/projects/fal/tests/unit/cli/test_run.py
@@ -16,6 +16,7 @@ def test_run():
     assert args.func == _run
     assert args.func_ref == ("/my/path.py", "myfunc")
     assert args.machine_type is None
+    assert args.forward_compat is False
     assert args.limit_max_requests is None
     assert args.exposed_port is None
     assert args.exposed_metrics_port is None
@@ -46,6 +47,13 @@ def test_run_with_machine_type():
     assert args.func == _run
     assert args.func_ref == ("/my/path.py", "myfunc")
     assert args.machine_type == "GPU-H100"
+
+
+def test_run_with_forward_compat():
+    args = parse_args(["run", "/my/path.py::myfunc", "--forward-compat"])
+    assert args.func == _run
+    assert args.func_ref == ("/my/path.py", "myfunc")
+    assert args.forward_compat is True
 
 
 def test_run_with_limit_max_requests():
@@ -171,6 +179,7 @@ def mock_args(
     no_cache: bool = False,
     auth: Optional[str] = "public",
     machine_type: Optional[str] = None,
+    forward_compat: bool = False,
     limit_max_requests: Optional[int] = None,
     local: bool = False,
     exposed_port: Optional[int] = None,
@@ -187,6 +196,7 @@ def mock_args(
     args.app_name = None
     args.env = None
     args.machine_type = machine_type
+    args.forward_compat = forward_compat
     args.limit_max_requests = limit_max_requests
     args.local = local
     args.exposed_port = exposed_port
@@ -463,6 +473,33 @@ def test_run_applies_machine_type_override(mock_load_function_from, mock_create_
     _run(args)
 
     assert loaded.function.options.host["machine_type"] == "GPU-H100"
+
+
+@patch("fal.api.client.SyncServerlessClient._create_host")
+@patch("fal.utils.load_function_from")
+def test_run_applies_forward_compat_scheduler_option(
+    mock_load_function_from, mock_create_host
+):
+    host = mocked_fal_serverless_host("my-host")
+    mock_create_host.return_value = host
+
+    loaded = mocked_loaded_function(
+        options=Options(host={"_scheduler_options": {"storage_region": "us-east"}})
+    )
+    mock_load_function_from.return_value = loaded
+
+    args = mock_args(
+        func_ref=("/my/path.py", "myfunc"),
+        host="my-host",
+        forward_compat=True,
+    )
+
+    _run(args)
+
+    assert loaded.function.options.host["_scheduler_options"] == {
+        "storage_region": "us-east",
+        "forward_compat": True,
+    }
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, opt-in CLI change that only adjusts scheduler options before deploy; no auth or data-path changes.
> 
> **Overview**
> Adds an opt-in **`fal run --forward-compat`** flag so runs can target test nodes with upcoming infrastructure changes.
> 
> When the flag is set, `_run` sets **`forward_compat: true`** on **`options.host["_scheduler_options"]`**, merging with any existing scheduler options (same pattern as **`--machine-type`**). Unit tests cover CLI parsing and the merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e84bf5e0fcbcac00684dcdc33aa5d208277b03bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->