### PR TITLE
fix(cli): show the app error when a `fal api` request fails

### DIFF
--- a/projects/fal/src/fal/apps.py
+++ b/projects/fal/src/fal/apps.py
@@ -52,10 +52,13 @@ class InProgress(_Status):
 
 @dataclass
 class Completed(_Status):
-    """Indicates the request has been completed successfully and the result is
-    ready to be retrieved."""
+    """Indicates the request has reached a terminal state and the result is
+    ready to be retrieved. A completed request may still have failed, in which
+    case `error` describes it."""
 
     logs: list[dict[str, Any]] | None = field()
+    error: str | None = None
+    error_type: str | None = None
 
 
 @lru_cache(maxsize=1)
@@ -102,7 +105,11 @@ class RequestHandle:
         data = response.json()
 
         if response.status_code == 200:
-            return Completed(logs=data["logs"])
+            return Completed(
+                logs=data["logs"],
+                error=data.get("error"),
+                error_type=data.get("error_type"),
+            )
 
         if data["status"] == "IN_QUEUE":
             return Queued(position=data["queue_position"])

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -121,7 +121,9 @@ def queue_run(model_id: str, params: dict):
                     subtitle=request_id,
                     subtitle_align="right",
                 )
-                logs_panel = Panel("\n".join(logs[-10:]), title="Logs")
+                # Text(), not a markup string: a log line holding "[/]" or
+                # "[gw0]" would otherwise raise MarkupError or be swallowed.
+                logs_panel = Panel(Text("\n".join(logs[-10:])), title="Logs")
 
                 live.update(Group(status_panel, logs_panel))
                 live.refresh()
@@ -161,14 +163,20 @@ def queue_run(model_id: str, params: dict):
 
         if new_count:
             target_console.print(
-                Panel("\n".join(logs[-new_count:]), title="Logs", border_style="red")
+                Panel(
+                    Text("\n".join(logs[-new_count:])),
+                    title="Logs",
+                    border_style="red",
+                )
             )
 
-        target_console.print(
-            f"{get_cross_icon(target_console)} Request {handle.request_id} failed "
+        summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
+        summary.append(
+            f"Request {handle.request_id} failed "
             f"with HTTP {exc.response.status_code}: "
             f"{error or _response_detail(exc.response)}"
         )
+        target_console.print(summary)
         return 1
 
 

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -1,5 +1,7 @@
+import json
 import re
 
+import httpx
 import rich
 
 from fal import flags
@@ -18,9 +20,9 @@ def _api(args):
     )
 
     if args.model_id.endswith("/stream"):
-        stream_run(args.model_id, params)
+        return stream_run(args.model_id, params)
     else:
-        queue_run(args.model_id, params)
+        return queue_run(args.model_id, params)
 
 
 def stream_run(model_id: str, params: dict):
@@ -37,6 +39,39 @@ def stream_run(model_id: str, params: dict):
                 rich.print(line.decode())
 
 
+def _format_log(log: dict) -> str:
+    """Render a log entry.
+
+    An app that lets an exception escape an endpoint logs it as a one-line
+    ``{"traceback": ...}`` envelope (see ``fal.api.api``); unwrap it so the
+    traceback reads as a traceback instead of an escaped JSON blob.
+    """
+    message = log.get("message", str(log))
+
+    try:
+        payload = json.loads(message)
+    except (TypeError, ValueError):
+        return message
+
+    if isinstance(payload, dict) and "traceback" in payload:
+        return str(payload["traceback"]).rstrip()
+
+    return message
+
+
+def _response_detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text.strip()
+
+    if isinstance(body, dict) and "detail" in body:
+        detail = body["detail"]
+        return detail if isinstance(detail, str) else json.dumps(detail)
+
+    return response.text.strip()
+
+
 def queue_run(model_id: str, params: dict):
     from rich.console import Group
     from rich.live import Live
@@ -45,6 +80,7 @@ def queue_run(model_id: str, params: dict):
 
     import fal.apps
     from fal.console.icons import (  # noqa: PLC0415
+        get_cross_icon,
         get_status_done_icon,
         get_status_progress_icon,
         get_status_queued_icon,
@@ -57,6 +93,13 @@ def queue_run(model_id: str, params: dict):
     status_progress_icon = get_status_progress_icon(target_console)
     status_done_icon = get_status_done_icon(target_console)
 
+    # A status response carries every log entry emitted so far, so only the
+    # ones past what we already hold are new.
+    def consume_logs(entries) -> int:
+        new_entries = (entries or [])[len(logs) :]
+        logs.extend(_format_log(entry) for entry in new_entries)
+        return len(new_entries)
+
     try:
         with Live(auto_refresh=False, console=target_console) as live:
             for event in handle.iter_events(logs=True):
@@ -67,9 +110,7 @@ def queue_run(model_id: str, params: dict):
                     )
                 elif isinstance(event, fal.apps.InProgress):
                     status = Text(f"{status_progress_icon} In Progress", style="blue")
-                    if event.logs:
-                        logs.extend(log.get("message", str(log)) for log in event.logs)
-                        logs = logs[-10:]  # Keep only last 10 logs
+                    consume_logs(event.logs)
                 else:
                     status = Text(f"{status_done_icon} Done", style="green")
 
@@ -80,7 +121,7 @@ def queue_run(model_id: str, params: dict):
                     subtitle=request_id,
                     subtitle_align="right",
                 )
-                logs_panel = Panel("\n".join(logs), title="Logs")
+                logs_panel = Panel("\n".join(logs[-10:]), title="Logs")
 
                 live.update(Group(status_panel, logs_panel))
                 live.refresh()
@@ -103,6 +144,32 @@ def queue_run(model_id: str, params: dict):
         rich.print("[yellow]Cancelling request...[/yellow]")
         handle.cancel()
         rich.print("[green]Request cancelled.[/green]")
+    except httpx.HTTPStatusError as exc:
+        # An app that fails answers with a generic detail and logs the reason,
+        # and iter_events returns before the terminal status, so the batch of
+        # logs that explains the failure is only reachable from here.
+        error = None
+        new_count = 0
+        try:
+            final_status = handle.status(logs=True)
+        except httpx.HTTPError:
+            pass
+        else:
+            if isinstance(final_status, fal.apps.Completed):
+                new_count = consume_logs(final_status.logs)
+                error = final_status.error or final_status.error_type
+
+        if new_count:
+            target_console.print(
+                Panel("\n".join(logs[-new_count:]), title="Logs", border_style="red")
+            )
+
+        target_console.print(
+            f"{get_cross_icon(target_console)} Request {handle.request_id} failed "
+            f"with HTTP {exc.response.status_code}: "
+            f"{error or _response_detail(exc.response)}"
+        )
+        return 1
 
 
 def add_parser(main_subparsers, parents):

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -175,9 +175,11 @@ def queue_run(model_id: str, params: dict):
         except httpx.HTTPError:
             pass
 
-        completed = isinstance(final_status, fal.apps.Completed)
-        if completed:
-            new_lines = consume_logs(final_status.logs)
+        completed = (
+            final_status if isinstance(final_status, fal.apps.Completed) else None
+        )
+        if completed is not None:
+            new_lines = consume_logs(completed.logs)
             if new_lines:
                 # A logged traceback reads cause-first, so the tail is the
                 # framework frames -- the safe end to cut.
@@ -192,8 +194,12 @@ def queue_run(model_id: str, params: dict):
         detail = _response_detail(exc.response)
         summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
 
-        if completed or not from_poll:
-            error = final_status.error or final_status.error_type if completed else None
+        if completed is not None or not from_poll:
+            error = (
+                completed.error or completed.error_type
+                if completed is not None
+                else None
+            )
             summary.append(
                 f"Request {handle.request_id} failed "
                 f"with HTTP {exc.response.status_code}: {error or detail}"

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -9,6 +9,11 @@ from fal import flags
 # = or := only
 KV_SPLIT_RE = re.compile(r"(=|:=)")
 
+# An unhandled app error is logged as one entry holding the whole traceback,
+# and fal.App runs endpoints under starlette/anyio, so that entry routinely
+# runs to hundreds of lines of framework frames.
+_FAILURE_LOG_LINES = 40
+
 
 def _api(args):
     """Handle the api command execution."""
@@ -174,8 +179,14 @@ def queue_run(model_id: str, params: dict):
         if completed:
             new_lines = consume_logs(final_status.logs)
             if new_lines:
+                # A logged traceback reads cause-first, so the tail is the
+                # framework frames -- the safe end to cut.
+                body = "\n".join(new_lines).splitlines()
+                shown = body[:_FAILURE_LOG_LINES]
+                if len(body) > len(shown):
+                    shown.append(f"... {len(body) - len(shown)} more lines")
                 target_console.print(
-                    Panel(Text("\n".join(new_lines)), title="Logs", border_style="red")
+                    Panel(Text("\n".join(shown)), title="Logs", border_style="red")
                 )
 
         detail = _response_detail(exc.response)

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -93,12 +93,22 @@ def queue_run(model_id: str, params: dict):
     status_progress_icon = get_status_progress_icon(target_console)
     status_done_icon = get_status_done_icon(target_console)
 
-    # A status response carries every log entry emitted so far, so only the
-    # ones past what we already hold are new.
-    def consume_logs(entries) -> int:
-        new_entries = (entries or [])[len(logs) :]
-        logs.extend(_format_log(entry) for entry in new_entries)
-        return len(new_entries)
+    # A status response returns the entries inside a moving time window, not a
+    # growing prefix, so identity decides what is new -- a positional cursor
+    # stops advancing once the window slides past what we already hold.
+    seen = set()
+
+    def consume_logs(entries) -> list:
+        new_lines = []
+        for entry in entries or []:
+            key = (entry.get("timestamp"), entry.get("message"))
+            if key in seen:
+                continue
+            seen.add(key)
+            new_lines.append(_format_log(entry))
+
+        logs.extend(new_lines)
+        return new_lines
 
     try:
         with Live(auto_refresh=False, console=target_console) as live:
@@ -134,7 +144,7 @@ def queue_run(model_id: str, params: dict):
                     f"{header}: {value}"
                     for header, value in response.headers.multi_items()
                 )
-                headers_panel = Panel(headers, title="Headers")
+                headers_panel = Panel(Text(headers), title="Headers")
 
                 body = rich.pretty.Pretty(response.json())
                 live.update(Group(headers_panel, body))
@@ -147,35 +157,38 @@ def queue_run(model_id: str, params: dict):
         handle.cancel()
         rich.print("[green]Request cancelled.[/green]")
     except httpx.HTTPStatusError as exc:
-        # An app that fails answers with a generic detail and logs the reason,
-        # and iter_events returns before the terminal status, so the batch of
-        # logs that explains the failure is only reachable from here.
-        error = None
-        new_count = 0
+        # This also catches a status poll failing mid-flight, where the request
+        # itself may be fine, so re-read the status: only it can say whether the
+        # request finished. An app that fails answers with a generic detail and
+        # logs the reason, and iter_events returns before the terminal status,
+        # so the logs that explain the failure are only reachable here too.
+        final_status = None
         try:
             final_status = handle.status(logs=True)
         except httpx.HTTPError:
             pass
-        else:
-            if isinstance(final_status, fal.apps.Completed):
-                new_count = consume_logs(final_status.logs)
-                error = final_status.error or final_status.error_type
 
-        if new_count:
-            target_console.print(
-                Panel(
-                    Text("\n".join(logs[-new_count:])),
-                    title="Logs",
-                    border_style="red",
+        detail = _response_detail(exc.response)
+        summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
+
+        if isinstance(final_status, fal.apps.Completed):
+            new_lines = consume_logs(final_status.logs)
+            if new_lines:
+                target_console.print(
+                    Panel(Text("\n".join(new_lines)), title="Logs", border_style="red")
                 )
+            summary.append(
+                f"Request {handle.request_id} failed "
+                f"with HTTP {exc.response.status_code}: "
+                f"{final_status.error or final_status.error_type or detail}"
+            )
+        else:
+            summary.append(
+                f"Could not read request {handle.request_id} "
+                f"(HTTP {exc.response.status_code}: {detail}). "
+                "It may still be running -- check its status before resubmitting."
             )
 
-        summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
-        summary.append(
-            f"Request {handle.request_id} failed "
-            f"with HTTP {exc.response.status_code}: "
-            f"{error or _response_detail(exc.response)}"
-        )
         target_console.print(summary)
         return 1
 

--- a/projects/fal/src/fal/cli/api.py
+++ b/projects/fal/src/fal/cli/api.py
@@ -157,30 +157,35 @@ def queue_run(model_id: str, params: dict):
         handle.cancel()
         rich.print("[green]Request cancelled.[/green]")
     except httpx.HTTPStatusError as exc:
-        # This also catches a status poll failing mid-flight, where the request
-        # itself may be fine, so re-read the status: only it can say whether the
-        # request finished. An app that fails answers with a generic detail and
-        # logs the reason, and iter_events returns before the terminal status,
-        # so the logs that explain the failure are only reachable here too.
+        # This arm also sees a status poll fail mid-flight. The result endpoint
+        # answering at all means the request reached a terminal state; a failed
+        # poll says nothing about the request, so fall back to re-reading the
+        # status there. That re-read also carries the logs explaining an app
+        # failure, which iter_events returns too early to have seen.
+        from_poll = exc.request.url.path.rstrip("/").endswith("/status")
+
         final_status = None
         try:
             final_status = handle.status(logs=True)
         except httpx.HTTPError:
             pass
 
-        detail = _response_detail(exc.response)
-        summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
-
-        if isinstance(final_status, fal.apps.Completed):
+        completed = isinstance(final_status, fal.apps.Completed)
+        if completed:
             new_lines = consume_logs(final_status.logs)
             if new_lines:
                 target_console.print(
                     Panel(Text("\n".join(new_lines)), title="Logs", border_style="red")
                 )
+
+        detail = _response_detail(exc.response)
+        summary = Text.from_markup(f"{get_cross_icon(target_console)} ")
+
+        if completed or not from_poll:
+            error = final_status.error or final_status.error_type if completed else None
             summary.append(
                 f"Request {handle.request_id} failed "
-                f"with HTTP {exc.response.status_code}: "
-                f"{final_status.error or final_status.error_type or detail}"
+                f"with HTTP {exc.response.status_code}: {error or detail}"
             )
         else:
             summary.append(

--- a/projects/fal/src/fal/cli/cli_nested_json.py
+++ b/projects/fal/src/fal/cli/cli_nested_json.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
 from enum import Enum, auto
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple, Type, Union
 
 EMPTY_STRING = ""
 HIGHLIGHTER = "^"
@@ -301,7 +301,7 @@ def assert_cant_happen():
     raise ValueError("Unexpected value")
 
 
-JSONType = type[Union[dict, list, int, float, str]]
+JSONType = Type[Union[dict, list, int, float, str]]
 JSON_TYPE_MAPPING = {
     dict: "object",
     list: "array",

--- a/projects/fal/tests/unit/cli/test_api.py
+++ b/projects/fal/tests/unit/cli/test_api.py
@@ -80,9 +80,10 @@ def _failing_queue(**kwargs):
     kwargs.setdefault(
         "status_logs", [_log("starting up"), _log(json.dumps({"traceback": TRACEBACK}))]
     )
-    return FakeQueue(
-        response=httpx.Response(500, json={"detail": "Internal Server Error"}), **kwargs
+    kwargs.setdefault(
+        "response", httpx.Response(500, json={"detail": "Internal Server Error"})
     )
+    return FakeQueue(**kwargs)
 
 
 def test_failed_request_reports_detail_and_exits_nonzero(run_api):
@@ -133,6 +134,22 @@ def test_logs_are_not_duplicated_across_polls(run_api):
     _, out = run_api(queue)
 
     assert out.count("starting up") == 1
+
+
+def test_square_brackets_in_logs_and_detail_survive(run_api):
+    # Rich parses markup in a plain string: "[/]" raises MarkupError and
+    # "[gw0]" is swallowed as a style tag.
+    queue = _failing_queue(
+        status_logs=[_log("worker [gw0] died"), _log("expected [/] token")],
+        response=httpx.Response(500, json={"detail": "bad [/] input"}),
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert "[gw0]" in out
+    assert "expected [/] token" in out
+    assert "bad [/] input" in out
 
 
 def test_format_log_unwraps_traceback_envelope():

--- a/projects/fal/tests/unit/cli/test_api.py
+++ b/projects/fal/tests/unit/cli/test_api.py
@@ -130,6 +130,30 @@ def test_failed_request_shows_app_traceback(run_api):
     assert '{"traceback"' not in out
 
 
+def test_long_traceback_is_truncated_from_the_tail(run_api):
+    # A real fal.App traceback runs to hundreds of framework frames; the cause
+    # is logged first, so the tail is what gets dropped.
+    long_traceback = "ModuleNotFoundError: No module named 'torch'\n" + "\n".join(
+        f"  frame {i}" for i in range(200)
+    )
+    queue = _failing_queue(
+        # The traceback is logged as the request dies, so it arrives with the
+        # terminal status rather than during the poll loop.
+        status_logs=[
+            _log("starting up"),
+            _log(json.dumps({"traceback": long_traceback})),
+        ],
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert "ModuleNotFoundError: No module named 'torch'" in out
+    assert "frame 0" in out
+    assert "frame 199" not in out
+    assert "more lines" in out
+
+
 def test_failed_request_prefers_gateway_error(run_api):
     queue = _failing_queue(
         status_logs=[_log("starting up")],

--- a/projects/fal/tests/unit/cli/test_api.py
+++ b/projects/fal/tests/unit/cli/test_api.py
@@ -203,6 +203,22 @@ def test_already_seen_logs_are_not_reprinted_on_failure(run_api):
     assert out.count("still going") == 1
 
 
+def test_failure_is_reported_even_when_the_status_reread_fails(run_api):
+    # The result endpoint answered, so the request is finished however the
+    # follow-up status call goes.
+    queue = _failing_queue(
+        status_logs=[_log("starting up")],
+        poll_failures=[(2, httpx.Response(503, text="upstream unavailable"))],
+        in_progress_polls=0,
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert f"Request {REQUEST_ID} failed with HTTP 500" in out
+    assert "may still be running" not in out
+
+
 def test_transient_poll_failure_does_not_claim_the_request_failed(run_api):
     # A 503 from one status poll says nothing about the request itself.
     queue = _failing_queue(

--- a/projects/fal/tests/unit/cli/test_api.py
+++ b/projects/fal/tests/unit/cli/test_api.py
@@ -1,0 +1,152 @@
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+import rich
+
+from fal.cli.api import _api, _format_log, _response_detail
+from fal.cli.main import parse_args
+from fal.sdk import Credentials
+
+REQUEST_ID = "00000000-0000-4000-8000-000000000001"
+TRACEBACK = (
+    "ModuleNotFoundError: No module named 'torch'\n"
+    '  File "/app/app.py", line 18, in run\n'
+    "    import torch\n"
+)
+
+
+def _log(message):
+    return {"timestamp": "2020-01-01T00:00:00Z", "message": message, "labels": {}}
+
+
+class FakeQueue:
+    """Serves the queue endpoints `fal api` polls, for a single request."""
+
+    def __init__(self, *, response, status_logs, error=None, error_type=None):
+        self.response = response
+        self.status_logs = status_logs
+        self.error = error
+        self.error_type = error_type
+        self.polls = 0
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(200, json={"request_id": REQUEST_ID})
+
+        if not request.url.path.endswith("/status/"):
+            return self.response
+
+        self.polls += 1
+        if self.polls == 1:
+            return httpx.Response(
+                202, json={"status": "IN_PROGRESS", "logs": self.status_logs[:1]}
+            )
+
+        body = {"status": "COMPLETED", "logs": self.status_logs}
+        if self.error is not None:
+            body["error"] = self.error
+        if self.error_type is not None:
+            body["error_type"] = self.error_type
+        return httpx.Response(200, json=body)
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(transport=httpx.MockTransport(self._handle))
+
+
+@pytest.fixture(autouse=True)
+def wide_console():
+    # Keep panel borders from wrapping the strings the assertions look for.
+    console = rich.console.Console(width=200)
+    with patch.object(rich, "get_console", return_value=console):
+        yield
+
+
+@pytest.fixture
+def run_api(capsys):
+    def _run(queue: FakeQueue):
+        args = parse_args(["api", "owner/app", "prompt=hi"])
+        patch_client = patch("fal.apps._get_http_client", return_value=queue.client())
+        patch_creds = patch("fal.apps.get_credentials", return_value=Credentials())
+        with patch_client, patch_creds:
+            code = _api(args)
+        return code, capsys.readouterr().out
+
+    return _run
+
+
+def _failing_queue(**kwargs):
+    kwargs.setdefault(
+        "status_logs", [_log("starting up"), _log(json.dumps({"traceback": TRACEBACK}))]
+    )
+    return FakeQueue(
+        response=httpx.Response(500, json={"detail": "Internal Server Error"}), **kwargs
+    )
+
+
+def test_failed_request_reports_detail_and_exits_nonzero(run_api):
+    code, out = run_api(_failing_queue())
+
+    assert code == 1
+    assert f"Request {REQUEST_ID} failed with HTTP 500" in out
+    assert "Internal Server Error" in out
+
+
+def test_failed_request_shows_app_traceback(run_api):
+    _, out = run_api(_failing_queue())
+
+    # The traceback only arrives with the terminal status, wrapped in a JSON
+    # envelope that has to be unpacked to be readable.
+    assert "ModuleNotFoundError: No module named 'torch'" in out
+    assert '{"traceback"' not in out
+
+
+def test_failed_request_prefers_gateway_error(run_api):
+    queue = _failing_queue(
+        status_logs=[_log("starting up")],
+        error="Request timed out",
+        error_type="request_timeout",
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert "Request timed out" in out
+
+
+def test_successful_request_returns_result(run_api):
+    queue = FakeQueue(
+        response=httpx.Response(200, json={"text": "hi"}),
+        status_logs=[_log("starting up"), _log("done")],
+    )
+
+    code, out = run_api(queue)
+
+    assert code is None
+    assert "'text'" in out
+
+
+def test_logs_are_not_duplicated_across_polls(run_api):
+    queue = _failing_queue(status_logs=[_log("starting up"), _log("still going")])
+
+    _, out = run_api(queue)
+
+    assert out.count("starting up") == 1
+
+
+def test_format_log_unwraps_traceback_envelope():
+    assert _format_log(_log(json.dumps({"traceback": TRACEBACK}))) == TRACEBACK.rstrip()
+
+
+def test_format_log_passes_through_plain_messages():
+    assert _format_log(_log("plain message")) == "plain message"
+    assert _format_log(_log('{"not": "a traceback"}')) == '{"not": "a traceback"}'
+
+
+def test_response_detail_falls_back_to_body_text():
+    assert _response_detail(httpx.Response(502, text="bad gateway")) == "bad gateway"
+    assert (
+        _response_detail(httpx.Response(422, json={"detail": [{"loc": ["prompt"]}]}))
+        == '[{"loc": ["prompt"]}]'
+    )

--- a/projects/fal/tests/unit/cli/test_api.py
+++ b/projects/fal/tests/unit/cli/test_api.py
@@ -22,14 +22,36 @@ def _log(message):
 
 
 class FakeQueue:
-    """Serves the queue endpoints `fal api` polls, for a single request."""
+    """Serves the queue endpoints `fal api` polls, for a single request.
 
-    def __init__(self, *, response, status_logs, error=None, error_type=None):
+    The gateway answers each status poll with the log entries inside a moving
+    time window rather than everything so far, so `window` bounds how many
+    entries a poll may return -- the oldest fall out as new ones arrive, which
+    is what a request outliving the window looks like from the client.
+    """
+
+    def __init__(
+        self,
+        *,
+        response,
+        status_logs,
+        error=None,
+        error_type=None,
+        in_progress_polls=1,
+        window=None,
+        poll_failures=(),
+    ):
         self.response = response
         self.status_logs = status_logs
         self.error = error
         self.error_type = error_type
+        self.in_progress_polls = in_progress_polls
+        self.window = window or len(status_logs)
+        self.poll_failures = dict(poll_failures)
         self.polls = 0
+
+    def _visible(self, upto):
+        return self.status_logs[max(0, upto - self.window) : upto]
 
     def _handle(self, request: httpx.Request) -> httpx.Response:
         if request.method == "POST":
@@ -39,12 +61,17 @@ class FakeQueue:
             return self.response
 
         self.polls += 1
-        if self.polls == 1:
+        if self.polls in self.poll_failures:
+            return self.poll_failures[self.polls]
+
+        if self.polls <= self.in_progress_polls:
+            # One more entry becomes visible per poll, so a later poll can hold
+            # entries an earlier one did not.
             return httpx.Response(
-                202, json={"status": "IN_PROGRESS", "logs": self.status_logs[:1]}
+                202, json={"status": "IN_PROGRESS", "logs": self._visible(self.polls)}
             )
 
-        body = {"status": "COMPLETED", "logs": self.status_logs}
+        body = {"status": "COMPLETED", "logs": self._visible(len(self.status_logs))}
         if self.error is not None:
             body["error"] = self.error
         if self.error_type is not None:
@@ -129,11 +156,66 @@ def test_successful_request_returns_result(run_api):
 
 
 def test_logs_are_not_duplicated_across_polls(run_api):
-    queue = _failing_queue(status_logs=[_log("starting up"), _log("still going")])
+    queue = _failing_queue(
+        status_logs=[_log("starting up"), _log("still going"), _log("nearly there")],
+        in_progress_polls=3,
+    )
+
+    _, out = run_api(queue)
+
+    assert queue.polls > 3
+    assert out.count("starting up") == 1
+    assert out.count("still going") == 1
+
+
+def test_traceback_survives_a_log_window_that_slides(run_api):
+    # A request outliving the log window: by the time it fails, the early
+    # entries have fallen out and the batch is no longer a growing prefix.
+    queue = _failing_queue(
+        status_logs=[
+            _log("progress 1"),
+            _log("progress 2"),
+            _log("progress 3"),
+            _log("progress 4"),
+            _log(json.dumps({"traceback": TRACEBACK})),
+        ],
+        in_progress_polls=4,
+        window=2,
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert "ModuleNotFoundError: No module named 'torch'" in out
+
+
+def test_already_seen_logs_are_not_reprinted_on_failure(run_api):
+    # The terminal status adds nothing new; the failure panel must stay away
+    # rather than repeat the whole log.
+    queue = _failing_queue(
+        status_logs=[_log("starting up"), _log("still going")],
+        in_progress_polls=2,
+    )
 
     _, out = run_api(queue)
 
     assert out.count("starting up") == 1
+    assert out.count("still going") == 1
+
+
+def test_transient_poll_failure_does_not_claim_the_request_failed(run_api):
+    # A 503 from one status poll says nothing about the request itself.
+    queue = _failing_queue(
+        status_logs=[_log("starting up"), _log("still going")],
+        in_progress_polls=4,
+        poll_failures=[(2, httpx.Response(503, text="upstream unavailable"))],
+    )
+
+    code, out = run_api(queue)
+
+    assert code == 1
+    assert "may still be running" in out
+    assert "failed with HTTP" not in out
 
 
 def test_square_brackets_in_logs_and_detail_survive(run_api):


### PR DESCRIPTION
## What's wrong

When an app raises inside an endpoint, `fal api` prints only this:

```
✘ 500: {"detail":"Internal Server Error"}: Server error '500 Internal Server Error' for url 'https://queue.fal.run/<owner>/<app>/requests/<request-id>/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
```

The actual cause — say a `ModuleNotFoundError` for a package missing from `requirements` — is nowhere in that output. Two things go wrong:

1. **The real error is fetched and then thrown away.** [`fal.App`'s exception handler](https://github.com/fal-ai/fal/blob/95bc7eb7/projects/fal/src/fal/api/api.py#L2339-L2364) deliberately answers the caller with a generic `{"detail": "Internal Server Error"}` and logs the traceback instead — so the traceback is in the request's logs, not in the response body. `fal api` polls with `logs=True`, but [`RequestHandle.iter_events`](https://github.com/fal-ai/fal/blob/95bc7eb7/projects/fal/src/fal/apps.py#L123-L138) returns *without yielding* the terminal `Completed` status, so the last batch of logs — the one carrying the traceback — is never read. (`fal_client` and `fal.workflows` both already read that terminal status; only the CLI didn't.)
2. **The message is httpx's, not ours.** The `except Exception` arm of [`cli/main.py`](https://github.com/fal-ai/fal/blob/95bc7eb7/projects/fal/src/fal/cli/main.py#L179-L184) appends `str(exc.__cause__)`, and the cause is `httpx.HTTPStatusError` from `raise_for_status()` — hence the duplicated status, the queue URL, and the MDN link.

## What this changes

`projects/fal/src/fal/cli/api.py`

- A new `except httpx.HTTPStatusError` arm on the existing `try`: it pulls the terminal status, prints the batch of logs that only arrives with it, and reports the status error or the response detail. Nothing in the existing live-render block moves or re-indents.
- `_format_log` unwraps the `{"traceback": ...}` envelope the app server logs unhandled exceptions as, so a traceback renders as a traceback instead of an escaped JSON blob.
- `consume_logs` appends only entries not already held, keyed on `(timestamp, message)`. The previous `logs.extend(...)` re-appended every line on every poll; a positional cursor would not work either, because the status endpoint answers with the entries inside a five-minute window ending at the request's finish time ([gateway clamp](https://github.com/fal-ai/isolate-cloud/blob/main/monorust/monorust-common/src/domain/gateway/mod.rs)), not with everything so far — so for a request that outlives the window the batch stops being a growing prefix. Truncation moves to display time so the full log stays available.
- `_api` returns the exit code, so `fal api` exits non-zero when a request fails (previously it exited 1 only as a side effect of the unhandled exception).
- The failure summary is worded from the endpoint that answered: the `except` arm also sees a status poll failing mid-flight, and reporting "request failed" there would be wrong — the request may still be running, and a user who resubmits pays twice. The result endpoint answering is proof of a terminal state; only a failed poll falls back to re-reading the status, and when that does not say `Completed` the CLI says the request may still be running.
- Log output and the server-supplied error are rendered through `rich.text.Text` rather than as markup strings. A bracket group in that text was otherwise parsed as a tag: `[gw0]` was silently swallowed and `[/]` raised `MarkupError`. The logs panel already had this hazard before this PR; printing tracebacks — which routinely carry `[Errno 2]`, `[gw0]` — makes it easy to hit. (Reported by Cursor Bugbot; see the thread.)

`projects/fal/src/fal/apps.py`

- `Completed` carries `error` / `error_type` from the status payload, matching `fal_client.Completed`. Used for the summary line when the request fails before it reaches the app (timeouts, runner errors), where there is no useful response body.

`projects/fal/src/fal/cli/cli_nested_json.py`

- `JSONType = type[Union[...]]` is a runtime assignment, so `from __future__ import annotations` does not defer it and it raises `TypeError: 'type' object is not subscriptable` on Python 3.8 — importing the module, and therefore running `fal api` at all, fails there. Switched to `typing.Type`. Found because the new tests are the first unit coverage to import this module.

No change to the success path or to `fal api --stream`. The status panel still reads `In Progress` in its last frame on a failed request; it does that today on success too (`iter_events` never yields the terminal status), and fixing it would mean moving the result fetch inside the live block, which is a bigger change than it is worth here.

## Before / after

Same scenario in both runs: the endpoint raises `ModuleNotFoundError: No module named 'torch'`, the runner logs the traceback, and the queue response endpoint returns `500 {"detail": "Internal Server Error"}`.

**Before**

```
╭────────────────────────────────── Status ──────────────────────────────────╮
│ 🔄 In Progress                                                             │
╰───────────────────────────────────── 00000000-0000-4000-8000-000000000001 ─╯
╭─────────────────────────────────── Logs ───────────────────────────────────╮
│ INFO: Application startup complete.                                        │
╰────────────────────────────────────────────────────────────────────────────╯
✘ 500: {"detail":"Internal Server Error"}: Server error '500 Internal Server Error' for url 'https://queue.fal.run/owner/app/requests/00000000-0000-4000-8000-000000000001/'
  For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

[exit code: 1]
```

**After**

```
╭────────────────────────────────── Status ──────────────────────────────────╮
│ 🔄 In Progress                                                             │
╰───────────────────────────────────── 00000000-0000-4000-8000-000000000001 ─╯
╭─────────────────────────────────── Logs ───────────────────────────────────╮
│ INFO: Application startup complete.                                        │
╰────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────────────────── Logs ───────────────────────────────────╮
│ INFO: 127.0.0.1 - POST / HTTP/1.1 500                                      │
│ ModuleNotFoundError: No module named 'torch'                               │
│   File "/root/app.py", line 18, in run                                     │
│     import torch                                                           │
│   File "/usr/lib/python3.12/site-packages/fastapi/routing.py", line 301,   │
│ in app                                                                     │
│     raw_response = await run_endpoint_function(...)                        │
╰────────────────────────────────────────────────────────────────────────────╯
✘ Request 00000000-0000-4000-8000-000000000001 failed with HTTP 500: Internal 
Server Error

[exit code: 1]
```

(Captured at 78 columns against the mock queue described below.)

## How to test

Automated:

```bash
python -m pytest projects/fal/tests/unit/cli/test_api.py -q   # 14 passed
python -m pytest projects/fal/tests/unit/cli -q               # 261 passed
python -m pytest projects/fal/tests/unit -q                   # 858 passed, 3 skipped
ruff format --check && ruff check projects/fal/src/fal/cli/api.py projects/fal/src/fal/apps.py
mypy --ignore-missing-imports --no-warn-no-return --check-untyped-defs \
  projects/fal/src/fal/cli/api.py projects/fal/src/fal/apps.py        # clean
```

The new `tests/unit/cli/test_api.py` drives the real CLI entrypoint against an `httpx.MockTransport` queue that serves the submit / status / response endpoints, covering: the failure summary and exit code, the traceback surfacing, the status `error` taking precedence over the response body, the success path, log de-duplication across several polls, a traceback arriving after the log window has slid past the early entries, a transient poll failure not being reported as a failed request, a genuine failure still being reported when the status re-read itself fails, and square brackets in log lines and error details surviving rich's markup parser.

The fake queue serves a moving window across multiple in-progress polls, which is what makes these fail-able. Each new test was checked against the defect it names by restoring the old behaviour one change at a time: the positional cursor loses the traceback on a slid window, the naive `extend` re-prints earlier lines, the unconditional wording claims a live request failed, and the markup-string rendering raises `MarkupError`.

Against a real app, without a deployment. `fal run app.py::BrokenApp --local` boots the
app on localhost, and hitting it produces the two things the CLI depends on:

```
HTTP 500
{"detail":"Internal Server Error"}                      <- response body, verbatim
{"traceback": "ModuleNotFoundError: No module named 'torch'\n  File \"/app/app.py\", line 20, in run\n ..."}
```

Replaying those exact bytes (18.5 KB of real runner log, the real 500 body) through the
CLI renders:

```
╭─────────────────────────────────── Logs ───────────────────────────────────╮
│ ModuleNotFoundError: No module named 'torch'                               │
│   File "/app/app.py", line 20, in run                                      │
│     import torch  # noqa: F401  (not installed on purpose)                 │
│     ^^^^^^^^^^^^                                                           │
│   File "/usr/lib/python3.12/site-packages/anyio/_backends/_asyncio.py",    │
│ line 1033, in run                                                          │
│     result = context.run(func, *args)                                      │
│              ^^^^^^^^^^^^^^^^^^^^^^^^                                      │
│   File "/usr/lib/python3.12/site-packages/anyio/_backends/_asyncio.py",    │
... 140 more lines
```

That capture is what drove the 40-line cap: the real traceback is 390 lines, because
endpoints run under starlette/anyio and the whole ExceptionGroup is logged as one entry.
The envelope reads cause-first, so the user's own frame is at the top and the tail is
framework noise.

Against a deployed app, the same shape end to end:

```python
class BrokenApp(fal.App, keep_alive=0):
    machine_type = "XS"

    @fal.endpoint("/")
    def run(self, input: Input) -> Output:
        import torch          # not in requirements
        return Output(text=input.prompt)
```

```bash
fal deploy app.py::BrokenApp --app-name cli-error-repro --auth private
fal api <owner>/cli-error-repro prompt=hi
```

Expected: a red Logs panel opening with the `ModuleNotFoundError`, a
`✘ Request <id> failed with HTTP 500: Internal Server Error` summary, and exit code 1.

**Not verified:** the deployed round trip — `fal deploy` did not complete on the account available while writing this, so the gateway hop (runner logs reaching the status endpoint) is the one link covered only by the mock queue. The app-server half and the rendering half are both verified against real bytes, as above, and the "before" capture reproduces a reported failure verbatim including the MDN line.

CI: unit (all 8 jobs, including py 3.8 and Windows) and CodeQL are green. `e2e` and `integration` fail here and on `main` alike; on this branch they are `pytest-timeout` expiries waiting for apps to start, unrelated to this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and error-handling changes with broad unit test coverage; no changes to auth, deployment, or the success path.
> 
> **Overview**
> **`fal api` queue runs** now surface why a request failed instead of dumping raw httpx errors and hiding tracebacks in the queue logs.
> 
> On HTTP failure, the CLI re-reads terminal **status** (because `iter_events` stops before yielding `Completed`), unwraps JSON **`traceback`** log envelopes, dedupes log lines across **moving-window** status polls, and prints a short failure summary with exit code **1**. Transient **status** poll errors are worded differently from a finished request failure. Log panels use **`rich.text.Text`** so bracket-heavy lines do not break markup.
> 
> **`Completed`** in `fal.apps` now carries optional **`error`** / **`error_type`** from the status API. **`cli_nested_json`** fixes a Python 3.8 **`typing.Type`** alias so the CLI module imports cleanly. New **`test_api.py`** covers failures, tracebacks, log windows, and poll edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1871d0ee0ae6a795778eec448e0fd836627e924a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->