### PR TITLE
fix(fal-client): support HTTP methods in run

### DIFF
--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -1679,7 +1679,7 @@ class AsyncClient:
             client,
             method,
             url,
-            json=arguments,
+            json=arguments if method.upper() != "GET" else None,
             timeout=timeout,
             headers=_headers,
         )
@@ -2207,7 +2207,7 @@ class SyncClient:
             self._client,
             method,
             url,
-            json=arguments,
+            json=arguments if method.upper() != "GET" else None,
             timeout=timeout,
             headers=_headers,
         )

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -1641,6 +1641,7 @@ class AsyncClient:
         application: str,
         arguments: AnyJSON,
         *,
+        method: str = "POST",
         path: str = "",
         timeout: Optional[Union[int, float]] = None,
         start_timeout: Optional[Union[int, float]] = None,
@@ -1651,6 +1652,7 @@ class AsyncClient:
         specify a subpath when applicable. This method will return the result of the inference call directly.
 
         Args:
+            method: HTTP method to use for the inference request.
             timeout: Client-side HTTP timeout in seconds. Controls how long the HTTP
                 client waits for a response. Defaults to the client's default_timeout.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
@@ -1675,7 +1677,7 @@ class AsyncClient:
 
         response = await _async_maybe_retry_request(
             client,
-            "POST",
+            method,
             url,
             json=arguments,
             timeout=timeout,
@@ -2171,6 +2173,7 @@ class SyncClient:
         application: str,
         arguments: AnyJSON,
         *,
+        method: str = "POST",
         path: str = "",
         timeout: Optional[Union[int, float]] = None,
         start_timeout: Optional[Union[int, float]] = None,
@@ -2180,6 +2183,7 @@ class SyncClient:
         """Run an application with the given arguments (which will be JSON serialized).
 
         Args:
+            method: HTTP method to use for the inference request.
             timeout: Client-side HTTP timeout in seconds. Controls how long the HTTP
                 client waits for a response. Defaults to the client's default_timeout.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
@@ -2201,7 +2205,7 @@ class SyncClient:
 
         response = _maybe_retry_request(
             self._client,
-            "POST",
+            method,
             url,
             json=arguments,
             timeout=timeout,

--- a/projects/fal_client/tests/unit/test_client.py
+++ b/projects/fal_client/tests/unit/test_client.py
@@ -191,17 +191,19 @@ def test_sync_client_run_with_headers():
         assert call_kwargs["headers"]["X-Trace-Id"] == "123"
 
 
-def test_sync_client_run_with_method():
+@pytest.mark.parametrize("method", ["GET", "get"])
+def test_sync_client_run_with_method(method):
     with patch("fal_client.client._maybe_retry_request") as mock_request:
         mock_response = Mock()
         mock_response.json.return_value = {"status": "ok"}
         mock_request.return_value = mock_response
 
         client = SyncClient(key="test-key")
-        result = client.run("test-app", {}, path="/health", method="GET")
+        result = client.run("test-app", {}, path="/health", method=method)
 
         assert result == {"status": "ok"}
-        assert mock_request.call_args.args[1] == "GET"
+        assert mock_request.call_args.args[1] == method
+        assert mock_request.call_args.kwargs["json"] is None
 
 
 def test_sync_client_run_defaults_to_post():
@@ -213,6 +215,7 @@ def test_sync_client_run_defaults_to_post():
         SyncClient(key="test-key").run("test-app", {"input": "data"})
 
         assert mock_request.call_args.args[1] == "POST"
+        assert mock_request.call_args.kwargs["json"] == {"input": "data"}
 
 
 def test_sync_client_run_with_headers_and_hint():
@@ -773,7 +776,8 @@ async def test_async_client_run_with_headers():
 
 
 @pytest.mark.asyncio
-async def test_async_client_run_with_method():
+@pytest.mark.parametrize("method", ["GET", "get"])
+async def test_async_client_run_with_method(method):
     with patch(
         "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
     ) as mock_request:
@@ -782,10 +786,11 @@ async def test_async_client_run_with_method():
         mock_request.return_value = mock_response
 
         client = AsyncClient(key="test-key")
-        result = await client.run("test-app", {}, path="/health", method="GET")
+        result = await client.run("test-app", {}, path="/health", method=method)
 
         assert result == {"status": "ok"}
-        assert mock_request.call_args.args[1] == "GET"
+        assert mock_request.call_args.args[1] == method
+        assert mock_request.call_args.kwargs["json"] is None
 
 
 @pytest.mark.asyncio
@@ -800,6 +805,7 @@ async def test_async_client_run_defaults_to_post():
         await AsyncClient(key="test-key").run("test-app", {"input": "data"})
 
         assert mock_request.call_args.args[1] == "POST"
+        assert mock_request.call_args.kwargs["json"] == {"input": "data"}
 
 
 @pytest.mark.asyncio

--- a/projects/fal_client/tests/unit/test_client.py
+++ b/projects/fal_client/tests/unit/test_client.py
@@ -191,6 +191,30 @@ def test_sync_client_run_with_headers():
         assert call_kwargs["headers"]["X-Trace-Id"] == "123"
 
 
+def test_sync_client_run_with_method():
+    with patch("fal_client.client._maybe_retry_request") as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_request.return_value = mock_response
+
+        client = SyncClient(key="test-key")
+        result = client.run("test-app", {}, path="/health", method="GET")
+
+        assert result == {"status": "ok"}
+        assert mock_request.call_args.args[1] == "GET"
+
+
+def test_sync_client_run_defaults_to_post():
+    with patch("fal_client.client._maybe_retry_request") as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_request.return_value = mock_response
+
+        SyncClient(key="test-key").run("test-app", {"input": "data"})
+
+        assert mock_request.call_args.args[1] == "POST"
+
+
 def test_sync_client_run_with_headers_and_hint():
     """Test that custom headers are merged with hint header"""
     with patch("fal_client.client._maybe_retry_request") as mock_request:
@@ -746,6 +770,36 @@ async def test_async_client_run_with_headers():
         assert "headers" in call_kwargs
         assert call_kwargs["headers"]["X-Custom-Header"] == "test-value"
         assert call_kwargs["headers"]["X-Trace-Id"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_async_client_run_with_method():
+    with patch(
+        "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_request.return_value = mock_response
+
+        client = AsyncClient(key="test-key")
+        result = await client.run("test-app", {}, path="/health", method="GET")
+
+        assert result == {"status": "ok"}
+        assert mock_request.call_args.args[1] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_async_client_run_defaults_to_post():
+    with patch(
+        "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_request.return_value = mock_response
+
+        await AsyncClient(key="test-key").run("test-app", {"input": "data"})
+
+        assert mock_request.call_args.args[1] == "POST"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Backward-compatible API extension on the inference `run` path; default remains POST with JSON body.
> 
> **Overview**
> **`SyncClient.run` and `AsyncClient.run`** now accept an optional **`method`** argument (default **`POST`**) so callers can hit app subpaths with **GET** (e.g. health checks via `path="/health"`).
> 
> When **`method`** is **GET** (case-insensitive), the client omits the JSON body instead of sending `arguments` as `json=`. Non-GET behavior is unchanged: the chosen method is passed through to the existing retry layer with the same headers, timeouts, and hints.
> 
> Unit tests cover custom methods and the POST default for both sync and async clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502436dcb662d0ee4708bdded23af8f1250e7816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->