### PR TITLE
feat(fal_client): add a `tags` request option

### DIFF
--- a/projects/fal_client/src/fal_client/_headers.py
+++ b/projects/fal_client/src/fal_client/_headers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Literal, Union, get_args, Optional, Any, Callable
+import re
+from typing import Literal, Mapping, Union, get_args, Optional, Any, Callable
 
 from httpx import Headers
 
@@ -33,9 +34,23 @@ REQUEST_TIMEOUT_HEADER = "X-Fal-Request-Timeout"
 REQUEST_TIMEOUT_TYPE_HEADER = "X-Fal-Request-Timeout-Type"
 RUNNER_HINT_HEADER = "X-Fal-Runner-Hint"
 QUEUE_PRIORITY_HEADER = "X-Fal-Queue-Priority"
+TAGS_HEADER = "X-Fal-Tags"
 
 # Valid priority values
 Priority = Literal["normal", "low"]
+
+# Tag limits, mirroring the gateway's validator. The gateway fails open and
+# drops pairs it rejects, so the client validates up front instead of silently
+# sending tags that never make it into the account's usage breakdown.
+MAX_TAG_PAIRS = 10
+MAX_TAG_KEY_LENGTH = 64
+MAX_TAG_VALUE_LENGTH = 256
+MAX_TAGS_TOTAL_BYTES = 1024
+
+# System-only tag namespace, rejected in caller input.
+RESERVED_TAG_KEY_PREFIX = "fal."
+
+_TAG_KEY_PATTERN = re.compile(r"^[a-z0-9._-]+$")
 
 
 def add_timeout_header(timeout: Union[int, float], headers: dict[str, str]) -> None:
@@ -76,6 +91,80 @@ def add_priority_header(priority: Priority, headers: dict[str, str]) -> None:
             f"Priority must be one of {valid_priorities}, got '{priority}'"
         )
     headers[QUEUE_PRIORITY_HEADER] = priority
+
+
+def _is_valid_tag_value(value: str) -> bool:
+    # Printable ASCII (incl. space), excluding control chars and the "," separator.
+    return all(char.isascii() and char.isprintable() and char != "," for char in value)
+
+
+def add_tags_header(tags: Mapping[str, str], headers: dict[str, str]) -> None:
+    """
+    Validates the tags and adds the packed tags header to the headers dictionary.
+
+    Keys and values are trimmed, keys are lowercased, and the pairs are packed
+    into a single `key=value,key=value` header. An empty mapping adds no header.
+
+    Args:
+        tags: Tags to attach to the request, as a key to value mapping.
+        headers: Headers dictionary to add the tags header to.
+
+    Raises:
+        ValueError: If a key or value is invalid, or a tag limit is exceeded.
+    """
+    if not tags:
+        return
+
+    if len(tags) > MAX_TAG_PAIRS:
+        raise ValueError(f"At most {MAX_TAG_PAIRS} tags are allowed, got {len(tags)}")
+
+    packed: dict[str, str] = {}
+    total_bytes = 0
+
+    for raw_key, raw_value in tags.items():
+        if not isinstance(raw_key, str) or not isinstance(raw_value, str):
+            raise ValueError(
+                f"Tag keys and values must be strings, got {raw_key!r}: {raw_value!r}"
+            )
+
+        key = raw_key.strip().lower()
+        value = raw_value.strip()
+
+        if not _TAG_KEY_PATTERN.match(key):
+            raise ValueError(
+                f"Tag key must be non-empty and match [a-z0-9._-], got '{raw_key}'"
+            )
+        if not _is_valid_tag_value(value):
+            raise ValueError(
+                f"Tag value must be printable ASCII without ',', got '{raw_value}'"
+            )
+        if len(key) > MAX_TAG_KEY_LENGTH:
+            raise ValueError(
+                f"Tag key must be at most {MAX_TAG_KEY_LENGTH} characters, "
+                f"got '{raw_key}'"
+            )
+        if len(value) > MAX_TAG_VALUE_LENGTH:
+            raise ValueError(
+                f"Tag value must be at most {MAX_TAG_VALUE_LENGTH} characters, "
+                f"got '{raw_value}'"
+            )
+        if key.startswith(RESERVED_TAG_KEY_PREFIX):
+            raise ValueError(
+                f"Tag keys starting with '{RESERVED_TAG_KEY_PREFIX}' are reserved, "
+                f"got '{raw_key}'"
+            )
+
+        # Both the pair count and this byte budget (key and value) are measured
+        # before duplicate keys collapse -- the same way the gateway counts them.
+        total_bytes += len(key) + len(value)
+        if total_bytes > MAX_TAGS_TOTAL_BYTES:
+            raise ValueError(
+                f"Tags must be at most {MAX_TAGS_TOTAL_BYTES} bytes of keys and values"
+            )
+
+        packed[key] = value  # last-wins on duplicate keys
+
+    headers[TAGS_HEADER] = ",".join(f"{key}={value}" for key, value in packed.items())
 
 
 def add_fal_app_context_headers(headers: dict[str, str]) -> None:

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -24,6 +24,7 @@ from typing import (
     Awaitable,
     Dict,
     Iterator,
+    Mapping,
     TYPE_CHECKING,
     Optional,
     Literal,
@@ -52,6 +53,7 @@ from fal_client._headers import (
     add_priority_header,
     add_timeout_header,
     add_hint_header,
+    add_tags_header,
     add_fal_app_context_headers,
     handle_response_headers,
     REQUEST_TIMEOUT_TYPE_HEADER,
@@ -1646,6 +1648,7 @@ class AsyncClient:
         timeout: Optional[Union[int, float]] = None,
         start_timeout: Optional[Union[int, float]] = None,
         hint: str | None = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
     ) -> AnyJSON:
         """Run an application with the given arguments (which will be JSON serialized). The path parameter can be used to
@@ -1657,6 +1660,8 @@ class AsyncClient:
                 client waits for a response. Defaults to the client's default_timeout.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts. Does not apply once the application begins processing.
+            tags: Tags to attach to the request, as a key to value mapping. Sent
+                as one packed X-Fal-Tags header; invalid or over-limit tags raise.
         """
 
         client = await self._client
@@ -1672,6 +1677,9 @@ class AsyncClient:
 
         if start_timeout is not None:
             add_timeout_header(start_timeout, _headers)
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
 
         add_fal_app_context_headers(_headers)
 
@@ -1697,6 +1705,7 @@ class AsyncClient:
         hint: str | None = None,
         webhook_url: str | None = None,
         priority: Optional[Priority] = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
         start_timeout: Optional[Union[int, float]] = None,
     ) -> AsyncRequestHandle:
@@ -1708,6 +1717,8 @@ class AsyncClient:
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts (includes queue wait, retries, and
                 routing). Does not apply once the application begins processing.
+            tags: Tags to attach to the request, as a key to value mapping. Sent
+                as one packed X-Fal-Tags header; invalid or over-limit tags raise.
         """
 
         client = await self._client
@@ -1729,6 +1740,9 @@ class AsyncClient:
 
         if start_timeout is not None:
             add_timeout_header(start_timeout, _headers)
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
 
         add_fal_app_context_headers(_headers)
 
@@ -1764,6 +1778,7 @@ class AsyncClient:
         on_enqueue: Optional[Callable[[str], None | Awaitable[None]]] = None,
         on_queue_update: Optional[Callable[[Status], None | Awaitable[None]]] = None,
         priority: Optional[Priority] = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
         start_timeout: Optional[Union[int, float]] = None,
         client_timeout: Optional[Union[int, float]] = None,
@@ -1799,6 +1814,7 @@ class AsyncClient:
                 path=path,
                 hint=hint,
                 priority=priority,
+                tags=tags,
                 headers=headers,
                 start_timeout=start_timeout,
             )
@@ -1862,6 +1878,7 @@ class AsyncClient:
         *,
         path: str = "/stream",
         timeout: float | None = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream the output of an application with the given arguments (which will be JSON serialized). This is only supported
@@ -1877,6 +1894,10 @@ class AsyncClient:
             url += "/" + path.lstrip("/")
 
         _headers: dict[str, str] = {**headers}
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
+
         add_fal_app_context_headers(_headers)
 
         async with aconnect_sse(
@@ -2178,6 +2199,7 @@ class SyncClient:
         timeout: Optional[Union[int, float]] = None,
         start_timeout: Optional[Union[int, float]] = None,
         hint: str | None = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
     ) -> AnyJSON:
         """Run an application with the given arguments (which will be JSON serialized).
@@ -2188,6 +2210,8 @@ class SyncClient:
                 client waits for a response. Defaults to the client's default_timeout.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts. Does not apply once the application begins processing.
+            tags: Tags to attach to the request, as a key to value mapping. Sent
+                as one packed X-Fal-Tags header; invalid or over-limit tags raise.
         """
 
         url = RUN_URL_FORMAT + application
@@ -2200,6 +2224,9 @@ class SyncClient:
 
         if start_timeout is not None:
             add_timeout_header(start_timeout, _headers)
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
 
         add_fal_app_context_headers(_headers)
 
@@ -2225,6 +2252,7 @@ class SyncClient:
         hint: str | None = None,
         webhook_url: str | None = None,
         priority: Optional[Priority] = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
         start_timeout: Optional[Union[int, float]] = None,
     ) -> SyncRequestHandle:
@@ -2234,6 +2262,8 @@ class SyncClient:
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts (includes queue wait, retries, and
                 routing). Does not apply once the application begins processing.
+            tags: Tags to attach to the request, as a key to value mapping. Sent
+                as one packed X-Fal-Tags header; invalid or over-limit tags raise.
         """
 
         url = QUEUE_URL_FORMAT + application
@@ -2253,6 +2283,9 @@ class SyncClient:
 
         if start_timeout is not None:
             add_timeout_header(start_timeout, _headers)
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
 
         add_fal_app_context_headers(_headers)
 
@@ -2288,6 +2321,7 @@ class SyncClient:
         on_enqueue: Optional[Callable[[str], None]] = None,
         on_queue_update: Optional[Callable[[Status], None]] = None,
         priority: Optional[Priority] = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
         start_timeout: Optional[Union[int, float]] = None,
         client_timeout: Optional[Union[int, float]] = None,
@@ -2323,6 +2357,7 @@ class SyncClient:
                 path=path,
                 hint=hint,
                 priority=priority,
+                tags=tags,
                 headers=headers,
                 start_timeout=start_timeout,
             )
@@ -2379,6 +2414,7 @@ class SyncClient:
         *,
         path: str = "/stream",
         timeout: float | None = None,
+        tags: Optional[Mapping[str, str]] = None,
         headers: dict[str, str] = {},
     ) -> Iterator[dict[str, Any]]:
         """Stream the output of an application with the given arguments (which will be JSON serialized). This is only supported
@@ -2393,6 +2429,10 @@ class SyncClient:
             url += "/" + path.lstrip("/")
 
         _headers: dict[str, str] = {**headers}
+
+        if tags is not None:
+            add_tags_header(tags, _headers)
+
         add_fal_app_context_headers(_headers)
 
         with connect_sse(

--- a/projects/fal_client/tests/unit/test_client.py
+++ b/projects/fal_client/tests/unit/test_client.py
@@ -242,6 +242,81 @@ def test_sync_client_run_with_headers_and_hint():
         assert call_kwargs["headers"]["X-Custom-Header"] == "test-value"
 
 
+def test_sync_client_run_with_tags():
+    """Test that tags are packed into the X-Fal-Tags header in run()"""
+    with patch("fal_client.client._maybe_retry_request") as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_request.return_value = mock_response
+
+        client = SyncClient(key="test-key")
+
+        client.run(
+            "test-app",
+            {"input": "data"},
+            tags={"team": "design", "env": "prod"},
+            headers={"X-Custom": "value"},
+        )
+
+        call_kwargs = mock_request.call_args[1]
+        assert call_kwargs["headers"]["X-Fal-Tags"] == "team=design,env=prod"
+        assert call_kwargs["headers"]["X-Custom"] == "value"
+
+
+def test_sync_client_run_with_invalid_tags_raises():
+    """Test that invalid tags are rejected before the request is made"""
+    with patch("fal_client.client._maybe_retry_request") as mock_request:
+        client = SyncClient(key="test-key")
+
+        with pytest.raises(ValueError, match="Tag key"):
+            client.run("test-app", {"input": "data"}, tags={"bad key": "value"})
+
+        mock_request.assert_not_called()
+
+
+def test_sync_client_stream_with_tags():
+    """Test that tags are packed into the X-Fal-Tags header in stream()"""
+    with patch("fal_client.client.connect_sse") as mock_connect_sse:
+        events = Mock()
+        events.response.headers = {}
+        events.iter_sse.return_value = iter([])
+        mock_connect_sse.return_value.__enter__ = Mock(return_value=events)
+        mock_connect_sse.return_value.__exit__ = Mock(return_value=False)
+
+        client = SyncClient(key="test-key")
+        assert list(client.stream("test-app", {}, tags={"env": "prod"})) == []
+
+        call_kwargs = mock_connect_sse.call_args[1]
+        assert call_kwargs["headers"]["X-Fal-Tags"] == "env=prod"
+
+
+def test_sync_client_subscribe_with_tags():
+    """Test that tags reach the submit request in subscribe()"""
+    with patch("fal_client.client._maybe_retry_request") as mock_request:
+        submit_response = Mock()
+        submit_response.json.return_value = {
+            "request_id": "req-123",
+            "response_url": "http://response",
+            "status_url": "http://status",
+            "cancel_url": "http://cancel",
+        }
+
+        status_response = Mock()
+        status_response.json.return_value = {"status": "COMPLETED", "logs": []}
+
+        result_response = Mock()
+        result_response.json.return_value = {"result": "done"}
+
+        mock_request.side_effect = [submit_response, status_response, result_response]
+
+        client = SyncClient(key="test-key")
+        result = client.subscribe("test-app", {"input": "data"}, tags={"env": "prod"})
+
+        assert result == {"result": "done"}
+        first_call_kwargs = mock_request.call_args_list[0][1]
+        assert first_call_kwargs["headers"]["X-Fal-Tags"] == "env=prod"
+
+
 def test_sync_client_submit_with_headers():
     """Test that custom headers are passed through in submit()"""
     with patch("fal_client.client._maybe_retry_request") as mock_request:
@@ -1278,6 +1353,33 @@ async def test_async_upload_respects_repository_order():
         mock_request.call_args_list[0][0][2]
         == f"{REST_URL}/storage/upload/initiate?storage_type=gcs"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_client_submit_with_tags():
+    """Test that tags are packed into the X-Fal-Tags header in submit()"""
+    with patch(
+        "fal_client.client._async_maybe_retry_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "request_id": "req-123",
+            "response_url": "http://response",
+            "status_url": "http://status",
+            "cancel_url": "http://cancel",
+        }
+        mock_request.return_value = mock_response
+
+        client = AsyncClient(key="test-key")
+
+        await client.submit(
+            "test-app",
+            {"input": "data"},
+            tags={"team": "design"},
+        )
+
+        call_kwargs = mock_request.call_args[1]
+        assert call_kwargs["headers"]["X-Fal-Tags"] == "team=design"
 
 
 @pytest.mark.asyncio

--- a/projects/fal_client/tests/unit/test_headers.py
+++ b/projects/fal_client/tests/unit/test_headers.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import pytest
 
 from fal_client._headers import (
+    MAX_TAG_KEY_LENGTH,
+    MAX_TAG_PAIRS,
+    MAX_TAG_VALUE_LENGTH,
+    MAX_TAGS_TOTAL_BYTES,
     MIN_REQUEST_TIMEOUT_SECONDS,
     QUEUE_PRIORITY_HEADER,
     REQUEST_TIMEOUT_HEADER,
     RUNNER_HINT_HEADER,
+    TAGS_HEADER,
     add_fal_app_context_headers,
     add_hint_header,
     add_priority_header,
+    add_tags_header,
     add_timeout_header,
     set_get_current_app,
 )
@@ -140,6 +146,134 @@ class TestAddPriorityHeader:
 
         with pytest.raises(ValueError):
             add_priority_header("", headers)  # type: ignore[arg-type]
+
+
+class TestAddTagsHeader:
+    """Tests for add_tags_header function."""
+
+    def test_packs_pairs_into_one_header(self) -> None:
+        """Tags are packed into a single comma-separated header."""
+        headers: dict[str, str] = {}
+        add_tags_header({"team": "design", "env": "prod"}, headers)
+
+        assert headers[TAGS_HEADER] == "team=design,env=prod"
+
+    def test_no_header_for_empty_tags(self) -> None:
+        """An empty mapping adds no header."""
+        headers: dict[str, str] = {}
+        add_tags_header({}, headers)
+
+        assert TAGS_HEADER not in headers
+
+    def test_lowercases_keys_and_trims(self) -> None:
+        """Keys are lowercased and both sides are trimmed."""
+        headers: dict[str, str] = {}
+        add_tags_header({" Team ": " design "}, headers)
+
+        assert headers[TAGS_HEADER] == "team=design"
+
+    def test_last_wins_on_duplicate_keys(self) -> None:
+        """Keys that collide after lowercasing keep the last value."""
+        headers: dict[str, str] = {}
+        add_tags_header({"team": "design", "TEAM": "eng"}, headers)
+
+        assert headers[TAGS_HEADER] == "team=eng"
+
+    def test_allows_empty_value(self) -> None:
+        """An empty value is a valid pair, matching the server's parser."""
+        headers: dict[str, str] = {}
+        add_tags_header({"team": ""}, headers)
+
+        assert headers[TAGS_HEADER] == "team="
+
+    def test_preserves_existing_headers(self) -> None:
+        """Adding the tags header preserves existing headers."""
+        headers: dict[str, str] = {"X-Existing": "value"}
+        add_tags_header({"env": "prod"}, headers)
+
+        assert headers["X-Existing"] == "value"
+        assert headers[TAGS_HEADER] == "env=prod"
+
+    @pytest.mark.parametrize(
+        "key", ["", " ", "team!", "team space", "tea,m", "team=x", "\u00e9quipe"]
+    )
+    def test_raises_for_invalid_key(self, key: str) -> None:
+        """Keys outside [a-z0-9._-] are rejected."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="Tag key must be non-empty"):
+            add_tags_header({key: "prod"}, headers)
+
+    @pytest.mark.parametrize("value", ["a,b", "line\nbreak", "tab\there", "caf\u00e9"])
+    def test_raises_for_invalid_value(self, value: str) -> None:
+        """Values with commas, control chars, or non-ASCII are rejected."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="Tag value must be printable ASCII"):
+            add_tags_header({"env": value}, headers)
+
+    def test_raises_for_too_many_pairs(self) -> None:
+        """More than MAX_TAG_PAIRS tags is rejected."""
+        headers: dict[str, str] = {}
+        tags = {f"key{index}": "value" for index in range(MAX_TAG_PAIRS + 1)}
+
+        with pytest.raises(ValueError, match="At most"):
+            add_tags_header(tags, headers)
+
+    def test_allows_exactly_max_pairs(self) -> None:
+        """Exactly MAX_TAG_PAIRS tags is allowed."""
+        headers: dict[str, str] = {}
+        tags = {f"key{index}": "value" for index in range(MAX_TAG_PAIRS)}
+
+        add_tags_header(tags, headers)
+
+        assert headers[TAGS_HEADER].count(",") == MAX_TAG_PAIRS - 1
+
+    def test_raises_for_long_key(self) -> None:
+        """A key over MAX_TAG_KEY_LENGTH is rejected."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="Tag key must be at most"):
+            add_tags_header({"k" * (MAX_TAG_KEY_LENGTH + 1): "prod"}, headers)
+
+    def test_raises_for_long_value(self) -> None:
+        """A value over MAX_TAG_VALUE_LENGTH is rejected."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="Tag value must be at most"):
+            add_tags_header({"env": "v" * (MAX_TAG_VALUE_LENGTH + 1)}, headers)
+
+    def test_raises_over_total_byte_budget(self) -> None:
+        """The key+value byte budget is enforced across all pairs."""
+        headers: dict[str, str] = {}
+        # 5 pairs of 4 + 250 bytes = 1270 bytes, over the 1 KB budget.
+        tags = {f"key{index}": "v" * 250 for index in range(5)}
+
+        with pytest.raises(ValueError, match=f"at most {MAX_TAGS_TOTAL_BYTES} bytes"):
+            add_tags_header(tags, headers)
+
+    def test_raises_for_reserved_key(self) -> None:
+        """The fal.* namespace is reserved for the platform."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="are reserved"):
+            add_tags_header({"fal.endpoint": "x"}, headers)
+
+    def test_raises_for_non_string_pair(self) -> None:
+        """Non-string keys or values are rejected."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError, match="must be strings"):
+            add_tags_header({"attempt": 2}, headers)  # type: ignore[dict-item]
+
+    def test_no_header_when_validation_fails(self) -> None:
+        """A rejected mapping leaves the headers untouched."""
+        headers: dict[str, str] = {}
+
+        with pytest.raises(ValueError):
+            add_tags_header({"env": "prod", "bad key": "x"}, headers)
+
+        assert headers == {}
 
 
 class _FakeRequest:


### PR DESCRIPTION
Why: callers want to attach their own `key=value` tags to fal requests so usage and cost can be attributed to their own dimensions (team, environment, feature). The gateway already parses and stamps the packed `X-Fal-Tags` header; the Python client had no way to send it.

Adds a `tags=` option to `run`, `submit`, `subscribe`, and `stream` on both `SyncClient` and `AsyncClient` (and therefore the module-level `fal_client.run`/`submit`/... aliases). Tags are packed into a single `X-Fal-Tags: k=v,k=v` header by a new `add_tags_header` helper in `_headers.py`, which validates them the way the gateway does — keys lowercased and limited to `[a-z0-9._-]`, values printable ASCII without commas, at most 10 pairs, 64-char keys, 256-char values, 1 KB of keys and values, and the reserved `fal.*` namespace refused. The gateway fails open and silently drops pairs it rejects, so the client raises `ValueError` up front instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional parameter and request-header validation only; no changes to auth, billing logic, or existing call paths when `tags` is omitted.
> 
> **Overview**
> Adds optional **`tags=`** on **`run`**, **`submit`**, **`subscribe`**, and **`stream`** for **`SyncClient`** and **`AsyncClient`**, so callers can attach custom dimensions (team, env, feature) for usage attribution.
> 
> Tags are validated client-side in new **`add_tags_header`** (limits and rules aligned with the gateway: key format, printable ASCII values, max pairs/lengths, 1 KB budget, no **`fal.*`** keys), then sent as a single **`X-Fal-Tags: key=value,...`** header. Invalid tags raise **`ValueError`** before any HTTP call, instead of being silently dropped server-side.
> 
> Unit tests cover header packing/validation and that tagged requests set the header on sync/async paths (including **`subscribe`** forwarding to **`submit`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbc0a34ab7ce9fd4baac141b3cee41fad49df83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->