### PR TITLE
fix(ci): mirror Docker Hub at the builder

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -29,6 +29,7 @@ jobs:
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
+        build-args: DOCKER_MIRROR=mirror.gcr.io
 
   push:
     if: github.event_name != 'pull_request'
@@ -55,6 +56,7 @@ jobs:
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
+        build-args: DOCKER_MIRROR=mirror.gcr.io
         push: true
         platforms: linux/amd64, linux/arm64
         tags: ghcr.io/fal-ai/fal:latest, ghcr.io/fal-ai/fal:${{ inputs.version || steps.version.outputs.version }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,11 +25,17 @@ jobs:
       uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
+      with:
+        # Resolve Docker Hub images through Google's pull-through cache so CI
+        # does not draw on the anonymous docker.io rate limit. BuildKit falls
+        # back to docker.io for anything the mirror cannot serve.
+        config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
     - name: Build container
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
-        build-args: DOCKER_MIRROR=mirror.gcr.io
 
   push:
     if: github.event_name != 'pull_request'
@@ -42,6 +48,13 @@ jobs:
       uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
+      with:
+        # Resolve Docker Hub images through Google's pull-through cache so CI
+        # does not draw on the anonymous docker.io rate limit. BuildKit falls
+        # back to docker.io for anything the mirror cannot serve.
+        config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
     - name: Login to GitHub Container Registry
       uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
@@ -56,7 +69,6 @@ jobs:
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
-        build-args: DOCKER_MIRROR=mirror.gcr.io
         push: true
         platforms: linux/amd64, linux/arm64
         tags: ghcr.io/fal-ai/fal:latest, ghcr.io/fal-ai/fal:${{ inputs.version || steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-# Registry the Docker Hub base image is pulled from. CI overrides this with a
-# pull-through cache so builds do not draw on the anonymous docker.io rate
-# limit; unset it and the build behaves exactly as before.
-ARG DOCKER_MIRROR=docker.io
-
-FROM ${DOCKER_MIRROR}/library/python:3.11-slim as build
+FROM python:3.11-slim as build
 RUN ln -s /usr/bin/python3 /tmp/python3
 RUN python3 -m venv /opt/fal
 COPY projects /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM python:3.11-slim as build
+# Registry the Docker Hub base image is pulled from. CI overrides this with a
+# pull-through cache so builds do not draw on the anonymous docker.io rate
+# limit; unset it and the build behaves exactly as before.
+ARG DOCKER_MIRROR=docker.io
+
+FROM ${DOCKER_MIRROR}/library/python:3.11-slim as build
 RUN ln -s /usr/bin/python3 /tmp/python3
 RUN python3 -m venv /opt/fal
 COPY projects /src


### PR DESCRIPTION
## Why

Docker Hub anonymous pull rate limiting (`429 Too Many Requests`) is currently breaking CI across our repos. This repo has exactly one Docker Hub dependency — the `python:3.11-slim` base image in the root `Dockerfile` — so this is the small tail of that work. Resolving it through Google's pull-through cache takes it off the rate limit: "pulling cached images does not count against Docker Hub rate limits" ([docs](https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images)).

## What changed

`.github/workflows/container.yml` only — both `docker/setup-buildx-action` steps (the PR-time `container` job and the `push` job) now pass a `config-inline` BuildKit config:

```toml
[registry."docker.io"]
  mirrors = ["mirror.gcr.io"]
```

**The `Dockerfile` is untouched** — byte-identical to `main`.

## How / design decisions

**The mirror is configured at the builder, not written into the image reference.** An earlier revision of this PR added `ARG DOCKER_MIRROR=docker.io` and rewrote the `FROM` line. This is better on every axis:

- **It falls back.** BuildKit tries the mirror and drops to `docker.io` for anything the mirror cannot serve. A rewritten `FROM mirror.gcr.io/library/python:3.11-slim` would simply fail if the image were not cached.
- **It stays out of the Dockerfile.** Anyone building this image locally or from another context gets stock Docker Hub behaviour with no build args to remember and no repointing at a Google cache.
- **It covers future base images automatically**, rather than only the `FROM` lines someone remembered to parameterize.

**`config-inline`, not `buildkitd-config-inline`** — this repo pins `setup-buildx-action@v2.10.0`, which predates the rename in v3.4. Verified against that tag's `action.yml` input list.

**The second stage, `gcr.io/distroless/python3-debian12`, is unaffected** — it already comes from GCR. The `Login to GitHub Container Registry` step is also untouched; it targets `ghcr.io`, and this repo neither pulls from nor pushes to Docker Hub with a credential.

> [!NOTE]
> Cache coverage is best-effort: Google caches "frequently-accessed" images with "no guarantee that a particular image will remain cached". Because this is a mirror rather than a rewritten reference, a miss is a fallback rather than a failure.

## How to review

One file, one repeated block. Worth confirming the input name is right for the pinned action version (`config-inline` on v2.x) and that the TOML is indented correctly inside the YAML block scalar.

## Test evidence

<details><summary>Workflow parses and both embedded TOML configs are valid</summary>

Parsed the YAML, then parsed each `config-inline` value as TOML and asserted on the resolved structure:

```
  job=container: config-inline TOML valid -> {'docker.io': {'mirrors': ['mirror.gcr.io']}}
  job=push:      config-inline TOML valid -> {'docker.io': {'mirrors': ['mirror.gcr.io']}}
workflow YAML parses; setup-buildx steps patched: 2
```

</details>

<details><summary>The cache serves this base image on both target platforms</summary>

The `push` job builds `linux/amd64, linux/arm64`. Platforms served for `python:3.11-slim` through the mirror:

```
linux/386      linux/amd64    linux/arm/v5   linux/arm/v7
linux/arm64/v8 linux/ppc64le  linux/riscv64  linux/s390x
```

And the manifest list is byte-identical to Docker Hub's, so the mirror is not serving a rebuild:

```
docker.io        manifests=16  amd64+arm64 digests=00eb6514bc506454
mirror.gcr.io    manifests=16  amd64+arm64 digests=00eb6514bc506454
```

</details>

> [!NOTE]
> I could not exercise `config-inline` end-to-end locally — this machine's Docker CLI has no `buildx` plugin, so a builder with that config could not be created. The TOML itself is the same stanza validated in fal-ai/infra#13394. **This PR's own `container` job is the real end-to-end check**; it builds on every PR, so a green run here is the proof.
