### PR TITLE
feat(sdk): forward health check config for fal run

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "isolate[build]>=0.26.9,<0.27.0",
-    "isolate-proto>=0.34.1,<1",
+    "isolate-proto>=0.34.2,<1",
     "grpcio>=1.64.0,<2",
     "dill==0.3.7",
     "cloudpickle>=3.0.0,<3.2",

--- a/projects/fal/src/fal/api/api.py
+++ b/projects/fal/src/fal/api/api.py
@@ -1255,6 +1255,7 @@ class FalServerlessHost(Host):
         request_timeout = options.host.get("request_timeout")
         startup_timeout = options.host.get("startup_timeout")
         regions = options.host.get("regions")
+        health_check_config = options.host.get("health_check_config")
         secrets = options.host.get("secrets")
         data_mounts = options.host.get("data_mounts")
         machine_requirements = MachineRequirements(
@@ -1315,6 +1316,7 @@ class FalServerlessHost(Host):
             application_name=effective_app_name,
             auth_mode=effective_auth_mode,
             environment_name=self.environment_name,
+            health_check_config=health_check_config,
             secrets=secrets,
             data_mounts=data_mounts,
             entrypoint=entrypoint,

--- a/projects/fal/src/fal/sdk.py
+++ b/projects/fal/src/fal/sdk.py
@@ -1178,6 +1178,7 @@ class FalServerlessConnection:
         function: Callable[..., ResultT] | None,
         environments: list[isolate_proto.EnvironmentDefinition],
         *,
+        health_check_config: ApplicationHealthCheckConfig | None = None,
         serialization_method: str = _DEFAULT_SERIALIZATION_METHOD,
         machine_requirements: MachineRequirements | None = None,
         setup_function: Callable[[], InputT] | None = None,
@@ -1242,6 +1243,11 @@ class FalServerlessConnection:
             if application_name
             else None
         )
+        wrapped_health_check_config = (
+            _health_check_config_to_proto(health_check_config)
+            if health_check_config
+            else None
+        )
         request = isolate_proto.HostedRun(
             environments=environments,
             machine_requirements=wrapped_requirements,
@@ -1255,6 +1261,7 @@ class FalServerlessConnection:
                 else None
             ),
             data_mounts=data_mounts or [],
+            health_check_config=wrapped_health_check_config,
         )
         if entrypoint is not None:
             request.entrypoint = entrypoint

--- a/projects/fal/tests/unit/test_app.py
+++ b/projects/fal/tests/unit/test_app.py
@@ -1612,6 +1612,43 @@ def test_data_mounts_run_sends_to_connection():
     assert call_kwargs["data_mounts"] == ["/data"]
 
 
+def test_health_check_config_run_sends_to_connection():
+    from fal.api.api import FalServerlessHost, Options, ResultHandler
+    from fal.sdk import ApplicationHealthCheckConfig, HostedRunState
+
+    host = FalServerlessHost()
+    health_check_config = ApplicationHealthCheckConfig(
+        path="/ready",
+        start_period_seconds=None,
+        timeout_seconds=None,
+        failure_threshold=None,
+        call_regularly=None,
+    )
+    options = Options(host={"health_check_config": health_check_config})
+
+    connection = MagicMock()
+    connection.define_environment.return_value = object()
+    partial_result = MagicMock()
+    partial_result.status.state = HostedRunState.SUCCESS
+    partial_result.result = "ok"
+    connection.run.return_value = iter([partial_result])
+
+    with patch.object(
+        FalServerlessHost, "_connection", new_callable=PropertyMock
+    ) as mock_connection:
+        mock_connection.return_value = connection
+        host._run(
+            lambda: "ok",
+            options,
+            args=(),
+            kwargs={},
+            result_handler=ResultHandler(),
+        )
+
+    _, call_kwargs = connection.run.call_args
+    assert call_kwargs["health_check_config"] is health_check_config
+
+
 def test_build_environment_raises_on_internal_failure():
     from fal.api.api import FalServerlessHost, InternalFalServerlessError, Options
     from fal.sdk import BuildEnvironmentResult, HostedRunState, HostedRunStatus

--- a/projects/fal/tests/unit/test_sdk.py
+++ b/projects/fal/tests/unit/test_sdk.py
@@ -294,6 +294,31 @@ def test_connection_run_allows_no_isolate_container_without_callable():
 
     assert stub.run_request is not None
     assert stub.run_request.WhichOneof("callable") is None
+    assert not stub.run_request.HasField("health_check_config")
+
+
+def test_connection_run_forwards_health_check_config():
+    connection = FalServerlessConnection("api.alpha.fal.ai", MagicMock())
+    stub = RecordingStub()
+    connection._stub = stub  # type: ignore[assignment]
+    environment = connection.define_environment("virtualenv")
+
+    list(
+        connection.run(
+            lambda: None,
+            [environment],
+            health_check_config=ApplicationHealthCheckConfig(
+                path="/ready",
+                start_period_seconds=None,
+                timeout_seconds=None,
+                failure_threshold=None,
+                call_regularly=None,
+            ),
+        )
+    )
+
+    assert stub.run_request is not None
+    assert stub.run_request.health_check_config.path == "/ready"
 
 
 def test_connection_run_rejects_isolate_container_without_callable():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small plumbing change that reuses existing proto conversion; no new auth or health-check semantics.
> 
> **Overview**
> Ephemeral `fal run` now sends `health_check_config` to the backend, matching register/deploy. Previously the option was only honored on registration.
> 
> `FalServerlessHost._run` reads host options and passes them through `FalServerlessConnection.run`, which serializes them onto the `HostedRun` proto. Bumps `isolate-proto` to `>=0.34.2`. Unit tests cover both the host and gRPC request paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c722b528d675aa217fd9baf72e13bd7682af935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->