### PR TITLE
feat(fal-client): add backup domains for fal run requests

### DIFF
--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -85,6 +85,15 @@ QUEUE_URL_FORMAT = f"https://{FAL_QUEUE_RUN_HOST}/"
 REALTIME_URL_FORMAT = f"wss://{FAL_RUN_HOST}/"
 REST_URL = "https://rest.fal.ai"
 
+_BACKUP_DOMAINS = {
+    "fal.run": "falrun.com",
+    "queue.fal.run": "queue.falrun.com",
+}
+# Ceiling on the connect timeout for HTTP requests to a mapped domain (run,
+# submit, status, result, cancel and stream alike). A shorter caller timeout
+# still wins; a longer one cannot delay falling back to the backup domain.
+_BACKUP_DOMAIN_CONNECT_TIMEOUT = 5.0
+
 CDN_URL = "https://v3.fal.media"
 DEFAULT_UPLOAD_REPOSITORY: UploadRepositoryId = "fal_v3"
 DEFAULT_UPLOAD_FALLBACK_REPOSITORY: list[UploadRepositoryId] = ["fal"]
@@ -988,6 +997,102 @@ class AsyncRealtimeConnection:
         await self.close()
 
 
+def _fallback_url(url: httpx.URL) -> httpx.URL | None:
+    host = _BACKUP_DOMAINS.get(url.host)
+    if host is None:
+        return None
+    return url.copy_with(host=host)
+
+
+def _limit_connect_timeout(request: httpx.Request) -> None:
+    if (
+        request.url.host not in _BACKUP_DOMAINS
+        and request.url.host not in _BACKUP_DOMAINS.values()
+    ):
+        return
+
+    # Per-request timeout=None must not disable detecting an unreachable domain.
+    timeouts = request.extensions.get("timeout", {})
+    connect = timeouts.get("connect")
+    request.extensions["timeout"] = {
+        **timeouts,
+        "connect": min(connect, _BACKUP_DOMAIN_CONNECT_TIMEOUT)
+        if connect is not None
+        else _BACKUP_DOMAIN_CONNECT_TIMEOUT,
+    }
+
+
+def _backup_request(request: httpx.Request) -> httpx.Request | None:
+    url = _fallback_url(request.url)
+    if url is None:
+        return None
+    headers = request.headers.copy()
+    headers["Host"] = url.netloc.decode("ascii")
+    return httpx.Request(
+        request.method,
+        url,
+        headers=headers,
+        stream=request.stream,
+        extensions=request.extensions.copy(),
+    )
+
+
+def _log_backup(primary_host: str, backup_host: str, exc: Exception) -> None:
+    logger.warning(
+        "Connection to %s failed (%s); trying backup domain %s",
+        primary_host,
+        type(exc).__name__,
+        backup_host,
+    )
+
+
+class BackupDomainTransport(httpx.BaseTransport):
+    def __init__(self, *, transport: httpx.BaseTransport | None = None) -> None:
+        # Let HTTPX route each domain through its environment proxy configuration.
+        # Redirects stay with the outer client so fallback only replays one hop.
+        self._client = httpx.Client(transport=transport, follow_redirects=False)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        _limit_connect_timeout(request)
+        try:
+            return self._client.send(request, stream=True)
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            backup = _backup_request(request)
+            if backup is None:
+                raise
+            _log_backup(request.url.host, backup.url.host, exc)
+            try:
+                return self._client.send(backup, stream=True)
+            except (httpx.ConnectError, httpx.ConnectTimeout):
+                # Preserve the primary error's retry policy; retain backup in context.
+                raise exc
+
+    def close(self) -> None:
+        self._client.close()
+
+
+class AsyncBackupDomainTransport(httpx.AsyncBaseTransport):
+    def __init__(self, *, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._client = httpx.AsyncClient(transport=transport, follow_redirects=False)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        _limit_connect_timeout(request)
+        try:
+            return await self._client.send(request, stream=True)
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            backup = _backup_request(request)
+            if backup is None:
+                raise
+            _log_backup(request.url.host, backup.url.host, exc)
+            try:
+                return await self._client.send(backup, stream=True)
+            except (httpx.ConnectError, httpx.ConnectTimeout):
+                raise exc
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
 @contextmanager
 def _connect_sync_ws(
     url: str, headers: dict[str, str] | None = None
@@ -1040,10 +1145,12 @@ MAX_DELAY = 30
 RETRY_CODES = [408, 409, 429]
 INGRESS_ERROR_CODES = [502, 503, 504]
 
-# Explicit timeout for queue polling requests (status checks and result fetching).
-# httpx's default timeout (120s) operates at the HTTP protocol layer and can fail
-# to fire when the hang is at the raw SSL socket level (ssl.read()).  Using an
+# Explicit timeout for queue polling requests (status, result and cancel).
+# The client's default timeout (120s) operates at the HTTP protocol layer and can
+# fail to fire when the hang is at the raw SSL socket level (ssl.read()).  Using an
 # httpx.Timeout object with a shorter connect timeout ensures we detect stalls.
+# The backup transport caps connect further on the mapped domains; server-supplied
+# hosts keep the 30s below.
 QUEUE_POLL_TIMEOUT = httpx.Timeout(120.0, connect=30.0)
 DEFAULT_QUEUE_POLL_INTERVAL = 0.1
 
@@ -1598,6 +1705,7 @@ class AsyncClient:
     async def _client(self) -> httpx.AsyncClient:
         auth = await self._auth
         return httpx.AsyncClient(
+            transport=AsyncBackupDomainTransport(),
             headers={
                 "Authorization": auth.header_value,
                 "User-Agent": USER_AGENT,
@@ -1653,8 +1761,9 @@ class AsyncClient:
 
         Args:
             method: HTTP method to use for the inference request.
-            timeout: Client-side HTTP timeout in seconds. Controls how long the HTTP
-                client waits for a response. Defaults to the client's default_timeout.
+            timeout: Client-side HTTP timeout in seconds. Defaults to no client-side
+                read timeout; long generations are unbounded. Connections to mapped
+                primary and backup domains are still capped at 5 seconds.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts. Does not apply once the application begins processing.
         """
@@ -1703,6 +1812,9 @@ class AsyncClient:
         """Submit an application with the given arguments (which will be JSON serialized). The path parameter can be used to
         specify a subpath when applicable. This method will return a handle to the request that can be used to check the status
         and retrieve the result of the inference call when it is done.
+
+        The submission POST uses the client's default_timeout (120 seconds by
+        default), unlike run(), whose default read timeout is unbounded.
 
         Args:
             start_timeout: Server-side request timeout in seconds. Limits total time spent
@@ -2124,6 +2236,7 @@ class SyncClient:
     def _client(self) -> httpx.Client:
         auth = self._auth
         return httpx.Client(
+            transport=BackupDomainTransport(),
             headers={
                 "Authorization": auth.header_value,
                 "User-Agent": USER_AGENT,
@@ -2184,8 +2297,9 @@ class SyncClient:
 
         Args:
             method: HTTP method to use for the inference request.
-            timeout: Client-side HTTP timeout in seconds. Controls how long the HTTP
-                client waits for a response. Defaults to the client's default_timeout.
+            timeout: Client-side HTTP timeout in seconds. Defaults to no client-side
+                read timeout; long generations are unbounded. Connections to mapped
+                primary and backup domains are still capped at 5 seconds.
             start_timeout: Server-side request timeout in seconds. Limits total time spent
                 waiting before processing starts. Does not apply once the application begins processing.
         """
@@ -2229,6 +2343,9 @@ class SyncClient:
         start_timeout: Optional[Union[int, float]] = None,
     ) -> SyncRequestHandle:
         """Submit an application with the given arguments (which will be JSON serialized).
+
+        The submission POST uses the client's default_timeout (120 seconds by
+        default), unlike run(), whose default read timeout is unbounded.
 
         Args:
             start_timeout: Server-side request timeout in seconds. Limits total time spent

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -86,8 +86,8 @@ REALTIME_URL_FORMAT = f"wss://{FAL_RUN_HOST}/"
 REST_URL = "https://rest.fal.ai"
 
 _BACKUP_DOMAINS = {
-    "fal.run": "falrun.com",
-    "queue.fal.run": "queue.falrun.com",
+    FAL_RUN_HOST: "falrun.com",
+    FAL_QUEUE_RUN_HOST: "queue.falrun.com",
 }
 # Ceiling on the connect timeout for HTTP requests to a mapped domain (run,
 # submit, status, result, cancel and stream alike). A shorter caller timeout

--- a/projects/fal_client/src/fal_client/client.py
+++ b/projects/fal_client/src/fal_client/client.py
@@ -86,8 +86,8 @@ REALTIME_URL_FORMAT = f"wss://{FAL_RUN_HOST}/"
 REST_URL = "https://rest.fal.ai"
 
 _BACKUP_DOMAINS = {
-    FAL_RUN_HOST: "falrun.com",
-    FAL_QUEUE_RUN_HOST: "queue.falrun.com",
+    "fal.run": "falrun.com",
+    "queue.fal.run": "queue.falrun.com",
 }
 # Ceiling on the connect timeout for HTTP requests to a mapped domain (run,
 # submit, status, result, cancel and stream alike). A shorter caller timeout

--- a/projects/fal_client/tests/unit/test_backup_domains.py
+++ b/projects/fal_client/tests/unit/test_backup_domains.py
@@ -1,0 +1,510 @@
+import inspect
+import json
+from contextlib import asynccontextmanager
+from functools import partial
+
+import httpx
+import pytest
+
+from fal_client.client import (
+    AsyncClient,
+    AsyncBackupDomainTransport,
+    BackupDomainTransport,
+    MAX_ATTEMPTS,
+    Completed,
+    FalClientHTTPError,
+    SyncClient,
+    _fallback_url,
+)
+
+
+@pytest.fixture
+def make_client(monkeypatch):
+    @asynccontextmanager
+    async def create(asynchronous, handler, **kwargs):
+        transport_type = (
+            AsyncBackupDomainTransport if asynchronous else BackupDomainTransport
+        )
+        monkeypatch.setattr(
+            f"fal_client.client.{transport_type.__name__}",
+            partial(transport_type, transport=httpx.MockTransport(handler)),
+        )
+
+        cls = AsyncClient if asynchronous else SyncClient
+        client = cls(key="test-key", **kwargs)
+        http = await resolve(client._client)
+        try:
+            yield client
+        finally:
+            await resolve(http.aclose() if asynchronous else http.close())
+
+    return create
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://fal.run/a/b?x=a%2Fb", "https://falrun.com/a/b?x=a%2Fb"),
+        ("https://queue.fal.run:8443/a", "https://queue.falrun.com:8443/a"),
+        ("https://run.fal.dev/a", None),
+        ("https://falrun.com/a", None),
+        ("https://fal.run.example.com/a", None),
+        ("https://rest.fal.ai/tokens/", None),
+        ("https://v3.fal.media/files/upload", None),
+    ],
+)
+def test_fallback_domains(url, expected):
+    assert _fallback_url(httpx.URL(url)) == expected
+
+
+async def resolve(value):
+    return await value if inspect.isawaitable(value) else value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_run_and_queue_fallback(make_client, asynchronous):
+    requests = []
+    queue_url = "https://queue.fal.run/fal-ai/test/requests/request-id"
+
+    def respond(request):
+        requests.append(request)
+        if request.url.host in ("fal.run", "queue.fal.run"):
+            raise httpx.ConnectError("connection failed", request=request)
+        if request.url.path.endswith("/status"):
+            return httpx.Response(
+                200, json={"status": "COMPLETED", "logs": [], "metrics": {}}
+            )
+        if request.url.host == "queue.falrun.com" and request.method == "POST":
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "request-id",
+                    "response_url": queue_url,
+                    "status_url": queue_url + "/status",
+                    "cancel_url": queue_url + "/cancel",
+                },
+            )
+        return httpx.Response(200, json={"output": "ok"})
+
+    async with make_client(asynchronous, respond) as client:
+        assert await resolve(
+            client.run(
+                "fal-ai/test",
+                {"prompt": "test"},
+                headers={"x-test": "yes"},
+                start_timeout=30,
+            )
+        ) == {"output": "ok"}
+        handle = await resolve(
+            client.submit(
+                "fal-ai/test",
+                {"prompt": "test"},
+                webhook_url="https://example.com/hook?a=b",
+                start_timeout=30,
+            )
+        )
+        assert isinstance(await resolve(handle.status(with_logs=True)), Completed)
+        assert await resolve(handle.get()) == {"output": "ok"}
+        await resolve(handle.cancel())
+        restored = await resolve(client.get_handle("fal-ai/test", "request-id"))
+        assert isinstance(await resolve(restored.status()), Completed)
+
+    # run, submit, status, get, cancel, get_handle + its status, each retried once
+    # against the backup domain.
+    assert len(requests) == 7 * 2
+    for primary, backup in zip(requests[::2], requests[1::2]):
+        assert backup.url == _fallback_url(primary.url)
+        assert backup.method == primary.method
+        assert backup.content == primary.content
+        assert backup.headers["authorization"] == "Key test-key"
+        assert backup.headers["host"] == backup.url.host
+        assert backup.extensions["timeout"] == primary.extensions["timeout"]
+        assert {k: v for k, v in backup.headers.items() if k != "host"} == {
+            k: v for k, v in primary.headers.items() if k != "host"
+        }
+    assert requests[1].headers["x-test"] == "yes"
+    assert json.loads(requests[1].content) == {"prompt": "test"}
+    assert requests[3].url.params["fal_webhook"] == "https://example.com/hook?a=b"
+    assert requests[5].url.params["logs"] == "true"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize(
+    "host,outcome",
+    [
+        ("fal.run", 200),
+        ("fal.run", 500),
+        ("fal.run", httpx.ReadError("read failed")),
+        ("fal.run", httpx.WriteError("write failed")),
+        ("custom.example.com", httpx.ConnectError("connect failed")),
+    ],
+)
+async def test_http_does_not_fallback(make_client, asynchronous, host, outcome):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return httpx.Response(outcome)
+
+    async with make_client(asynchronous, respond) as client:
+        http = await resolve(client._client)
+        if isinstance(outcome, Exception):
+            with pytest.raises(type(outcome)) as exc:
+                await resolve(http.post(f"https://{host}/model", json={}))
+            assert exc.value is outcome
+        else:
+            response = await resolve(http.post(f"https://{host}/model", json={}))
+            assert response.status_code == outcome
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_stream_fallback(make_client, asynchronous):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if request.url.host == "fal.run":
+            raise httpx.ConnectError("DNS failed", request=request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='data: {"output":"ok"}\n\n',
+        )
+
+    async with make_client(asynchronous, respond) as client:
+        stream = client.stream("fal-ai/test", {"prompt": "test"})
+        events = [event async for event in stream] if asynchronous else list(stream)
+        assert events == [{"output": "ok"}]
+    assert [r.url.host for r in requests] == ["fal.run", "falrun.com"]
+    assert requests[1].content == requests[0].content
+    assert requests[1].headers["authorization"] == "Key test-key"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_stream_failure_after_open_does_not_fallback(make_client, asynchronous):
+    requests = []
+    closed = []
+
+    class FailingStream(httpx.SyncByteStream, httpx.AsyncByteStream):
+        def __iter__(self):
+            yield b'data: {"output":"first"}\n\n'
+            raise httpx.ReadError("stream interrupted")
+
+        async def __aiter__(self):
+            for chunk in self:
+                yield chunk
+
+        def close(self):
+            closed.append(True)
+
+        async def aclose(self):
+            self.close()
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=FailingStream()
+        )
+
+    async with make_client(asynchronous, respond) as client:
+        with pytest.raises(httpx.ReadError, match="stream interrupted"):
+            stream = client.stream("fal-ai/test", {})
+            if asynchronous:
+                async for _ in stream:
+                    pass
+            else:
+                for _ in stream:
+                    pass
+    assert len(requests) == 1
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize(
+    "operation,timeout,default_timeout,expected_read,expected_connect",
+    [
+        ("run", None, 120, None, 5),
+        ("run", 20, 120, 20, 5),
+        ("run", 2, 120, 2, 2),
+        ("stream", None, 120, None, 5),
+        ("stream", 20, 120, 20, 5),
+        ("stream", 2, 120, 2, 2),
+        ("submit", None, 120, 120, 5),
+        ("submit", None, 2, 2, 2),
+        ("subscribe", None, 120, 120, 5),
+        ("status", None, 120, 120, 5),
+    ],
+)
+async def test_public_connect_timeouts_and_start_timeout(
+    make_client,
+    asynchronous,
+    operation,
+    timeout,
+    default_timeout,
+    expected_read,
+    expected_connect,
+):
+    requests = []
+    queue_url = "https://queue.fal.run/fal-ai/test/requests/test-id"
+
+    def respond(request):
+        requests.append(request)
+        if request.url.host in ("fal.run", "queue.fal.run"):
+            raise httpx.ConnectTimeout("handshake hung", request=request)
+        if request.url.path.endswith("/status"):
+            return httpx.Response(
+                200, json={"status": "COMPLETED", "logs": [], "metrics": {}}
+            )
+        if request.url.path.endswith("/stream"):
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content='data: {"ok":true}\n\n',
+            )
+        if request.url.host == "queue.falrun.com" and request.method == "POST":
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "test-id",
+                    "response_url": queue_url,
+                    "status_url": queue_url + "/status",
+                    "cancel_url": queue_url + "/cancel",
+                },
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    async with make_client(
+        asynchronous, respond, default_timeout=default_timeout
+    ) as client:
+        if operation == "stream":
+            stream = client.stream("fal-ai/test", {}, timeout=timeout)
+            result = [event async for event in stream] if asynchronous else list(stream)
+            assert result == [{"ok": True}]
+        elif operation == "status":
+            await resolve(getattr(client, operation)("fal-ai/test", "test-id"))
+        elif operation == "run":
+            assert await resolve(
+                client.run("fal-ai/test", {}, timeout=timeout, start_timeout=30)
+            ) == {"ok": True}
+        else:
+            await resolve(getattr(client, operation)("fal-ai/test", {}, start_timeout=30))
+    for request in requests:
+        assert request.extensions["timeout"] == {
+            "connect": expected_connect,
+            "read": expected_read,
+            "write": expected_read,
+            "pool": expected_read,
+        }
+    hosts = (
+        ["fal.run", "falrun.com"]
+        if operation in ("run", "stream")
+        else ["queue.fal.run", "queue.falrun.com"]
+    )
+    assert [request.url.host for request in requests] == hosts * (
+        3 if operation == "subscribe" else 1
+    )
+    if operation not in ("stream", "status"):
+        assert requests[0].headers["X-Fal-Request-Timeout"] == "30.0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize(
+    "host,timeout,expected_connect",
+    [
+        ("fal.run", None, 5),
+        ("falrun.com", None, 5),
+        ("queue.falrun.com", None, 5),
+        ("custom.example.com", None, None),
+        ("custom.example.com", httpx.USE_CLIENT_DEFAULT, 120),
+        ("rest.fal.ai", httpx.USE_CLIENT_DEFAULT, 120),
+        ("v3.fal.media", httpx.USE_CLIENT_DEFAULT, 120),
+    ],
+)
+async def test_connect_timeout_is_capped_only_on_mapped_domains(
+    make_client, asynchronous, host, timeout, expected_connect
+):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if request.url.host == "fal.run":
+            raise httpx.ConnectTimeout("primary unavailable", request=request)
+        return httpx.Response(200, json={})
+
+    async with make_client(asynchronous, respond) as client:
+        http = await resolve(client._client)
+        await resolve(http.get(f"https://{host}/model", timeout=timeout))
+    assert requests
+    for request in requests:
+        assert request.extensions["timeout"] == {
+            "connect": expected_connect,
+            "read": None if timeout is None else 120,
+            "write": None if timeout is None else 120,
+            "pool": None if timeout is None else 120,
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_backup_log_omits_paths_and_credentials(
+    make_client, caplog, asynchronous
+):
+    def respond(request):
+        if request.url.host == "fal.run":
+            raise httpx.ConnectTimeout("failed with secret-token", request=request)
+        return httpx.Response(200, json={})
+
+    async with make_client(asynchronous, respond) as client:
+        http = await resolve(client._client)
+        response = await resolve(
+            http.get("https://fal.run/private-path?fal_jwt_token=secret-token")
+        )
+
+    assert response.url.host == "fal.run"
+    records = [
+        record for record in caplog.records if record.name == "fal_client.client"
+    ]
+    assert len(records) == 1
+    assert records[0].levelname == "WARNING"
+    assert records[0].message == (
+        "Connection to fal.run failed (ConnectTimeout); trying backup domain falrun.com"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "asynchronous,follow_redirects", [(False, None), (True, None), (True, True)]
+)
+async def test_public_run_preserves_redirect_policy(
+    make_client, asynchronous, follow_redirects
+):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if request.url.path == "/fal-ai/model":
+            return httpx.Response(
+                307, headers={"location": "/fal-ai/redirected?input=a%2Fb"}
+            )
+        if request.url.host == "fal.run":
+            raise httpx.ConnectError("redirected host unavailable", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    async with make_client(asynchronous, respond) as client:
+        if follow_redirects is not None:
+            http = await resolve(client._client)
+            http.follow_redirects = follow_redirects
+        if asynchronous and follow_redirects is None:
+            with pytest.raises(FalClientHTTPError) as exc:
+                await client.run("fal-ai/model", {"prompt": "test"})
+            assert exc.value.response.status_code == 307
+            assert len(requests) == 1
+            return
+        assert await resolve(client.run("fal-ai/model", {"prompt": "test"})) == {
+            "ok": True
+        }
+    assert [(r.url.host, r.url.path) for r in requests] == [
+        ("fal.run", "/fal-ai/model"),
+        ("fal.run", "/fal-ai/redirected"),
+        ("falrun.com", "/fal-ai/redirected"),
+    ]
+    assert all(r.method == "POST" for r in requests)
+    assert len({r.content for r in requests}) == 1
+    assert requests[1].url.query == requests[2].url.query == b"input=a%2Fb"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize(
+    "start_timeout,primary_type,backup_type",
+    [
+        # A backup that also fails to connect re-raises the primary error, so the
+        # primary's type decides whether the request is retried.
+        (None, httpx.ConnectError, httpx.ConnectError),
+        (None, httpx.ConnectTimeout, httpx.ConnectTimeout),
+        # A backup that connects and then fails keeps its own error and type.
+        (None, httpx.ConnectError, httpx.ReadTimeout),
+        # A caller-supplied start_timeout stops retries for timeout errors only.
+        (30, httpx.ConnectTimeout, httpx.ConnectTimeout),
+        (30, httpx.ConnectError, httpx.ConnectError),
+        (30, httpx.ConnectError, httpx.ReadTimeout),
+    ],
+)
+async def test_failure_type_preserves_retry_policy(
+    make_client,
+    monkeypatch,
+    asynchronous,
+    start_timeout,
+    primary_type,
+    backup_type,
+):
+    requests = []
+    errors = []
+    monkeypatch.setattr("fal_client.client._get_retry_delay", lambda *args: 0)
+
+    def respond(request):
+        requests.append(request)
+        error = (
+            primary_type("primary failure", request=request)
+            if request.url.host == "fal.run"
+            else backup_type("backup failure", request=request)
+        )
+        errors.append(error)
+        raise error
+
+    expected_type = backup_type if backup_type is httpx.ReadTimeout else primary_type
+    async with make_client(asynchronous, respond) as client:
+        with pytest.raises(expected_type) as exc:
+            await resolve(client.run("fal-ai/test", {}, start_timeout=start_timeout))
+        assert type(exc.value) is expected_type
+        primary_error, backup_error = errors[-2:]
+        if backup_type is httpx.ReadTimeout:
+            assert exc.value is backup_error
+            assert exc.value.__context__ is primary_error
+        else:
+            assert exc.value is primary_error
+            assert exc.value.__context__ is backup_error
+        assert exc.value.__cause__ is None
+    attempts = (
+        1
+        if start_timeout is not None
+        and issubclass(expected_type, httpx.TimeoutException)
+        else MAX_ATTEMPTS
+    )
+    assert [r.url.host for r in requests] == ["fal.run", "falrun.com"] * attempts
+    assert exc.value.request.url.host == "fal.run"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_backup_transport_closes_injected_transport(asynchronous):
+    closed = []
+
+    class Transport(httpx.MockTransport):
+        def close(self):
+            closed.append(True)
+
+        async def aclose(self):
+            closed.append(True)
+
+    transport = Transport(lambda request: httpx.Response(200))
+    if asynchronous:
+        async with httpx.AsyncClient(
+            transport=AsyncBackupDomainTransport(transport=transport)
+        ) as client:
+            await client.get("https://fal.run/test")
+    else:
+        with httpx.Client(
+            transport=BackupDomainTransport(transport=transport)
+        ) as client:
+            client.get("https://fal.run/test")
+    assert closed == [True]

--- a/projects/fal_client/tests/unit/test_backup_domains.py
+++ b/projects/fal_client/tests/unit/test_backup_domains.py
@@ -295,7 +295,9 @@ async def test_public_connect_timeouts_and_start_timeout(
                 client.run("fal-ai/test", {}, timeout=timeout, start_timeout=30)
             ) == {"ok": True}
         else:
-            await resolve(getattr(client, operation)("fal-ai/test", {}, start_timeout=30))
+            await resolve(
+                getattr(client, operation)("fal-ai/test", {}, start_timeout=30)
+            )
     for request in requests:
         assert request.extensions["timeout"] == {
             "connect": expected_connect,

--- a/projects/fal_client/tests/unit/test_backup_domains.py
+++ b/projects/fal_client/tests/unit/test_backup_domains.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import socket
 from contextlib import asynccontextmanager
 from functools import partial
 
@@ -14,6 +15,7 @@ from fal_client.client import (
     Completed,
     FalClientHTTPError,
     SyncClient,
+    _BACKUP_DOMAINS,
     _fallback_url,
 )
 
@@ -59,6 +61,40 @@ def test_fallback_domains(url, expected):
 
 async def resolve(value):
     return await value if inspect.isawaitable(value) else value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_nonexistent_primary_and_backup_domains(monkeypatch, asynchronous):
+    primary = "wrong.fal.run"
+    backup = "wrong.falrun.com"
+    lookups = []
+    monkeypatch.setitem(_BACKUP_DOMAINS, primary, backup)
+    monkeypatch.setattr("fal_client.client.RUN_URL_FORMAT", f"https://{primary}/")
+    monkeypatch.setattr("fal_client.client._get_retry_delay", lambda *args: 0)
+    monkeypatch.setenv("NO_PROXY", "*")
+    monkeypatch.setenv("no_proxy", "*")
+
+    # Keep the real HTTP transport and its DNS-error conversion, without relying
+    # on external DNS or these domains remaining unregistered.
+    def getaddrinfo(host, *args, **kwargs):
+        host = host.decode("ascii") if isinstance(host, bytes) else host
+        lookups.append(host)
+        raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", getaddrinfo)
+    client = (AsyncClient if asynchronous else SyncClient)(key="test-key")
+    http = await resolve(client._client)
+    try:
+        with pytest.raises(httpx.ConnectError) as exc:
+            await resolve(client.run("fal-ai/test", {}))
+    finally:
+        await resolve(http.aclose() if asynchronous else http.close())
+
+    assert lookups == [primary, backup] * MAX_ATTEMPTS
+    assert exc.value.request.url.host == primary
+    assert isinstance(exc.value.__context__, httpx.ConnectError)
+    assert exc.value.__context__.request.url.host == backup
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Assuming at t=0 we send a request to `fal.run` and it fails due to a Connection Timeout which is set to 5 seconds, the timeline of the events will look like below.
Time, approximately | What happens
-- | --
t=0 | Connect to fal.run.
t=5s | Connection times out. Immediately try falrun.com; emit a warning.
t=10s | Backup connection also times out. First attempt failed.
t=10.05–10.15s | After a short randomized delay, start attempt 2 on fal.run again.
~5s later | If primary still fails, try backup again.
Both fail again | Wait 0.1–0.3s, then start attempt 3 (upper bound is 10 attempts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request routing for all run/queue HTTP traffic; misconfigured backup mapping or transport edge cases could affect connectivity, though scope is limited to connect-time fallback with extensive tests.
> 
> **Overview**
> Adds **automatic HTTP fallback** from `fal.run` / `queue.fal.run` to backup hosts (`falrun.com`, `queue.falrun.com`) for sync and async clients via custom `httpx` transports. On **connect** failures only (`ConnectError`, `ConnectTimeout`), the client replays the same request to the backup host (with updated `Host`), logs a warning (path only, no query secrets), and preserves existing retry behavior by re-raising the primary error when the backup also fails to connect.
> 
> Connect timeouts on mapped domains are **capped at 5s** (shorter caller timeouts still apply) so unreachable primaries don’t block fallback. Fallback does **not** apply to HTTP errors, read/write failures, unmapped hosts, or mid-stream failures. Redirect handling stays on the outer client (inner transport disables `follow_redirects`).
> 
> Docstrings for `run()` / `submit()` clarify default read timeouts (unbounded for `run`, `default_timeout` for queue submit). A large unit test suite covers URL rewriting, run/queue/stream paths, timeout caps, logging, redirects, and retry policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d400e94c3b5d86116656de0dbbd5d3d2830cda7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->