### PR TITLE
feat(cli): add --older-than to queue flush

### DIFF
--- a/projects/fal/src/fal/cli/queue.py
+++ b/projects/fal/src/fal/cli/queue.py
@@ -63,15 +63,17 @@ def _queue_flush(args):
 
     client = SyncServerlessClient(host=args.host, team=args.team)._create_rest_client()
     user = _get_user(client)
-    caller_user_id = args.caller_user_id
+    params = {}
+    if args.caller_user_id:
+        params["caller_user_id"] = args.caller_user_id
+    if args.older_than is not None:
+        params["older_than"] = args.older_than
 
     url = f"{client.base_url}/applications/{user.username}/{args.app_name}/queue"
     headers = client.get_headers()
 
     with httpx.Client(base_url=client.base_url, headers=headers, timeout=300) as c:
-        resp = c.delete(
-            url, params={"caller_user_id": caller_user_id} if caller_user_id else None
-        )
+        resp = c.delete(url, params=params or None)
 
     if resp.status_code != HTTPStatus.OK:
         try:
@@ -137,5 +139,11 @@ def add_parser(main_subparsers, parents):
             "Only flush requests from this user ID. "
             "If not provided, all requests will be flushed."
         ),
+    )
+    flush_parser.add_argument(
+        "--older-than",
+        default=None,
+        type=str,
+        help="Only flush requests older than this duration.",
     )
     flush_parser.set_defaults(func=_queue_flush)

--- a/projects/fal/tests/unit/cli/test_queue.py
+++ b/projects/fal/tests/unit/cli/test_queue.py
@@ -1,0 +1,52 @@
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fal.cli.main import parse_args
+from fal.cli.queue import _queue_flush
+
+
+def test_flush_with_older_than():
+    args = parse_args(["queue", "flush", "my-app", "--older-than", "1h"])
+
+    assert args.func == _queue_flush
+    assert args.app_name == "my-app"
+    assert args.older_than == "1h"
+
+
+def test_flush_forwards_filters():
+    args = parse_args(
+        [
+            "queue",
+            "flush",
+            "my-app",
+            "--caller-user-id",
+            "user-id",
+            "--older-than",
+            "1h",
+        ]
+    )
+    rest_client = MagicMock(
+        base_url="https://rest.example.com",
+        get_headers=MagicMock(return_value={"Authorization": "Bearer token"}),
+    )
+    serverless_client = MagicMock()
+    serverless_client._create_rest_client.return_value = rest_client
+    http_client = MagicMock()
+    http_client.delete.return_value = MagicMock(status_code=HTTPStatus.OK)
+    http_client_context = MagicMock()
+    http_client_context.__enter__.return_value = http_client
+    with patch(
+        "fal.api.client.SyncServerlessClient", return_value=serverless_client
+    ), patch(
+        "fal.api.deploy._get_user",
+        return_value=SimpleNamespace(username="app-owner"),
+    ), patch(
+        "fal.cli.queue.httpx.Client", return_value=http_client_context
+    ):
+        _queue_flush(args)
+
+    http_client.delete.assert_called_once_with(
+        "https://rest.example.com/applications/app-owner/my-app/queue",
+        params={"caller_user_id": "user-id", "older_than": "1h"},
+    )


### PR DESCRIPTION
## Summary
- add `--older-than` to `fal queue flush`
- forward it as the `older_than` queue API parameter alongside caller filtering
- cover parsing and request forwarding

## Verification
- `PYTHONPATH=projects/fal/src python -m pytest projects/fal/tests/unit/cli/test_queue.py -q`
- parser smoke test returned `app 1h`

Prompted by: Vishnu Jaddipal