### PR TITLE
test(cli): cover long runner exec commands

### DIFF
--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -2024,7 +2024,7 @@ def test_exec_runner(host: api.FalServerlessHost, test_sleep_app: str):
         assert len(runners) == 1
         runner_id = runners[0].runner_id
 
-        proc = subprocess.Popen(
+        short_command = subprocess.run(
             [
                 "python",
                 "-m",
@@ -2036,20 +2036,35 @@ def test_exec_runner(host: api.FalServerlessHost, test_sleep_app: str):
                 "echo",
                 "hello",
             ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
+            timeout=10,
+            check=False,
         )
+        assert short_command.returncode == 0, short_command.stderr.decode()
+        assert b"hello" in short_command.stdout
 
-        try:
-            stdout, stderr = proc.communicate(timeout=10)
-            assert (
-                b"hello" in stdout
-            ), f"Expected 'hello' in output, got: {stdout.decode()}"
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait()
+        long_argument = "x" * 10_000
+        long_command = subprocess.run(
+            [
+                "python",
+                "-m",
+                "fal",
+                "runners",
+                "exec",
+                runner_id,
+                "--",
+                "/usr/bin/env",
+                "python",
+                "-c",
+                "import sys; print(len(sys.argv[1]))",
+                long_argument,
+            ],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        assert long_command.returncode == 0, long_command.stderr.decode()
+        assert b"10000" in long_command.stdout
 
 
 def test_container_app_client(test_container_app: str):

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -2064,7 +2064,7 @@ def test_exec_runner(host: api.FalServerlessHost, test_sleep_app: str):
             check=False,
         )
         assert long_command.returncode == 0, long_command.stderr.decode()
-        assert b"10000" in long_command.stdout
+        assert long_command.stdout.strip() == b"10000"
 
 
 def test_container_app_client(test_container_app: str):

--- a/projects/fal/tests/e2e/test_apps.py
+++ b/projects/fal/tests/e2e/test_apps.py
@@ -2056,7 +2056,7 @@ def test_exec_runner(host: api.FalServerlessHost, test_sleep_app: str):
                 "/usr/bin/env",
                 "python",
                 "-c",
-                "import sys; print(len(sys.argv[1]))",
+                'import sys; print(len(sys.argv), sys.argv[1] == "x" * 10_000)',
                 long_argument,
             ],
             capture_output=True,
@@ -2064,7 +2064,7 @@ def test_exec_runner(host: api.FalServerlessHost, test_sleep_app: str):
             check=False,
         )
         assert long_command.returncode == 0, long_command.stderr.decode()
-        assert long_command.stdout.strip() == b"10000"
+        assert long_command.stdout.strip() == b"2 True"
 
 
 def test_container_app_client(test_container_app: str):


### PR DESCRIPTION
The existing runner exec end-to-end test checks only a short command.

This change also sends a 10,000-character argument. The test verifies that the runner receives the exact argument once through the new bootstrap path.

This test requires https://github.com/fal-ai/isolate-cloud/pull/9636.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e coverage; no production or CLI behavior modified in this diff.
> 
> **Overview**
> Extends the **`test_exec_runner`** e2e test so `fal runners exec` is exercised beyond a short `echo hello`.
> 
> The short exec path is refactored from **`Popen`/`communicate`/manual kill** to **`subprocess.run`** with captured output, a 10s timeout, and explicit checks on exit code and stderr.
> 
> A second exec invokes remote Python with a **10,000-character CLI argument** and asserts the runner sees exactly one argv entry matching that string (`2 True` on stdout), guarding the **long-argument / bootstrap** path for runner exec (depends on isolate-cloud **#9636**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d38fced1fcb2da9717cebc6d05447d68ece5edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->