### PR TITLE
fix(cli): support runner shell on Python 3.14

### DIFF
--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import os
 import signal
-import struct
 import sys
 from collections import deque
 from dataclasses import dataclass
@@ -123,15 +122,12 @@ def runners_requests_table(runners: list[RunnerInfo]):
     return table
 
 
-def _get_tty_size():
+def _get_tty_size(fd: int):
     """Get current terminal dimensions."""
-    import fcntl
-    import termios
-
     try:
-        h, w = struct.unpack("HH", fcntl.ioctl(0, termios.TIOCGWINSZ, b"\0" * 4))[:2]
-        return h, w
-    except (OSError, ValueError):
+        size = os.get_terminal_size(fd)
+        return size.lines, size.columns
+    except OSError:
         return 24, 80  # Fallback to standard size
 
 
@@ -213,7 +209,7 @@ def _shell(args):
         # Send terminal size
         if is_tty:
             msg = isolate_proto.ShellRunnerInput()
-            h, w = _get_tty_size()
+            h, w = _get_tty_size(fd)
             msg.tty_size.height = h
             msg.tty_size.width = w
             yield msg
@@ -229,7 +225,7 @@ def _shell(args):
                 yield isolate_proto.ShellRunnerInput(data=data)
             elif msg_type == "resize":
                 msg = isolate_proto.ShellRunnerInput()
-                h, w = _get_tty_size()
+                h, w = _get_tty_size(fd)
                 msg.tty_size.height = h
                 msg.tty_size.width = w
                 yield msg

--- a/projects/fal/tests/unit/cli/test_runners.py
+++ b/projects/fal/tests/unit/cli/test_runners.py
@@ -1,15 +1,36 @@
 import json
+import os
+import struct
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from fal.cli.main import parse_args
-from fal.cli.runners import _gpus
+from fal.cli.runners import _get_tty_size, _gpus
+
+if os.name != "nt":
+    import fcntl
+    import termios
 
 _GPUS_PAYLOAD = {
     "gpus": {"H100": 394, "B200": 353, "H200": 334},
     "total": 1120,
 }
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Pseudo-terminals are Unix-only")
+def test_get_tty_size():
+    master_fd, slave_fd = os.openpty()
+    try:
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 120, 0, 0))
+        assert _get_tty_size(slave_fd) == (40, 120)
+    finally:
+        os.close(master_fd)
+        os.close(slave_fd)
+
+
+def test_get_tty_size_fallback():
+    assert _get_tty_size(-1) == (24, 80)
 
 
 def test_gpus_parser_registered():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized CLI change to terminal dimension reporting for runner shell; behavior is covered by new unit tests with no auth or data-handling impact.
> 
> **Overview**
> Fixes interactive **runner shell** / **exec -it** TTY sizing on Python 3.14 by replacing `fcntl`/`termios` window-size `ioctl` with **`os.get_terminal_size(fd)`**.
> 
> **`_get_tty_size`** now takes the stdin file descriptor (same `fd` used for raw mode and stdin reads) instead of assuming fd `0`, so initial and **SIGWINCH** resize messages to the gRPC stream use the correct dimensions. Invalid or non-terminal fds still fall back to **24×80**.
> 
> Adds unit tests: dimensions via a pseudo-terminal on Unix, and fallback when the fd is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2283cf0615a5fb47b386ffcefeafd6879a15bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->