### PR TITLE
fix(cli): show the checksum phase during large file uploads (SERV-1567)

### DIFF
--- a/projects/fal/src/fal/files.py
+++ b/projects/fal/src/fal/files.py
@@ -153,10 +153,10 @@ class FalFileSystem(AbstractFileSystem):
             fobj.write(response.content)
 
     def _put_file_multipart(self, lpath, rpath, size, progress):
-        md5 = _compute_md5(lpath)
-
         num_parts = max(1, (size + MULTIPART_CHUNK_SIZE - 1) // MULTIPART_CHUNK_SIZE)
-        task = progress.add_task(f"{os.path.basename(lpath)}", total=num_parts)
+        task = progress.add_task("Calculating checksum...", total=num_parts)
+        md5 = _compute_md5(lpath)
+        progress.update(task, description=f"Uploading {os.path.basename(lpath)}")
 
         def on_part_complete(part_number: int):
             progress.advance(task)

--- a/projects/fal/tests/unit/test_files_checksum_progress.py
+++ b/projects/fal/tests/unit/test_files_checksum_progress.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from fal.files import FalFileSystem
+
+
+def test_multipart_reports_checksum_then_upload(monkeypatch, tmp_path):
+    path = tmp_path / "model.bin"
+    progress = Mock()
+    progress.add_task.return_value = 7
+
+    def compute_md5(lpath):
+        assert lpath == str(path)
+        progress.add_task.assert_called_once_with("Calculating checksum...", total=1)
+        progress.update.assert_not_called()
+        return "etag"
+
+    uploader = Mock()
+
+    def upload_file(lpath, on_part_complete):
+        assert lpath == str(path)
+        progress.update.assert_called_once_with(7, description="Uploading model.bin")
+        return "etag"
+
+    uploader.upload_file.side_effect = upload_file
+    monkeypatch.setattr("fal.files._compute_md5", compute_md5)
+    monkeypatch.setattr(
+        "fal.files.DataFileMultipartUpload", Mock(return_value=uploader)
+    )
+
+    FalFileSystem._put_file_multipart(
+        SimpleNamespace(_client=object()), str(path), "/data/model.bin", 1, progress
+    )
+
+    uploader.upload_file.assert_called_once()


### PR DESCRIPTION
Closes [SERV-1567](https://linear.app/features-and-labels/issue/SERV-1567/fal-files-upload-silent-md5-checksum-phase-before-progress-bar-on).

## Problem

`fal files upload` showed a completely blank terminal while calculating the existing full-file MD5 before multipart upload. For a large file, the user could not tell whether the CLI was working or stuck.

## Change

Create the existing multipart progress task before checksum calculation and change its description when upload begins:

```text
⠋ Calculating checksum...                         0%
⠋ Uploading model.bin ━━━━━━━━━━━━━━━━━━━━━━━━━  10%
  Uploading model.bin ━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
```

This is one spinner and one progress task. During checksum it stays at 0% and only communicates that the CLI is active. The same task becomes actual upload progress when multipart upload starts.

This PR does not add or change the integrity check. `_compute_md5(lpath)` still hashes the complete local file with its original API and chunk size. Individual multipart part ETags remain handled by `BaseMultipartUpload`; the final ETag comparison is unchanged.

## Verification

- One focused regression test protects the changed observable sequence: create task → hash → rename task → upload → advance same task.
- Focused test: 1 passed.
- Full repository `pre-commit run --all-files` under Python 3.12: passed, including Ruff and mypy.
- The real Rich renderer was exercised through `_put_file_multipart`; only network transport was stubbed.

## Scope

Two files and one commit. No server/API, multipart protocol, retry, concurrency, checksum, or upload behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reordering around existing MD5 and multipart upload; no API, protocol, or integrity behavior changes.
> 
> **Overview**
> Large multipart uploads no longer sit on a blank terminal while the full-file MD5 is computed. **`_put_file_multipart`** now registers the Rich progress task first with **"Calculating checksum..."** (0% until upload starts), runs **`_compute_md5`** unchanged, then renames the same task to **"Uploading {filename}"** before multipart parts advance it.
> 
> A unit test locks in that order: create task → hash → update description → upload, without changing checksum logic or ETag verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c966ccd6615827b1282af88590a332f53ac0fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->