### PR TITLE
DRAFT: test(fal): give e2e and integration tests a 300s timeout

### DIFF
--- a/projects/fal/tests/conftest.py
+++ b/projects/fal/tests/conftest.py
@@ -14,6 +14,19 @@ from fal.sdk import get_credentials
 print("TARGET:", GRPC_HOST, file=sys.stderr)
 print("AUTH:", get_credentials(), file=sys.stderr)
 
+# Suites that deploy to the platform and wait on cold starts; the package
+# default timeout is sized for unit tests.
+REMOTE_SUITES = {"e2e", "integration"}
+REMOTE_SUITE_TIMEOUT = 300
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.get_closest_marker("timeout"):
+            continue
+        if REMOTE_SUITES & set(item.path.parts):
+            item.add_marker(pytest.mark.timeout(REMOTE_SUITE_TIMEOUT))
+
 
 @pytest.fixture(scope="function")
 def isolated_client():


### PR DESCRIPTION
> **DRAFT** — open for early feedback.

## What changed

The package-wide pytest timeout in `projects/fal/pyproject.toml` is 60 seconds, which suits the unit suite. The e2e and integration suites deploy apps to the platform and wait on cold starts, and lately that alone takes longer than 60 seconds, so both suites fail on `main` with `Failed: Timeout (>60.0s) from pytest-timeout` rather than with assertion failures.

This adds a `pytest_collection_modifyitems` hook to `projects/fal/tests/conftest.py` that gives every test under `tests/e2e` and `tests/integration` a 300 second budget. Tests that already carry their own `timeout` marker keep it. Unit tests are untouched.

## Why 300 seconds

- The last green integration run on `main` ([run 33294931386](https://github.com/fal-ai/fal/actions/runs/33294931386), Aug 30) had its slowest tests at 32 to 38 seconds, so 60 seconds never left much headroom.
- In [fal-ai/fal#1159](https://github.com/fal-ai/fal/pull/1159)'s reruns, ten integration tests and twenty e2e tests all failed at exactly the 60 second mark, and six e2e tests timed out inside fixture setup, which pytest-timeout counts against the same budget as the test body.
- Measured locally against api.alpha.fal.ai, `test_exec_runner` and `test_shell_runner` took about 4 minutes each including deploy on one attempt and about 20 seconds each an hour later. 300 seconds covers the slow end of that range.

## What this does not fix

A deploy that never comes up still fails, just later. Locally the `test_exception_app` fixture behind `test_traceback_logs` sat in setup for the full 15 minute cap. That test is already `xfail` for a known backend issue. Whether alpha's deploy latency itself needs attention is a separate question for the platform team.

`faulthandler_timeout` stays at 50 seconds, so slow remote tests will still dump a traceback to stderr before finishing. That is noise, not a failure.

## How it was tested

Marker distribution after the change, via a collect-only run with a plugin that prints each item's effective timeout:

```
$ pytest --collect-only -q projects/fal/tests/unit projects/fal/tests/integration projects/fal/tests/e2e
e2e          timeout=300          tests=50
integration  timeout=300          tests=44
unit         timeout=default(60)  tests=1228
```

```
$ pre-commit run --files projects/fal/tests/conftest.py
ruff-format / ruff / check-added-large-files / merge-conflicts / vcs-permalinks / debug-statements: Passed
```

Local e2e durations with the timeout raised (main at e0454812, Python 3.12):

```
25.45s call     tests/e2e/test_apps.py::test_shell_runner
18.97s call     tests/e2e/test_apps.py::test_exec_runner
 2.46s setup    tests/e2e/test_apps.py::test_exec_runner
 1.06s setup    tests/e2e/test_apps.py::test_shell_runner
2 passed, 1 xfailed in 949.05s
```

### CI results on this branch

Integration ([run 33921408196](https://github.com/fal-ai/fal/actions/runs/33921408196)): green on all seven matrix cells, Python 3.10 to 3.14 plus Windows. The first fully green integration run since Aug 30.

E2E ([run 33921408166](https://github.com/fal-ai/fal/actions/runs/33921408166)): still red, but for a different reason. Failure reasons tallied across all seven jobs:

```
 24  httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://queue.fal.run/fal2d2/<app>'
  7  AssertionError: {"detail":"Application \"<app>\" not found"}
  5  AssertionError: Regex pattern did not match   (input is the same 404 text)
  3  AssertionError: assert not {'<runner id>'}     (test_rollout_application)
  1  AssertionError: Expected Gateway Timeout even though the app handled it
  1  assert 504 == 499
  1  Failed: Timeout (>300.0s) from pytest-timeout
```

Per job: 3 to 10 failures out of 50, versus 16 to 23 per job on `main` where nearly every failure was the 60 second timeout. The one remaining timeout is a deploy that did not come up within five minutes. The 404s are the queue gateway not resolving freshly deployed apps on alpha, which no client-side timeout can address and is worth a look from the platform side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

