### PR TITLE
fix(sdk): fal exit with leaked argcomplete environment

### DIFF
--- a/projects/fal/src/fal/cli/parser.py
+++ b/projects/fal/src/fal/cli/parser.py
@@ -172,7 +172,12 @@ class FalParser(argparse.ArgumentParser):
         raise FalParserExit(status)
 
     def parse_args(self, args=None, namespace=None):
-        argcomplete.autocomplete(self)
+        if (
+            "_ARGCOMPLETE" in os.environ
+            and "COMP_LINE" in os.environ
+            and "COMP_POINT" in os.environ
+        ):
+            argcomplete.autocomplete(self)
         args, argv = self.parse_known_args(args, namespace)
         if argv:
             parser = _find_parser(self, getattr(args, "func", None)) or self

--- a/projects/fal/tests/unit/cli/test_main.py
+++ b/projects/fal/tests/unit/cli/test_main.py
@@ -328,6 +328,26 @@ def test_print_error_renders_with_cp1252_output() -> None:
     assert b"Check the logs" in result.stdout
 
 
+def test_main_ignores_incomplete_argcomplete_environment(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("check_updates = false\n")
+    env = os.environ.copy()
+    env["FAL_CONFIG_PATH"] = str(config_path)
+    env["_ARGCOMPLETE"] = "1"
+    env.pop("COMP_LINE", None)
+    env.pop("COMP_POINT", None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "fal", "--definitely-invalid"],
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert b"error:" in result.stderr
+
+
 def test_main_prints_deploy_failure_reason_and_logs_link(monkeypatch) -> None:
     """isolate-cloud#8647 (CLI boundary): a failed deploy comes back as a
     grpc.RpcError whose details() carry the categorized reason + logs link; main()


### PR DESCRIPTION
Fixes INFRA-4449.

A leaked `_ARGCOMPLETE=1` made argcomplete treat normal `fal` invocations as shell completion. Without completion fd 8, argcomplete called `os._exit(1)`, bypassing fal error handling and producing no output.

Only invoke argcomplete when `_ARGCOMPLETE`, `COMP_LINE`, and `COMP_POINT` are all present. Adds a subprocess regression test for the incomplete protocol.

Verification:
- `PYTHONPATH=projects/fal/src python -m pytest projects/fal/tests/unit/cli/test_main.py::test_main_ignores_incomplete_argcomplete_environment -q`
- `python -m pre_commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI parser guard plus a regression test; no auth, data, or API changes. Real completion still requires the full argcomplete protocol.
> 
> **Overview**
> Stops a leaked `_ARGCOMPLETE=1` from treating normal `fal` runs as shell completion. Incomplete completion env previously made argcomplete call `os._exit(1)` with no CLI error output.
> 
> `FalParser.parse_args` now calls `argcomplete.autocomplete` only when `_ARGCOMPLETE`, `COMP_LINE`, and `COMP_POINT` are all set. A subprocess test covers the incomplete-env case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a6a6d1f334b31e12302b44ed8efc916ce3148c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->