### PR TITLE
fix(cli): parse exec flags placed after the runner id

### DIFF
--- a/projects/fal/src/fal/cli/runners.py
+++ b/projects/fal/src/fal/cli/runners.py
@@ -132,28 +132,31 @@ def _get_tty_size(fd: int):
 
 
 def _shell(args):
-    """Execute a command (or interactive shell) on a runner."""
+    """Open an interactive shell on a runner."""
+    return _shell_session(args, command=None, interactive=True)
+
+
+def _exec(args):
+    """Execute a command on a runner."""
+    command = args.command
+    # argparse may leave the -- separator as the first token (Python < 3.12).
+    if command[0] == "--":
+        command = command[1:]
+
+    if not command:
+        args.console.print("[red]Error:[/] No command specified.")
+        return 1
+
+    return _shell_session(args, command=command, interactive=args.interactive)
+
+
+def _shell_session(args, command, interactive):
+    """Stream a shell session on a runner; command=None opens a login shell."""
     import isolate_proto
 
     client = SyncServerlessClient(host=args.host, team=args.team)
     stub = client._create_host()._connection.stub
     runner_id = args.id
-
-    is_exec = hasattr(args, "command")
-
-    if is_exec:
-        command = args.command
-        if command and command[0] == "--":
-            command = command[1:]
-
-        if not command:
-            args.console.print("[red]Error:[/] No command specified.")
-            return 1
-
-        interactive = args.interactive
-    else:
-        command = None
-        interactive = True
 
     if interactive and os.name == "nt":
         args.console.print(
@@ -853,12 +856,14 @@ def _add_exec_parser(subparsers, parents):
         action="store_true",
         help="Allocate a TTY and attach stdin (interactive mode).",
     )
+    # PARSER keeps fal's own flags parseable between the runner id and the
+    # command; REMAINDER would swallow them into the command.
     parser.add_argument(
         "command",
-        nargs=argparse.REMAINDER,
-        help="Command to execute (after --).",
+        nargs=argparse.PARSER,
+        help="Command to execute. Prefix with -- if it starts with a dash.",
     )
-    parser.set_defaults(func=_shell)
+    parser.set_defaults(func=_exec)
 
 
 def add_parser(main_subparsers, parents):

--- a/projects/fal/tests/unit/cli/test_runners.py
+++ b/projects/fal/tests/unit/cli/test_runners.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fal.cli.main import parse_args
-from fal.cli.runners import _get_tty_size, _gpus
+from fal.cli.parser import FalParserExit
+from fal.cli.runners import _exec, _get_tty_size, _gpus
 
 if os.name != "nt":
     import fcntl
@@ -36,6 +37,96 @@ def test_get_tty_size_fallback():
 def test_gpus_parser_registered():
     args = parse_args(["runners", "gpus"])
     assert args.func == _gpus
+
+
+@pytest.mark.parametrize(
+    ("argv", "interactive"),
+    [
+        pytest.param(
+            ["runners", "exec", "runner-id", "-it", "--", "python"],
+            True,
+            id="flag_after_id",
+        ),
+        pytest.param(
+            ["runners", "exec", "-it", "runner-id", "--", "python"],
+            True,
+            id="flag_before_id",
+        ),
+        pytest.param(
+            ["runners", "exec", "runner-id", "--", "python"],
+            False,
+            id="no_flag",
+        ),
+    ],
+)
+def test_exec_parses_fal_flags_on_either_side_of_runner_id(argv, interactive):
+    args = parse_args(argv)
+    assert args.func == _exec
+    assert args.id == "runner-id"
+    assert args.interactive is interactive
+    assert args.command[-1] == "python"
+
+
+def test_exec_keeps_command_flags_out_of_fal_parsing():
+    args = parse_args(["runners", "exec", "runner-id", "--", "tail", "-f", "/x"])
+    assert args.interactive is False
+    assert args.command[-3:] == ["tail", "-f", "/x"]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["runners", "exec", "runner-id"],
+        ["runners", "exec", "runner-id", "--"],
+        ["runners", "exec", "runner-id", "--bogus", "--", "env"],
+    ],
+    ids=["no_command", "separator_only", "unknown_flag_before_separator"],
+)
+def test_exec_rejects_missing_command_and_unknown_flags(argv, capsys):
+    with pytest.raises(FalParserExit) as exc:
+        parse_args(argv)
+    assert exc.value.status == 2
+    assert "fal runners exec: error:" in capsys.readouterr().err
+
+
+def _exec_with_command(mock_client_cls, command):
+    import isolate_proto
+
+    sent = []
+
+    def shell_runner(inputs):
+        sent.extend(inputs)
+        return [isolate_proto.ShellRunnerOutput(exit_code=0)]
+
+    stub = mock_client_cls.return_value._create_host.return_value._connection.stub
+    stub.ShellRunner.side_effect = shell_runner
+
+    args = parse_args(["runners", "exec", "runner-id", "--", "python"])
+    args.command = command
+    args.console = MagicMock()
+    return args.func(args), sent, args.console
+
+
+@pytest.mark.parametrize(
+    "command",
+    [["python"], ["--", "python"]],
+    ids=["bare", "with_separator"],
+)
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_exec_strips_leading_separator_before_sending(mock_client_cls, command):
+    exit_code, sent, _ = _exec_with_command(mock_client_cls, command)
+
+    assert exit_code == 0
+    assert list(sent[0].command) == ["python"]
+
+
+@patch("fal.cli.runners.SyncServerlessClient")
+def test_exec_rejects_separator_only_command(mock_client_cls):
+    exit_code, sent, console = _exec_with_command(mock_client_cls, ["--"])
+
+    assert exit_code == 1
+    assert sent == []
+    assert "No command specified" in console.print.call_args[0][0]
 
 
 def _mock_client(payload):


### PR DESCRIPTION
## What changed

`fal runners exec <id> -it -- python`, the form shown in the [CLI docs](https://fal.ai/docs/api-reference/cli/runners), never enabled interactive mode. The `command` positional used `argparse.REMAINDER`, which swallows everything after the runner id, including `-it` and `--`, so the container was asked to exec `-it`:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "-it": executable file not found in $PATH
```

Putting `-it` before the runner id worked, which is how the bug was found.

- `command` now uses `argparse.PARSER`, which keeps parsing fal's own flags until the first non-flag token. Flags work on either side of the runner id. `nargs="*"` was ruled out: on Python 3.8–3.11 argparse consumes the empty positional before it sees the flag and then rejects `-- python` as unrecognized.
- `exec` gets its own handler, `_exec`, instead of sharing `_shell` with the hidden `shell` subcommand. The custom parser attributes leftover-argument errors to the first subparser whose `func` matches, so unknown flags on `exec` were previously reported as `fal runners shell: error: …` with the wrong usage line. This also removes the `hasattr(args, "command")` sniff.
- The `--` strip stays in the handler because Python < 3.12 leaves the separator as the first token when a flag sits between the id and `--`. A separator-only command (`exec <id> -- --`) still exits 1 with "No command specified" rather than sending an empty command to the runner.

## Behavior changes to be aware of

- Flags between the runner id and `--` (`-it`, `--team`) are now fal's. With REMAINDER they were passed to the container as the command.
- A missing command is now an argparse usage error on stderr with exit code 2, instead of the rich "No command specified" error with exit code 1.
- The usage line changes from `id ...` to `id command ...`. The help block mirrored in [fal-docs `api-reference/cli/runners.mdx`](https://github.com/fal-ai/fal-docs/blob/2a2215519f54a3298ab76f67e847a31867a7dd4d/api-reference/cli/runners.mdx#L154-L166) will need a follow-up once this is released. The documented examples themselves are correct and are exactly what this fixes.

New help output:

```
$ fal runners exec --help
Usage: fal runners exec [-h] [--team TEAM] [-it] id command ...

Positional Arguments:
  id                  Runner ID.
  command             Command to execute. Prefix with -- if it starts with a dash.

Options:
  -h, --help          show this help message and exit
  --team TEAM         The team to use.
  -it, --interactive  Allocate a TTY and attach stdin (interactive mode).

$ fal runners exec rid --bogus -- env
Usage: fal runners exec [-h] [--team TEAM] [-it] id command ...
fal runners exec: error: unrecognized arguments: --bogus
[exit 2]
```

## Where to look first

1. `_add_exec_parser` in `projects/fal/src/fal/cli/runners.py`: the one-line `REMAINDER` → `PARSER` change is the fix.
2. `_exec` / `_shell` / `_shell_session` split just above it.
3. `test_exec_strips_leading_separator_before_sending` and `test_exec_rejects_missing_command_and_unknown_flags`, which fail against `main`.

## How it was tested

Unit tests for the touched module, run against this branch's source:

```
$ python -m pytest -q projects/fal/tests/unit/cli/test_runners.py        # Python 3.12.13
18 passed in 0.25s

$ uv run --python 3.9 --isolated --extra test --no-editable pytest -q tests/unit/cli/test_runners.py
18 passed in 0.51s

$ pre-commit run --files projects/fal/src/fal/cli/runners.py projects/fal/tests/unit/cli/test_runners.py
ruff-format / ruff / check-added-large-files / merge-conflicts / vcs-permalinks / debug-statements / mypy: Passed
```

Parser behavior was also checked with a standalone argparse reproduction on CPython 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 for `REMAINDER`, `"*"` and `PARSER`, with the documented invocation, the flag-before-id form, `--team` after the id, command flags after `--`, a command with no `--`, and unknown flags. Only `PARSER` handles all of them on every version.

Parsing the documented command on this branch:

```
$ fal runners exec runner_abc123xyz -it -- python   (parse only)
func=_exec interactive=True command=['python']
```

Not verified: an end-to-end `fal runners exec` against a live runner. The gRPC stream is exercised only through the mocked `SyncServerlessClient` in the new handler tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI parsing and error paths for a runner exec path; behavior shifts for flags between id and `--`, but scope is limited to the exec/shell CLI surface.
> 
> **Overview**
> Fixes **`fal runners exec`** so documented invocations like `exec <id> -it -- python` honor **`-it`** instead of trying to run `-it` on the runner.
> 
> The **`command`** positional switches from **`argparse.REMAINDER`** to **`argparse.PARSER`**, so fal flags (e.g. **`-it`**, **`--team`**) parse on either side of the runner id while tokens after **`--`** stay part of the remote command. **`exec`** now uses a dedicated **`_exec`** handler; interactive **`shell`** delegates to shared **`_shell_session`**, so errors attribute to **`runners exec`** rather than **`runners shell`**.
> 
> Missing commands and unknown fal flags surface as **argparse** errors (exit **2**); **`_exec`** still strips a leading **`--`** on older Python and rejects separator-only commands with exit **1**. Unit tests cover flag placement, command flags after **`--`**, and gRPC command payload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c62fb44b88fd4088400e63b6efef2577c7cf2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->