### PR TITLE
chore: drop Python 3.8/3.9 tests

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Create Github release
         env:

--- a/.github/workflows/fal-e2e-tests.yml
+++ b/.github/workflows/fal-e2e-tests.yml
@@ -37,14 +37,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # pydantic 1.10.18 runs on the oldest supported interpreter only
         exclude:
-          - deps: "pydantic==2.13.3"
-            python: "3.8"
-          - deps: "pydantic==1.10.18"
-            python: "3.9"
-          - deps: "pydantic==1.10.18"
-            python: "3.10"
           - deps: "pydantic==1.10.18"
             python: "3.11"
           - deps: "pydantic==1.10.18"
@@ -70,7 +65,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip wheel
-          pip install -e 'projects/fal[test]' graphlib ${{ matrix.deps }}
+          pip install -e 'projects/fal[test]' ${{ matrix.deps }}
           pip install -e 'projects/fal_client[test]'
 
       - name: Run e2e tests

--- a/.github/workflows/fal-integration-tests.yml
+++ b/.github/workflows/fal-integration-tests.yml
@@ -35,14 +35,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # pydantic 1.10.18 runs on the oldest supported interpreter only
         exclude:
-          - deps: "pydantic==2.13.3"
-            python: "3.8"
-          - deps: "pydantic==1.10.18"
-            python: "3.9"
-          - deps: "pydantic==1.10.18"
-            python: "3.10"
           - deps: "pydantic==1.10.18"
             python: "3.11"
           - deps: "pydantic==1.10.18"
@@ -68,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip wheel
-          pip install -e 'projects/fal[test]' graphlib ${{ matrix.deps }}
+          pip install -e 'projects/fal[test]' ${{ matrix.deps }}
 
       - name: Run integration tests
         env:

--- a/.github/workflows/fal-unit-tests.yml
+++ b/.github/workflows/fal-unit-tests.yml
@@ -39,14 +39,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         deps: ["pydantic==1.10.18", "pydantic==2.13.3"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # pydantic 1.10.18 runs on the oldest supported interpreter only
         exclude:
-          - deps: "pydantic==2.13.3"
-            python: "3.8"
-          - deps: "pydantic==1.10.18"
-            python: "3.9"
-          - deps: "pydantic==1.10.18"
-            python: "3.10"
           - deps: "pydantic==1.10.18"
             python: "3.11"
           - deps: "pydantic==1.10.18"
@@ -72,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip wheel
-          pip install -e 'projects/fal[test]' graphlib ${{ matrix.deps }}
+          pip install -e 'projects/fal[test]' ${{ matrix.deps }}
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Parse tag
         id: parse
@@ -58,18 +58,9 @@ jobs:
           name: dist
           path: projects/${{ steps.parse.outputs.name }}/dist
 
-  # Re-run the unit suite against the commit being released, resolving
-  # dependencies fresh. A green run from earlier in the day is not a statement
-  # about now: the dependency bounds are open, so the installed tree is a
-  # function of when the job runs. fal 1.79.0 shipped from a commit whose last
-  # CI run was green 12.5 hours earlier, by which point argcomplete 3.7.1 had
-  # broken the CLI on 3.8/3.9.
+  # Re-run tests at release time so open dependency ranges are resolved fresh.
   # `inputs.skip_tests` and not `github.event.inputs.skip_tests`: the latter is
-  # always a string, and any non-empty string is truthy in an expression, so
-  # `!github.event.inputs.skip_tests` would be false even for "false" and would
-  # silently disable this gate on every dispatch. `inputs` honours the declared
-  # boolean type, and is empty (falsy) on a `release` event, which keeps the
-  # automatic path gated with no way to bypass it.
+  # always a string, and any non-empty string is truthy.
   unit-tests:
     if: ${{ needs.build.outputs.name == 'fal' && !inputs.skip_tests }}
     needs: build
@@ -98,10 +89,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 3.8 and 3.9 are where the dependency markers diverge from 3.10+, and
-        # where the argcomplete 3.7.1 break landed; 3.13 covers current
-        # resolution. All three projects declare requires-python >=3.8.
-        python: ["3.8", "3.9", "3.13"]
+        # Smoke-test fresh dependency resolution at both ends of this gate.
+        python: ["3.10", "3.14"]
     steps:
       - name: Download dist
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/tests-fal-client.yml
+++ b/.github/workflows/tests-fal-client.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:

--- a/.github/workflows/tests-isolate-proto.yml
+++ b/.github/workflows/tests-isolate-proto.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Python 3.8 and 3.9 are both past end-of-life (October 2024 and October 2025). We were still declaring `requires-python = ">=3.8"` on all three published packages and burning a CI job per suite on each.
