### PR TITLE
fix(distributed): bind a free worker port before spawning

### DIFF
--- a/projects/fal/src/fal/distributed/worker.py
+++ b/projects/fal/src/fal/distributed/worker.py
@@ -235,7 +235,7 @@ class DistributedRunner:
         master_addr: str = "127.0.0.1",
         master_port: int = 29500,
         worker_addr: str = "127.0.0.1",
-        worker_port: int = 54923,
+        worker_port: Optional[int] = None,
         timeout: int = 86400,  # 24 hours
         keepalive_payload: dict[str, Any] = {},
         keepalive_interval: Optional[Union[int, float]] = None,
@@ -248,6 +248,7 @@ class DistributedRunner:
         self.master_port = master_port
         self.worker_addr = worker_addr
         self.worker_port = worker_port
+        self._auto_worker_port = worker_port is None
         self.timeout = timeout
         self.cwd = cwd
         self.zmq_socket = None
@@ -319,6 +320,8 @@ class DistributedRunner:
                     process.terminate()
                     process.join(timeout=timeout)
 
+        self.close_zmq_socket()
+
     def gather_errors(self) -> list[Exception]:
         """
         Gathers errors from the distributed worker processes.
@@ -353,9 +356,7 @@ class DistributedRunner:
 
     def get_zmq_socket(self) -> Socket[Any]:
         """
-        Returns a ZeroMQ socket of the specified type.
-        :param socket_type: The type of the ZeroMQ socket.
-        :return: A ZeroMQ socket.
+        Returns the bound ZeroMQ socket, choosing a port when none was configured.
         """
         if self.zmq_socket is not None:
             return self.zmq_socket
@@ -365,7 +366,17 @@ class DistributedRunner:
 
         context = zmq.asyncio.Context()
         socket = context.socket(zmq.ROUTER)
-        socket.bind(f"tcp://{self.worker_addr}:{self.worker_port}")
+        try:
+            if self.worker_port is None:
+                self.worker_port = socket.bind_to_random_port(
+                    f"tcp://{self.worker_addr}"
+                )
+            else:
+                socket.bind(f"tcp://{self.worker_addr}:{self.worker_port}")
+        except Exception:
+            socket.close()
+            context.term()
+            raise
         self.zmq_socket = socket
         return socket
 
@@ -382,6 +393,8 @@ class DistributedRunner:
                     f"{traceback.format_exc()}"
                 )
             self.zmq_socket = None
+            if self._auto_worker_port:
+                self.worker_port = None
 
     def run(self, **kwargs: Any) -> None:
         """
@@ -577,19 +590,25 @@ class DistributedRunner:
 
         self._keepalive_shutdown = False
 
-        self.context = launch_distributed_processes(
-            self.run,
-            world_size=self.world_size,
-            master_addr=self.master_addr,
-            master_port=self.master_port,
-            timeout=self.timeout,
-            cwd=self.cwd,
-            **kwargs,
-        )
-
         try:
-            ready_workers: set[int] = set()
             socket = self.get_zmq_socket()
+            # Keep the bound socket alive, but out of self while spawn pickles self.run.
+            self.zmq_socket = None
+            self.context = None
+            try:
+                self.context = launch_distributed_processes(
+                    self.run,
+                    world_size=self.world_size,
+                    master_addr=self.master_addr,
+                    master_port=self.master_port,
+                    timeout=self.timeout,
+                    cwd=self.cwd,
+                    **kwargs,
+                )
+            finally:
+                self.zmq_socket = socket
+
+            ready_workers: set[int] = set()
             start_time = time.perf_counter()
 
             while len(ready_workers) < self.world_size:

--- a/projects/fal/src/fal/distributed/worker.py
+++ b/projects/fal/src/fal/distributed/worker.py
@@ -633,6 +633,9 @@ class DistributedRunner:
                         )
                     await asyncio.sleep(0.5)
                 self.ensure_alive()
+        except asyncio.CancelledError:
+            self.terminate(timeout=timeout)
+            raise
         except Exception as e:
             print(f"[debug] Error during startup: {e}\n{traceback.format_exc()}")
             self.terminate(timeout=timeout)


### PR DESCRIPTION
## Why

`DistributedRunner` used a fixed ZMQ worker port (54923), which can already be occupied in the runtime. The parent now reserves an available worker port before spawning, and children connect to that concrete port. Refs #1165 / SERV-2102.

## Behavior

- Default `worker_port` is `None`. The parent binds with `bind_to_random_port()` and keeps the socket open across spawn, with no close/rebind race.
- The socket and previous process context are kept out of the serialized `self.run`. The parent socket is restored in `finally`.
- Restart after a partial worker crash terminates and joins the old group before replacing its context. A child that survives the graceful join timeout is killed and joined.
- Cleanup closes the socket and resets an automatically selected port. Restart binds again, but does not promise a different numerical port. Explicit worker ports stay pinned, and bind errors raise without silent fallback.
- Cancelled startup cleans up children and the socket, then re-raises cancellation. Restart, cancellation, and failed-start cleanup use the independent 10-second graceful shutdown timeout per worker, rather than the default 1800-second readiness timeout.
- `master_port=29500` and the NCCL rendezvous path are unchanged. Automatic master-port allocation and asynchronous teardown remain outside this fix.

## Current verification (September 17)

Head `5b825325`, rebased onto `main` at `504e5a71`.

- Full local SDK unit suite: **1242 passed, 3 existing skips** (GPU integration, optional torch serialization, and a GCloud-credentials test). Command: `env -u ISOLATE_AUTH_DISABLED -u FAL_KEY -u FAL_KEY_ID -u FAL_KEY_SECRET FAL_CONFIG_PATH=/dev/null .venv/bin/python -m pytest -n auto -q projects/fal/tests/unit` (Python 3.12).
- All pre-commit hooks passed: `uv run --no-project --python 3.11 --with pre-commit pre-commit run --all-files`. This includes Ruff and configured mypy.
- Eight focused regression cases cover automatic/explicit port lifecycle, both bind-failure paths, partial-crash restart, forced cleanup after a join timeout, and independent shutdown timeouts on cancellation/startup failure. The old no-op socket cleanup test was replaced.
- The restart test uses **real local CPU subprocesses**, with ZMQ and the replacement GPU launch mocked. Both process-cleanup regressions fail on the previous PR head `55808a33`. The port regressions fail on the pre-fix base `b5070518`.
- All three timeout regression paths fail on `1dda3b52` and pass on this head.
- Final GitHub result: **16 passed, 14 failed, 1 skipped**. The required [pre-commit check](https://github.com/fal-ai/fal/actions/runs/35221171825/job/105201413140), all seven unit-matrix jobs, CodeQL, and Socket checks passed. Bugbot completed on `5b825325` with **no issues found**. All six review threads were substantively answered and resolved.
- The [integration](https://github.com/fal-ai/fal/actions/runs/35221171877) and [e2e](https://github.com/fal-ai/fal/actions/runs/35221171864) matrices remain red. Representative Linux/Python 3.12 logs show 60-second service timeouts, with overlapping failing tests in the same base commit's scheduled [integration](https://github.com/fal-ai/fal/actions/runs/35186376068) and [e2e](https://github.com/fal-ai/fal/actions/runs/35186440831) runs earlier today. Those suites do not reference `DistributedRunner`. This comparison is not a diagnosis of every matrix failure or a claim that all CI is green. No unrelated tests, timeouts, or workflows were weakened.
- The branch is current with `main` and conflict-free. GitHub reports `REVIEW_REQUIRED`: final human approval is still required before merge.

## Historical GPU evidence

The September 10/11 runs used four actual H100 GPUs, PyTorch 2.4.1, and NCCL. They verified the occupied old default, normal and explicit-port restart, occupied explicit-port failure, concurrent groups with distinct master ports, setup failure recovery, and startup cancellation cleanup. All probe allocations were confirmed terminated. These runs predate the September 17 restart fix and are **not** presented as GPU verification of the current head.

[Probe source and recorded GPU outputs](https://gist.github.com/burak-fal/8b871a9f033c776071ebbfee00b8d1b4).

Teardown still joins synchronously and can block the event loop. Passing resolved ports through a child entrypoint that does not capture parent resources is a separate refactor. No backend/infrastructure changes, merge, release, or customer rollout are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed worker lifecycle, ZMQ binding, and process teardown/restart paths—important for multi-GPU runs but scoped to `DistributedRunner` with added regression tests.
> 
> **Overview**
> **`DistributedRunner` no longer defaults to a fixed ZMQ worker port (54923).** When `worker_port` is omitted, the parent binds a free port via `bind_to_random_port()`, keeps that socket open across worker spawn (temporarily detaching it from `self` so pickling `self.run` does not capture the socket), and workers connect to the resolved port.
> 
> **Shutdown and restart behavior is tightened.** `terminate()` joins every process (not only those that received `terminate()`), kills survivors after the join timeout, and always closes the ZMQ socket—resetting an auto-selected port for the next bind. `start()` reaps a stale process group and socket before respawning; cancelled or failed startup runs the same cleanup with the fixed 10s shutdown timeout instead of the long readiness `timeout`.
> 
> **Unit tests** replace the simple socket-close check with coverage for auto vs explicit ports, bind failures without fallback, partial-crash restart, forced kill, and startup/cancellation cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba86392ba74b1bef753c223f5cb72fe46e8ec850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->