### PR TITLE
fix(cli): open deployed apps in Testing Playground (SERV-2080)

### DIFF
--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 from fal.api.client import SyncServerlessClient
 
@@ -151,6 +152,40 @@ def _apps_command_hint(
     return hint
 
 
+_UNTESTABLE_PLAYGROUND_SUFFIXES = {"cancel", "health", "object_info"}
+
+
+def _deployed_app_playground_url(url: str) -> str | None:
+    """Map a server-provided model URL to its owning app's Playground tab."""
+    parsed = urlsplit(url)
+    path_segments = parsed.path.split("/")
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or path_segments[:2] != ["", "models"]
+    ):
+        return url
+
+    endpoint_segments = path_segments[2:]
+    if endpoint_segments and endpoint_segments[-1] == "":
+        endpoint_segments = endpoint_segments[:-1]
+    if len(endpoint_segments) < 2 or any(not segment for segment in endpoint_segments):
+        return url
+
+    decoded_segments = [unquote(segment) for segment in endpoint_segments]
+    if decoded_segments[-1] in _UNTESTABLE_PLAYGROUND_SUFFIXES:
+        return None
+
+    owner, app_name = decoded_segments[:2]
+    formatted_endpoint = "/".join(decoded_segments)
+    path = (
+        f"/dashboard/apps/{quote(owner, safe='')}/{quote(app_name, safe='')}"
+        "/testing/playground"
+    )
+    query = f"endpoint={quote(formatted_endpoint, safe='')}"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, query, ""))
+
+
 def _render_deploy_result(
     args, res, *, is_first_deploy: bool = False, team: str | None = None
 ) -> None:
@@ -237,7 +272,9 @@ def _render_deploy_result(
             lines.append(f"{section_icon} Playground ", style="bold")
             lines.append("(open in browser)\n", style="dim")
             for url in res.urls.get("playground", {}).values():
-                lines.append(f"  {url}\n", style="cyan")
+                app_url = _deployed_app_playground_url(url)
+                if app_url is not None:
+                    lines.append(f"  {app_url}\n", style="cyan")
 
         # API Endpoints section
         if URL_OUTPUT == "all":

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from urllib.parse import quote, unquote, urlsplit, urlunsplit
+import urllib.parse
 
 from fal.api.client import SyncServerlessClient
 
@@ -157,7 +157,7 @@ _UNTESTABLE_PLAYGROUND_SUFFIXES = {"cancel", "health", "object_info"}
 
 def _deployed_app_playground_url(url: str) -> str | None:
     """Map a server-provided model URL to its owning app's Playground tab."""
-    parsed = urlsplit(url)
+    parsed = urllib.parse.urlsplit(url)
     path_segments = parsed.path.split("/")
     if (
         parsed.scheme not in {"http", "https"}
@@ -172,18 +172,19 @@ def _deployed_app_playground_url(url: str) -> str | None:
     if len(endpoint_segments) < 2 or any(not segment for segment in endpoint_segments):
         return url
 
-    decoded_segments = [unquote(segment) for segment in endpoint_segments]
+    decoded_segments = [urllib.parse.unquote(segment) for segment in endpoint_segments]
     if decoded_segments[-1] in _UNTESTABLE_PLAYGROUND_SUFFIXES:
         return None
 
     owner, app_name = decoded_segments[:2]
     formatted_endpoint = "/".join(decoded_segments)
     path = (
-        f"/dashboard/apps/{quote(owner, safe='')}/{quote(app_name, safe='')}"
+        f"/dashboard/apps/{urllib.parse.quote(owner, safe='')}"
+        f"/{urllib.parse.quote(app_name, safe='')}"
         "/testing/playground"
     )
-    query = f"endpoint={quote(formatted_endpoint, safe='')}"
-    return urlunsplit((parsed.scheme, parsed.netloc, path, query, ""))
+    query = f"endpoint={urllib.parse.quote(formatted_endpoint, safe='')}"
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, query, ""))
 
 
 def _render_deploy_result(

--- a/projects/fal/src/fal/cli/deploy.py
+++ b/projects/fal/src/fal/cli/deploy.py
@@ -173,7 +173,10 @@ def _deployed_app_playground_url(url: str) -> str | None:
         return url
 
     decoded_segments = [urllib.parse.unquote(segment) for segment in endpoint_segments]
-    if decoded_segments[-1] in _UNTESTABLE_PLAYGROUND_SUFFIXES:
+    if (
+        len(decoded_segments) > 2
+        and decoded_segments[-1] in _UNTESTABLE_PLAYGROUND_SUFFIXES
+    ):
         return None
 
     owner, app_name = decoded_segments[:2]

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -648,7 +648,7 @@ def mock_args(
     return args
 
 
-@pytest.mark.parametrize("app_alias", ["image-app", "image-app--staging"])
+@pytest.mark.parametrize("app_alias", ["image-app", "image-app--staging", "health"])
 def test_deploy_output_links_testable_routes_to_the_owning_app_playground(
     monkeypatch, app_alias
 ):

--- a/projects/fal/tests/unit/cli/test_deploy.py
+++ b/projects/fal/tests/unit/cli/test_deploy.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from fal.api import Options
 from fal.api.api import IsolatedFunction
 from fal.cli._utils import AppData
-from fal.cli.deploy import _deploy
+from fal.cli.deploy import _deploy, _render_deploy_result
 from fal.cli.deploy_check import (
     _build_deployment_check_summary,
     _diff_table,
@@ -646,6 +646,60 @@ def mock_args(
     args.annotation = annotation
 
     return args
+
+
+@pytest.mark.parametrize("app_alias", ["image-app", "image-app--staging"])
+def test_deploy_output_links_testable_routes_to_the_owning_app_playground(
+    monkeypatch, app_alias
+):
+    monkeypatch.setattr("fal.flags.URL_OUTPUT", "playground")
+    origin = "https://shark.fal.dev"
+    app_model_path = f"{origin}/models/team-owner/{app_alias}"
+    result = SimpleNamespace(
+        revision="rev",
+        app_name="image-app",
+        auth_mode="private",
+        urls={
+            "playground": {
+                "/": f"{app_model_path}/",
+                "/v2/generate": f"{app_model_path}/v2/generate",
+                "/stream": f"{app_model_path}/stream",
+                "/ws": f"{app_model_path}/ws",
+                "/realtime": f"{app_model_path}/realtime",
+                "/sse": f"{app_model_path}/sse",
+                "/health": f"{app_model_path}/health",
+                "/v2/generate/cancel": f"{app_model_path}/v2/generate/cancel",
+                "/stream/cancel": f"{app_model_path}/stream/cancel",
+                "/object_info": f"{app_model_path}/object_info",
+            },
+            "sync": {},
+            "async": {},
+        },
+        log_url=f"{origin}/logs/rev",
+    )
+    args = mock_args(app_ref=("app.py", "App"))
+    args.console = Console(
+        record=True, width=240, force_terminal=False, color_system=None
+    )
+
+    _render_deploy_result(args, result)
+
+    rendered_urls = [
+        line.strip()
+        for line in args.console.export_text().splitlines()
+        if line.strip().startswith("https://")
+    ]
+    app_playground = (
+        f"{origin}/dashboard/apps/team-owner/{app_alias}/testing/playground"
+    )
+    assert rendered_urls == [
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}",
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}%2Fv2%2Fgenerate",
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}%2Fstream",
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}%2Fws",
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}%2Frealtime",
+        f"{app_playground}?endpoint=team-owner%2F{app_alias}%2Fsse",
+    ]
 
 
 @patch("fal.cli._utils.find_pyproject_toml", return_value="pyproject.toml")


### PR DESCRIPTION
Part of [SERV-2080](https://linear.app/features-and-labels/issue/SERV-2080/polish-testing-playground-entry-links-and-documentation).

## Problem

Deploy output should lead app owners into the in-app Testing Playground without losing discoverability of utility routes used during setup.

## Change

Change only the pretty `fal deploy` presentation, deriving the web origin and canonical owner/app alias from the server-provided model URLs.

- **Playground:** links to `/dashboard/apps/<owner>/<app>/testing/playground?endpoint=<encoded endpoint>` for supported non-utility routes.
- **Application Endpoints:** one link to the existing app overview, where exposed utility routes and their API references remain discoverable. This link is present even for a utility-only app.
- Preserve root normalization, nested paths, streaming/realtime twins, team ownership, named-environment aliases, and source origin.
- An app named `health`, `cancel`, or `object_info` still retains its normal root Playground link.

This responds to Jim's utility-route feedback without adding utility execution or another Playground surface. The existing overview's `/health` row and API Reference destination were checked in the real UI.

## Compatibility

No changes to `DeploymentResult.urls`, JSON deploy output, sync/async API URLs, log URLs, auth, billing, team/environment selection, or `fal run`/ephemeral result handlers. Existing standalone URLs remain usable. The Testing route already shipped in web-app#6961.

The separate cross-page Requests freshness proposal, web-app#7774, was withdrawn. It is not a dependency of this PR. Docs remain in [fal-docs#483](https://github.com/fal-ai/fal-docs/pull/483).

## Current validation

Integrated `main` at 335261eb without rewriting the published branch. The PR diff remains limited to `deploy.py` and its CLI output tests.

- Full local SDK unit suite on Python 3.11: **1,239 passed, 3 skipped**. Skips require GPU/torch/GCloud credentials. Used a clean test HOME and normal auth defaults.
- Current-main local isolate-proto tests: **11 passed**.
- Ruff format and lint passed on both changed files.
- Ran the updated `fal deploy` command against a real private XS app in alpha (min 0, max 1, keep-alive 10s). Root, `/divide`, and `/stream` printed new Playground URLs; a single Application Endpoints overview URL was printed; sync/async API URLs, including `/health`, remained available in `all` output.
- Followed the emitted overview and `/divide` destinations in the browser: Application Endpoints includes `/health`, and Playground selects `/divide` with numerator/denominator fields. No inference request was submitted for this check. The temporary app was deleted afterward.

Fresh CI completed on 981638b7. The full SDK unit matrix, formatting/lint, container, docs, CodeQL, Socket, and Cursor checks pass. Integration/E2E remain red with remote-execution timeouts and worker exits also present in today's scheduled main runs. The PR is not fully green and has not been merged. [Current CI and baseline comparison](https://github.com/fal-ai/fal/pull/1167#issuecomment-5677749217).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI pretty-print only; deploy APIs and returned URLs are untouched, with URL parsing fallbacks for non-standard model paths.
> 
> **Overview**
> **Pretty `fal deploy` output** now turns server model URLs into dashboard links instead of echoing raw playground URLs.
> 
> For each non-utility route, **Playground** lines point at `/dashboard/apps/<owner>/<app>/testing/playground?endpoint=<encoded path>` (owner/app parsed from `/models/...`). Routes whose path ends in `health`, `cancel`, or `object_info` are omitted from Playground; a new **Application Endpoints** block prints one **app overview** URL (`/dashboard/apps/<owner>/<app>`) for API references, including utility-only deploys.
> 
> Sync/async API URLs, JSON output, and deployment behavior are unchanged. Unit tests cover playground link generation, utility filtering, and env aliases (e.g. `image-app--staging`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d4ea7b2e00fcf5b6d5b77d728dff65592e7149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->