### PR TITLE
fix(client): adopt the runner's re-scoped CDN token from the queue result

### DIFF
--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -1488,6 +1488,12 @@ class SyncRequestHandle(_BaseRequestHandle):
             self.client, "GET", self.response_url, timeout=QUEUE_POLL_TIMEOUT
         )
         _raise_for_status(response)
+        # The result response is the only one that can carry the runner's
+        # re-scoped CDN token: the submit response is written before the runner
+        # has run, so its scope cannot cover the request ids the run ended up
+        # with access to. Adopting it here is what lets a chaining app read the
+        # output it just commissioned once tokens are request-scoped.
+        handle_response_headers(response.headers)
         return response.json()
 
     def cancel(self) -> None:
@@ -1568,6 +1574,9 @@ class AsyncRequestHandle(_BaseRequestHandle):
             timeout=QUEUE_POLL_TIMEOUT,
         )
         _raise_for_status(response)
+        # See the sync ``get`` above: the result response is the only one whose
+        # CDN token reflects the request ids the run actually accumulated.
+        handle_response_headers(response.headers)
         return response.json()
 
     async def cancel(self) -> None:

--- a/projects/fal_client/tests/unit/test_client.py
+++ b/projects/fal_client/tests/unit/test_client.py
@@ -2558,3 +2558,150 @@ class TestRaiseForStatus:
             request=httpx.Request("GET", "https://fal.run/test"),
         )
         _raise_for_status(resp)  # should not raise
+
+
+class _FakeCdnRequest:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class _FakeCdnApp:
+    def __init__(self, request):
+        self.current_request = request
+
+
+class TestQueueResultAdoptsCdnToken:
+    """``handle.get()`` must adopt the runner's re-scoped ``x-fal-cdn-token``.
+
+    The result response is the only one that can carry it: the submit response
+    is written before the runner has run, so its scope cannot cover the request
+    ids the run ended up with access to. Without this, a chaining app cannot
+    read the output it just commissioned once tokens are request-scoped, since
+    that object is tagged with the *inner* request id.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_current_app(self):
+        from fal_client._headers import set_get_current_app
+
+        yield
+        set_get_current_app(None)
+
+    @staticmethod
+    def _bind_app(headers):
+        from fal_client._headers import set_get_current_app
+
+        set_get_current_app(lambda: _FakeCdnApp(_FakeCdnRequest(headers)))
+        return headers
+
+    @staticmethod
+    def _result_response(headers=None):
+        req = httpx.Request("GET", "http://resp")
+        return httpx.Response(
+            200,
+            content=b'{"ok": true}',
+            headers={"Content-Type": "application/json", **(headers or {})},
+            request=req,
+        )
+
+    def test_sync_get_adopts_token(self, monkeypatch):
+        app_headers = self._bind_app({"x-fal-cdn-token": "outer-scope"})
+        client = httpx.Client()
+        handle = SyncRequestHandle(
+            request_id="r",
+            response_url="http://resp",
+            status_url="http://status",
+            cancel_url="http://cancel",
+            client=client,
+        )
+        monkeypatch.setattr(
+            SyncRequestHandle,
+            "iter_events",
+            lambda self, with_logs=False, interval=0: iter(
+                [Completed(logs=[], metrics={})]
+            ),
+            raising=True,
+        )
+        monkeypatch.setattr(
+            client,
+            "send",
+            lambda *a, **k: self._result_response({"x-fal-cdn-token": "inner-scope"}),
+            raising=False,
+        )
+        assert handle.get() == {"ok": True}
+        assert app_headers["x-fal-cdn-token"] == "inner-scope"
+
+    def test_sync_get_leaves_token_when_response_has_none(self, monkeypatch):
+        app_headers = self._bind_app({"x-fal-cdn-token": "outer-scope"})
+        client = httpx.Client()
+        handle = SyncRequestHandle(
+            request_id="r",
+            response_url="http://resp",
+            status_url="http://status",
+            cancel_url="http://cancel",
+            client=client,
+        )
+        monkeypatch.setattr(
+            SyncRequestHandle,
+            "iter_events",
+            lambda self, with_logs=False, interval=0: iter(
+                [Completed(logs=[], metrics={})]
+            ),
+            raising=True,
+        )
+        monkeypatch.setattr(
+            client, "send", lambda *a, **k: self._result_response(), raising=False
+        )
+        assert handle.get() == {"ok": True}
+        assert app_headers["x-fal-cdn-token"] == "outer-scope"
+
+    @pytest.mark.asyncio
+    async def test_async_get_adopts_token(self, monkeypatch):
+        app_headers = self._bind_app({"x-fal-cdn-token": "outer-scope"})
+        client = httpx.AsyncClient()
+        handle = AsyncRequestHandle(
+            request_id="r",
+            response_url="http://resp",
+            status_url="http://status",
+            cancel_url="http://cancel",
+            client=client,
+        )
+
+        async def _iter_events(self, with_logs=False, interval=0):
+            yield Completed(logs=[], metrics={})
+
+        monkeypatch.setattr(
+            AsyncRequestHandle, "iter_events", _iter_events, raising=True
+        )
+
+        async def _send(*a, **k):
+            return self._result_response({"x-fal-cdn-token": "inner-scope"})
+
+        monkeypatch.setattr(client, "send", _send, raising=False)
+        assert await handle.get() == {"ok": True}
+        assert app_headers["x-fal-cdn-token"] == "inner-scope"
+
+    @pytest.mark.asyncio
+    async def test_async_get_outside_app_context_is_noop(self, monkeypatch):
+        """Off-floor use (no fal app bound) must not raise."""
+        client = httpx.AsyncClient()
+        handle = AsyncRequestHandle(
+            request_id="r",
+            response_url="http://resp",
+            status_url="http://status",
+            cancel_url="http://cancel",
+            client=client,
+        )
+
+        async def _iter_events(self, with_logs=False, interval=0):
+            yield Completed(logs=[], metrics={})
+
+        monkeypatch.setattr(
+            AsyncRequestHandle, "iter_events", _iter_events, raising=True
+        )
+
+        async def _send(*a, **k):
+            return self._result_response({"x-fal-cdn-token": "inner-scope"})
+
+        monkeypatch.setattr(client, "send", _send, raising=False)
+        assert await handle.get() == {"ok": True}


### PR DESCRIPTION
## Problem

`handle.get()` fetched the queue result and returned `response.json()` without looking at the headers, so the **queue path silently dropped the `x-fal-cdn-token` the runner returns**. `subscribe` is built on `submit` + `handle.get()`, so every chaining app using it lost the token.

`submit` does call `handle_response_headers` — but on the **enqueue** response, written before the runner has even run. Its scope can never cover the request ids the run ended up with access to. Only the result response can.

## Why it matters

Once CDN tokens are request-scoped, an inner app's output is tagged with the **inner** request id, so the outer app's own token grants no read on it. The design ("CDN Access Control", Request-Scoped Access → Flow step 4) handles this by having the runner return a token whose scope accumulated every hop, which the gateway forwards upstream. That's needed rather than gateway-side reconstruction because in an A→B→C chain the gateway only knows the hop it proxied.

Everything except this step is already in place:

| leg | mechanism | status |
|---|---|---|
| gateway → runner (extend scope) | `_get_cdn_token` | ✓ |
| runner → response (set current token) | `fal.App` middleware | ✓ |
| gateway → caller (forward worker token) | `_build_worker_response_headers` — worker's token overrides the platform default | ✓ |
| caller adopts returned token | `handle_response_headers` | ✓ `run`/`stream`, ✗ **queue path** |

Verified against prod by forwarding a token as the caller: both `fal.run` and the queue result endpoint return `x-fal-cdn-token`, scoped `read:request_id:<that run's id>`.

## Change

One call in each of `SyncRequestHandle.get()` and `AsyncRequestHandle.get()`, after `_raise_for_status`.

`handle_response_headers` is already a no-op outside a fal app context, so non-app SDK users are unaffected.

## Testing

`TestQueueResultAdoptsCdnToken` — sync and async adoption, no-token-in-response leaves the existing token untouched, and no-app-context does not raise.

- `pytest tests/unit` → 148 passed
- `pre-commit run --files ...` → clean (ruff, ruff-format)

## Not covered — `fal.apps` has no token handling at all

`fal.apps.run`/`submit` send only `creds.to_headers()`: they neither forward `x-fal-cdn-token` on the way out nor adopt it on the way back. This PR does not reach them.

Four registry callers use that path:

| caller | chains to | exposure |
|---|---|---|
| `registry/video/fast_svd.py` | `fal-ai/fast-sdxl` | intermediate image ends up owned by the app owner and public; the parent then reads it by URL |
| `registry/video/fast_svd_lcm.py` | `fal-ai/fast-sdxl` | same |
| `registry/fine_tuning/personalization/inference.py` | `fal-ai/moondream/batched` | text output, no CDN object — unaffected |
| `registry/image/supir/inference.py` | `fal-ai/llava-next` | text output, no CDN object — unaffected |

The two `fast-sdxl` chains keep working post-flip precisely *because* the intermediate is not caller-scoped, but the caller does not own their own intermediate and it is world-readable. Suggested follow-up is migrating those callers to `registry.client` (which forwards, see fal-ai/registry#12943) rather than teaching `fal.apps` the protocol — one less client to maintain.

Part of INFRA-4420.
