### PR TITLE
fix: allow pathspec 1.x alongside 0.x

### DIFF
--- a/projects/fal/pyproject.toml
+++ b/projects/fal/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
     "argcomplete>=3.1.0,<4; python_version >= '3.10'",
     "argcomplete>=3.1.0,!=3.7.1,<4; python_version < '3.10'",
     "packaging>=21.3",
-    "pathspec>=0.11.1,<1",
+    # 1.0.0-1.0.3 each ship a crash bug, all fixed by 1.0.4 (#100, #102, #103):
+    # https://github.com/cpburnz/python-pathspec/blob/master/CHANGES.rst
+    "pathspec>=0.11.1,!=1.0.0,!=1.0.1,!=1.0.2,!=1.0.3,<2",
     "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*",
     # serve=True dependencies
     # FastAPI 0.123.1 fixes the OpenAPI schema remapping issue that blocked 0.119+.

--- a/projects/fal/src/fal/container.py
+++ b/projects/fal/src/fal/container.py
@@ -3,6 +3,7 @@ import os
 import re
 import shlex
 import sys
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
@@ -244,15 +245,17 @@ class DockerignoreHandler:
         return DEFAULT_DOCKERIGNORE_PATTERNS
 
     def get_regex_patterns(self) -> List[str]:
+        # Deprecated alias on pathspec 1.x; kept deliberately (see fal/sync.py).
         from pathspec.patterns.gitwildmatch import GitWildMatchPattern  # noqa: PLC0415
 
         patterns = self.get_patterns()
         regex_patterns = []
-        for pattern in patterns:
-            # Convert ignore patterns to regex, this way we can use `re` at runtime.
-            regex, _ = GitWildMatchPattern.pattern_to_regex(pattern)
-            if regex:
-                regex_patterns.append(regex)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            for pattern in patterns:
+                regex, _ = GitWildMatchPattern.pattern_to_regex(pattern)
+                if regex:
+                    regex_patterns.append(regex)
         return regex_patterns
 
 

--- a/projects/fal/src/fal/sync.py
+++ b/projects/fal/src/fal/sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import warnings
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -9,7 +10,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from openapi_fal_rest.client import Client
 
+import pathspec
+from packaging.version import Version
 from pathspec import PathSpec
+
+_PATHSPEC_IS_1X = Version(pathspec.__version__).major >= 1
 
 
 def _check_hash(client: Client, target_path: str, hash_string: str) -> bool:
@@ -80,13 +85,21 @@ def _load_gitignore_patterns(dir_path: str) -> list:
     return gitignore_patterns
 
 
-def _is_ignored(file_path: str, gitignore_patterns: list[str]) -> bool:
-    pathspec = PathSpec.from_lines("gitwildmatch", gitignore_patterns)
-    return pathspec.match_file(file_path)
+def _build_ignore_spec(gitignore_patterns: list[str]) -> PathSpec:
+    # "gitwildmatch" is deprecated on pathspec 1.x, but do not rename it to
+    # "gitignore": that name binds different pattern classes on 0.x vs 1.x.
+    if _PATHSPEC_IS_1X:
+        # Pin the stdlib backend; 1.x auto-picks re2/hyperscan when installed.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return PathSpec.from_lines(
+                "gitwildmatch", gitignore_patterns, backend="simple"
+            )
+    return PathSpec.from_lines("gitwildmatch", gitignore_patterns)
 
 
 def _zip_directory(dir_path: str, zip_path: str) -> None:
-    gitignore_patterns = _load_gitignore_patterns(dir_path)
+    ignore_spec = _build_ignore_spec(_load_gitignore_patterns(dir_path))
 
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         for root, _, files in os.walk(dir_path):
@@ -94,7 +107,7 @@ def _zip_directory(dir_path: str, zip_path: str) -> None:
                 file_path = os.path.join(root, file)
                 relative_path = os.path.relpath(file_path, dir_path)
 
-                if not _is_ignored(relative_path, gitignore_patterns):
+                if not ignore_spec.match_file(relative_path):
                     arcname = relative_path
                     zipf.write(file_path, arcname)
 

--- a/projects/fal/tests/unit/test_container.py
+++ b/projects/fal/tests/unit/test_container.py
@@ -1,5 +1,7 @@
 """Tests for fal.container module."""
 
+import re
+import warnings
 from pathlib import Path
 
 import pytest
@@ -593,6 +595,32 @@ class TestContainerImageDockerignore:
         assert len(patterns) > 0
         # Verify they are regex patterns (contain regex syntax)
         assert any("\\.git" in p or "\\.pyc" in p for p in patterns)
+
+    def test_regex_patterns_match_ignored_paths(self):
+        """Compiled patterns should match ignored paths and skip kept ones."""
+        img = ContainerImage(
+            dockerfile_str="FROM python:3.11",
+            dockerignore=["*.pyc", "node_modules/"],
+        )
+        compiled = [re.compile(p) for p in img._dockerignore]
+
+        def is_ignored(path: str) -> bool:
+            # Mirrors how file_sync.py applies these patterns at upload time.
+            return any(c.search(path) for c in compiled)
+
+        assert is_ignored("x/y.pyc")
+        assert is_ignored("node_modules/pkg/index.js")
+        assert not is_ignored("src/main.py")
+
+    def test_regex_pattern_generation_emits_no_warnings(self):
+        """The deprecated pathspec alias must not leak warnings to -W error users."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            img = ContainerImage(
+                dockerfile_str="FROM python:3.11",
+                dockerignore=["*.pyc"],
+            )
+            assert img._dockerignore
 
     def test_loads_dockerignore_file(self, tmp_path: Path):
         """Should load and convert patterns from .dockerignore to regex."""

--- a/projects/fal/tests/unit/test_sync.py
+++ b/projects/fal/tests/unit/test_sync.py
@@ -1,0 +1,46 @@
+"""Tests for fal.sync ignore handling."""
+
+import warnings
+
+import pytest
+
+from fal.sync import _build_ignore_spec
+
+IGNORE_PATTERNS = [
+    "# comment",
+    "",
+    "*.pyc",
+    "!keep.pyc",
+    "node_modules/",
+    "/env",
+    "build/**",
+]
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("src/main.py", False),
+        ("x/y.pyc", True),
+        ("keep.pyc", False),
+        ("node_modules/pkg/index.js", True),
+        ("env", True),
+        ("sub/env", False),
+        ("build/out/app.bin", True),
+    ],
+)
+def test_ignore_spec_matches_gitignore_semantics(path, expected):
+    spec = _build_ignore_spec(IGNORE_PATTERNS)
+    assert spec.match_file(path) is expected
+
+
+def test_empty_gitignore_ignores_nothing():
+    spec = _build_ignore_spec([])
+    assert not spec.match_file("anything.py")
+
+
+def test_building_and_matching_emits_no_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        spec = _build_ignore_spec(IGNORE_PATTERNS)
+        assert spec.match_file("x/y.pyc")


### PR DESCRIPTION
[SERV-1654](https://linear.app/features-and-labels/issue/SERV-1654/follow-up-on-pathspec-version)

## Problem

`fal` pins `pathspec>=0.11.1,<1`, and black 26 requires `pathspec>=1.0.0`, so users upgrading black cannot co-install fal without a resolver override.

## Fix

Widen the constraint to `<2`, excluding 1.0.0-1.0.3 (each ships a crash bug, all fixed by 1.0.4; issue links in the inline comment). Environments where something else still pins `pathspec<1` keep resolving 0.12.x unchanged.

Because 1.x auto-selects a regex backend (re2 or hyperscan when importable), sync ignore matching now pins the stdlib `re` backend so results never depend on what else is installed in the user's environment. The gitignore spec is also built once per directory walk instead of per file, and the deprecated `gitwildmatch` alias stays (it is the only spelling with identical semantics on both majors) with its DeprecationWarnings suppressed, so nothing leaks into user warnings-as-errors setups. Migrating to the 1.x API is queued behind dropping pathspec 0.x from the range.

## Tests

New `test_sync.py` plus a container test assert actual match/no-match behavior (negation, dir patterns, anchoring, `**`, empty gitignore, no leaked warnings). Verified locally on both 0.12.1 and 1.1.1:

```
pathspec==0.12.1: 85 passed
pathspec==1.1.1:  85 passed
```

The `docker_ignore` regex text differs across majors but its only consumer is client-side `re.search` truthiness in `file_sync.py`, where the forms are equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which local files are excluded during `sync_dir` zips and dependency resolution; backend pinning reduces but does not eliminate semantic risk across pathspec versions.
> 
> **Overview**
> **Widens the `pathspec` dependency** so `fal` can install alongside tools (e.g. black 26) that require 1.x, while still allowing 0.12.x when other pins keep `<1`. Broken releases `1.0.0`–`1.0.3` are excluded.
> 
> **Directory sync** now builds a single gitignore `PathSpec` per zip instead of recreating it for every file. On pathspec 1.x it forces the stdlib `simple` backend so ignore results do not vary with optional `re2`/`hyperscan`. The deprecated `gitwildmatch` spelling is kept for cross-major semantics; **DeprecationWarnings** from pathspec are suppressed in `sync` and dockerignore regex conversion so `-W error` setups stay clean.
> 
> **Tests** cover gitignore match/negation/anchoring, dockerignore regex behavior, and warning-free construction on both pathspec majors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f25bc2afd6b5d32ba64a8e98f0870fdeddb754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->